### PR TITLE
`searchControl` has changed to `search` in createVis options hash

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -192,7 +192,7 @@ cartodb.createVis('map', url)
   - **shareable**: add facebook and twitter share buttons.
   - **title**: adds a header with the title of the visualization.
   - **description**: adds description to the header (as you set in the UI).
-  - **searchControl**: adds a search control (default: false).
+  - **search**: adds a search control (default: true).
   - **zoomControl**: adds zoom control (default: true).
   - **loaderControl**: adds loading control (default: true).
   - **center_lat**: latitude where the map is initializated.


### PR DESCRIPTION
Searchbox options argument appears to have changed. Also appears to default to 'true'.