### PR TITLE
Correct HTTP method type and fixed typo

### DIFF
--- a/src/api/sql.js
+++ b/src/api/sql.js
@@ -83,7 +83,7 @@
     }
 
 
-    var isGetRequest = options.type == 'get' || params.type == 'get';
+    var isGetRequest = options.type == 'get';
     // generate url depending on the http method
     params.url = this._host() ;
     if(isGetRequest) {
@@ -95,7 +95,7 @@
       if(isGetRequest) {
         params.url += '&api_key=' + this.api_key;
       } else {
-        darams.data['api_key'] = this.api_key;
+        params.data['api_key'] = this.api_key;
       }
     }
 


### PR DESCRIPTION
The "isGetRequest" var is true if params.type is "get". Since the params object is being created some lines ahead and the type property is never modified, "isGetRequest" is always true. So it always pass the parameters into the URL. I fixed it so it really checks only for the options type given.

In the other hand, because of the bad check a line with the typo "darams" instead of "params" was never performed. I fixed that too.
