### PR TITLE
Fix not showing time slider if steps aren't > 1

### DIFF
--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -292,7 +292,7 @@ var Vis = cdb.core.View.extend({
 
   addTimeSlider: function(torqueLayer) {
     // if a timeslides already exists don't create it again
-    if (torqueLayer && !this.timeSlider) {
+    if (torqueLayer && (torqueLayer.options.steps > 1) && !this.timeSlider) {
       var self = this;
       // dont use add overlay since this overlay is managed by torque layer
       var timeSlider = Overlay.create('time_slider', this, { layer: torqueLayer });

--- a/test/spec/api/layers.spec.js
+++ b/test/spec/api/layers.spec.js
@@ -270,6 +270,31 @@ describe('api.layers', function() {
         }, wait);
       });
 
+      it("should not add a torque layer timeslider if steps are not greather than 1", function(done) {
+        var layer;
+        var s = sinon.spy();
+        
+        cartodb.createLayer(map, {
+          updated_at: 'jaja',
+          layers: [
+            null,
+            {kind: 'cartodb', options: { user_name: 'test', table_name: 'test', tile_style: 'test'}, infowindow: null },
+            {kind: 'torque', options: { user_name: 'test', table_name: 'test', tile_style: 'Map { -torque-frame-count: 1;} #test { marker-width: 10; }'}, infowindow: null }
+          ]
+        }, { layerIndex: 2 }, s).done(function(lyr) {
+          layer = lyr;
+        }).addTo(map)
+
+        var wait = 500;
+        if (!map.getContainer) wait = 2500;
+
+        setTimeout(function() {
+          if (map.getContainer) expect($(map.getContainer()).find('.cartodb-timeslider').length).toBe(0)
+          if (map.getDiv)       expect($(map.getDiv()).find('.cartodb-timeslider').length).toBe(0)
+          done()
+        }, wait);
+      });
+
       it("should add cartodb logo with torque layer although it is not defined", function(done) {
         var layer;
         var s = sinon.spy();


### PR DESCRIPTION
From an updated branch (develop). (It came from PR 280)

Tests added.
Also, in the example given in the issue, the time steps are: 0.5
Because of that, the condition is greather than 1 (instead of !== 1)