### PR TITLE
docfix: pos and latlng order were switched in event callbacks in examples

### DIFF
--- a/examples/annotations.html
+++ b/examples/annotations.html
@@ -37,8 +37,8 @@
           // layer 0 is the base layer, layer 1 is cartodb layer
           // setInteraction is disabled by default
           layers[1].setInteraction(true);
-          layers[1].on('featureOver', function(e, pos, latlng, data) {
-            cartodb.log.log(e, pos, latlng, data);
+          layers[1].on('featureOver', function(e, latlng, pos, data) {
+            cartodb.log.log(e, latlng, pos, data);
           });
 
           // you can get the native map to work with it

--- a/examples/cursor_interaction.html
+++ b/examples/cursor_interaction.html
@@ -42,7 +42,7 @@
             layer.on('featureOver', featureOver);
           })
 
-        function featureOver(e, pos, latlng, data) {
+        function featureOver(e, latlng, pos, data) {
           console.log(data.cartodb_id)
         }
       }

--- a/examples/easy.html
+++ b/examples/easy.html
@@ -37,8 +37,8 @@
           // layer 0 is the base layer, layer 1 is cartodb layer
           // setInteraction is disabled by default
           layers[1].setInteraction(true);
-          layers[1].on('featureOver', function(e, pos, latlng, data) {
-            cartodb.log.log(e, pos, latlng, data);
+          layers[1].on('featureOver', function(e, latlng, pos, data) {
+            cartodb.log.log(e, latlng, pos, data);
           });
 
           // you can get the native map to work with it

--- a/examples/gmaps/gmaps_driving_directions_plus_sql_api.html
+++ b/examples/gmaps/gmaps_driving_directions_plus_sql_api.html
@@ -61,7 +61,7 @@
             cdb.vis.Vis.addCursorInteraction(map, subLayer); // undo with removeCursorInteraction
 
             // Setup our event when an object is clicked
-            layers.on('featureClick', function(e, pos, latlng, data){
+            layers.on('featureClick', function(e, latlng, pos, data){
               // the location of the clicked school
               var school = new google.maps.LatLng(data.lat, data.lon);
 

--- a/examples/leaflet.html
+++ b/examples/leaflet.html
@@ -38,8 +38,8 @@
 
           layer.setInteraction(true);
 
-          layer.on('featureOver', function(e, pos, latlng, data) {
-            cartodb.log.log(e, pos, latlng, data);
+          layer.on('featureOver', function(e, latlng, pos, data) {
+            cartodb.log.log(e, latlng, pos, data);
           });
 
           layer.on('error', function(err) {

--- a/examples/leaflet_hover_features.html
+++ b/examples/leaflet_hover_features.html
@@ -67,7 +67,7 @@
             }
           });
 
-          function featureOver(e, pos, latlng, data) {
+          function featureOver(e, latlng, pos, data) {
             featureOut();
             var pol = polygons[data.cartodb_id] || [];
             for(var i = 0; i < pol.length; ++i) {

--- a/examples/tutorial-2.html
+++ b/examples/tutorial-2.html
@@ -53,7 +53,7 @@
         sublayer.set(subLayerOptions);
         sublayer.infowindow.set('template', $('#infowindow_template').html());
 
-        sublayer.on('featureClick', function(e, pos, latlng, data) {
+        sublayer.on('featureClick', function(e, latlng, pos, data) {
           alert("Hey! You clicked " + data.cartodb_id);
         });
       }).on('error', function() {

--- a/examples/tutorials/tutorial-2.html
+++ b/examples/tutorials/tutorial-2.html
@@ -53,7 +53,7 @@
         sublayer.set(subLayerOptions);
         sublayer.infowindow.set('template', $('#infowindow_template').html());
 
-        sublayer.on('featureClick', function(e, pos, latlng, data) {
+        sublayer.on('featureClick', function(e, latlng, pos, data) {
           alert("Hey! You clicked " + data.cartodb_id);
         });
       }).on('error', function() {


### PR DESCRIPTION
Looks like the correct order is (e, latlong, pos, ...): http://docs.cartodb.com/cartodb-platform/cartodb-js.html#layerfeatureoverevent-latlng-pos-data-layerindex