### PR TITLE
adds raster support

### DIFF
--- a/doc/raster_howto.md
+++ b/doc/raster_howto.md
@@ -1,0 +1,84 @@
+
+# how to use raster with cartodb.js
+
+The way to add a raster layer to your map with cartodb.js is similar to add a regular cartodb layer,
+as everything in CartoDB it uses ``SQL`` + ``CartoCSS``
+
+
+## introduction to raster
+
+In [mapschool](http://mapschool.io/) you have a very good introduction to the basis of raster. Here
+we are going to explain how raster works in CartoDB.
+
+Raster usually takes a lot of space in the database and therefore render tiles is a heavy task.
+Luckily CartoDB solved this for you, when you import a raster using the editor or the [Import
+API](http://docs.cartodb.com/cartodb-platform/import-api.html) it generates a series of overviews,
+that's it, a bunch of tables with preprocessed information in order to speedup rendering. 
+
+You don't need to care about that but there are special cases you should be aware of when you create
+a raster based visualization
+
+
+##  creating a layer
+
+As always a layer is created using ``createLayer`` method:
+
+```
+cartodb.createLayer(map, {
+  user_name: 'doc',
+  type: 'cartodb',
+  sublayers: [{
+     sql: 'select * from pop',
+     cartocss: '#pop { raster-opacity: 1.0; }',
+     raster: true,
+  }],
+  no_cdn: true
+})
+.addTo(map)
+```
+
+The only special thing here is the ``raster`` flag, that tells Maps API that you are going to use a
+raster table so all the optimizations and so on are enabled
+
+## working the the layer
+
+Change CartoCSS and so on it's the same than working with a regular layer, you can use methods like
+``setCartoCSS``:
+
+```
+layer.getSubLayer(0).setCartoCSS('#layer {..... }');
+```
+
+You can also use ``setSQL`` but if you use a query different than the identity (select * from table)
+the raster optimizations are not going to work and you will get a timeout depending on the zoom
+level you are working on.
+
+## using SQL for analysis
+
+You can also access raster tables using SQL API  though cartodb.js, the following example gets the
+average value for a raster in a radius of 100 meters with center in latlng 0, 0
+
+```
+ var sql = new cartodb.SQL({ user: 'doc' });
+ var query = "SELECT avg((stats).mean) as m from (select st_summarystats(the_raster_webmercator, 1) as stats from pop where st_intersects(the_raster_webmercator, st_transform(st_buffer(cdb_latlon(0, 0)::geography, 100)::geometry, 3857) as foo";
+                
+ sql.execute(q).done(function(data) {
+    if (data.rows && data.rows.length > 0) {
+        console.log("Average raster value inside the " + type + ": " + data.rows[0].m);
+    }
+```
+
+don't forget to use ``the_raster_webmercator`` column. 
+
+
+
+## limitations
+
+- changing the SQL to something custom could avoid Maps API to use overviews and not rendering the
+  tiles due to timeout
+- cartocss version should be 2.3.0. You usually don't need to do anything but if you are working
+  with specific versions take this into account
+- interaction does not work for rasters
+
+
+

--- a/examples/leaflet_raster.html
+++ b/examples/leaflet_raster.html
@@ -32,31 +32,18 @@
         })
 
         // add a base layer
-        L.tileLayer('http://tile.stamen.com/toner/{z}/{x}/{y}.png', {
-          attribution: 'Stamen'
-        }).addTo(map);
 
         // add cartodb layer with one sublayer
         cartodb.createLayer(map, {
-          tiler_domain: 'localhost.lan',
-          tiler_port: 8181,
-          user_name: 'dev',
+          user_name: 'documentation',
           type: 'cartodb',
           sublayers: [{
              sql: 'select * from pop',
              cartocss: '#pop { raster-opacity: 1.0; }',
-             raster: true,
-             interactivity: 'cartodb_id'
-          }],
-          no_cdn: true
+             raster: true
+          }]
         })
         .addTo(map)
-        .done(function(layer) {
-            layer.getSubLayer(0).setCartoCSS('#pop { raster-opacity: 0.2; }');
-            setTimeout(function() {
-              layer.getSubLayer(0).setCartoCSS('#pop { raster-opacity: 1.0; }');
-            }, 3000);
-        });
 
 
       }

--- a/examples/leaflet_raster.html
+++ b/examples/leaflet_raster.html
@@ -31,8 +31,6 @@
           zoom: 3
         })
 
-        // add a base layer
-
         // add cartodb layer with one sublayer
         cartodb.createLayer(map, {
           user_name: 'documentation',

--- a/examples/leaflet_raster.html
+++ b/examples/leaflet_raster.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Leaflet multilayer example | CartoDB.js</title>
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
+    <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
+    <style>
+      html, body, #map {
+        height: 100%;
+        padding: 0;
+        margin: 0;
+      }
+    </style>
+
+    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.11/themes/css/cartodb.css" />
+  </head>
+  <body>
+    <div id="map"></div>
+
+    <!-- include cartodb.js library -->
+    <script src="../dist/cartodb.uncompressed.js"></script>
+    <script>
+
+      function main() {
+
+        // create leaflet map
+        var map = L.map('map', { 
+          zoomControl: false,
+          center: [43, 0],
+          zoom: 3
+        })
+
+        // add a base layer
+        L.tileLayer('http://tile.stamen.com/toner/{z}/{x}/{y}.png', {
+          attribution: 'Stamen'
+        }).addTo(map);
+
+        // add cartodb layer with one sublayer
+        cartodb.createLayer(map, {
+          tiler_domain: 'localhost.lan',
+          tiler_port: 8181,
+          user_name: 'dev',
+          type: 'cartodb',
+          sublayers: [{
+             sql: 'select * from pop',
+             cartocss: '#pop { raster-opacity: 1.0; }',
+             raster: true,
+             interactivity: 'cartodb_id'
+          }],
+          no_cdn: true
+        })
+        .addTo(map)
+        .done(function(layer) {
+            layer.getSubLayer(0).setCartoCSS('#pop { raster-opacity: 0.2; }');
+            setTimeout(function() {
+              layer.getSubLayer(0).setCartoCSS('#pop { raster-opacity: 1.0; }');
+            }, 3000);
+        });
+
+
+      }
+
+      // you could use $(window).load(main);
+      window.onload = main; 
+
+    </script>
+
+  </body>
+</html>

--- a/examples/leaflet_raster.html
+++ b/examples/leaflet_raster.html
@@ -19,7 +19,7 @@
     <div id="map"></div>
 
     <!-- include cartodb.js library -->
-    <script src="../dist/cartodb.uncompressed.js"></script>
+    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.11/cartodb.js"></script>
     <script>
 
       function main() {

--- a/src/geo/layer_definition.js
+++ b/src/geo/layer_definition.js
@@ -461,7 +461,7 @@ Map.prototype = {
         callback && callback(self.urls);
       } else {
         if ((self.named_map !== null) && (err) ){
-          callback && callback(null, err);      
+          callback && callback(null, err);
         } else if (self.visibleLayers().length === 0) {
           callback && callback({
             tiles: [Map.EMPTY_GIF],
@@ -871,15 +871,26 @@ LayerDefinition.prototype = _.extend({}, Map.prototype, {
     var layers = this.visibleLayers();
     for(var i = 0; i < layers.length; ++i) {
       var layer = layers[i];
-      obj.layers.push({
+      var layer_def = {
         type: 'cartodb',
         options: {
           sql: layer.options.sql,
           cartocss: layer.options.cartocss,
           cartocss_version: layer.options.cartocss_version || '2.1.0',
-          interactivity: this._cleanInteractivity(layer.options.interactivity)
         }
-      });
+      };
+
+      if (layer.options.interactivity) {
+        layer_def.options.interactivity = this._cleanInteractivity(layer.options.interactivity);
+      }
+
+      if (layer.options.raster) {
+        layer_def.options.geom_column = "the_raster_webmercator";
+        layer_def.options.geom_type = "raster";
+        // raster needs 2.3.0 to work
+        layer_def.options.cartocss_version = layer.options.cartocss_version || '2.3.0';
+      }
+      obj.layers.push(layer_def);
     }
     return obj;
   },

--- a/test/spec/geo/layer_definition.spec.js
+++ b/test/spec/geo/layer_definition.spec.js
@@ -578,6 +578,51 @@ describe("LayerDefinition", function() {
     });
   });
 
+  describe("raster", function() {
+    var layerDefinitionRaster;
+    beforeEach(function() {
+      var layer_definition = {
+        version: '1.0.0',
+        stat_tag: 'vis_id',
+        layers: [{
+           type: 'cartodb', 
+           options: {
+             sql: 'select * from ne_10m_populated_places_simple',
+             cartocss: '#layer { marker-fill: red; }',
+             raster: true,
+           }
+         }
+        ]
+      };
+      layerDefinitionRaster = new LayerDefinition(layer_definition, {
+        tiler_domain:   "cartodb.com",
+        tiler_port:     "8081",
+        tiler_protocol: "http",
+        user_name: 'rambo',
+        no_cdn: true,
+        subdomains: [null]
+      });
+    });
+
+    it ("should include raster information when raster is true", function() {
+      expect(layerDefinitionRaster.toJSON()).toEqual({
+        version: '1.0.0',
+        stat_tag: 'vis_id',
+        layers: [{
+           type: 'cartodb', 
+           options: {
+             sql: 'select * from ne_10m_populated_places_simple',
+             cartocss: '#layer { marker-fill: red; }',
+             cartocss_version: '2.3.0',
+             geom_column: 'the_raster_webmercator',
+             geom_type: 'raster'
+           }
+         }
+        ]
+      });
+    });
+  });
+
 });
 
 describe("NamedMap", function() {


### PR DESCRIPTION
Hey @rochoa take a look.

the way to create a raster thing is: 
```
cartodb.createLayer(map, {
          user_name: 'dev',
          type: 'cartodb',
          sublayers: [{
             sql: 'select * from pop',
             cartocss: '#pop { raster-opacity: 1.0; }',
             raster: true,
          }],
})
```

I don't know if use ``raster: true`` or just ``geom_type: 'raster'`` what do you think ?