### PR TITLE
fixes getSubLayer for named maps, fixes #158

### DIFF
--- a/src/geo/layer_definition.js
+++ b/src/geo/layer_definition.js
@@ -94,7 +94,7 @@ Map.prototype = {
   },
 
   getLayerCount: function() {
-    return this.layers.length;
+    return this.layers ? this.layers.length: 0;
   },
 
   _encodeBase64Native: function (input) {
@@ -675,6 +675,19 @@ Map.prototype = {
 
 NamedMap.prototype = _.extend({}, Map.prototype, {
 
+  getSubLayer: function(index) {
+    var layer = this.layers[index];
+    // for named maps we don't know how many layers are defined so 
+    // we create the layer on the fly
+    if (!layer) {
+      layer = this.layers[index] = {
+        options: {}
+      };
+    }
+    layer.sub = layer.sub || new SubLayer(this, index);
+    return layer.sub;
+  },
+
   setLayerDefinition: function(named_map, options) {
     options = options || {}
     this.endPoint = Map.BASE_URL + '/named/' + named_map.name;
@@ -1073,7 +1086,7 @@ function SubLayer(_parent, position) {
   this._position = position;
   this._added = true;
   this._bindInteraction();
-  if (Backbone.Model) {
+  if (Backbone.Model && this._parent.getLayer(this._position)) {
     this.infowindow = new Backbone.Model(this._parent.getLayer(this._position).infowindow);
     this.infowindow.bind('change', function() {
       var def = this._parent.getLayer(this._position);

--- a/test/spec/geo/layer_definition.spec.js
+++ b/test/spec/geo/layer_definition.spec.js
@@ -782,6 +782,17 @@ describe("NamedMap", function() {
 
   })
 
+  it("should get sublayer", function() {
+    named_map = {
+      name: 'testing',
+      params: {
+        color: 'red'
+      }
+    };
+    namedMap = new NamedMap(named_map, {})
+    expect(namedMap.getSubLayer(0)).not.toEqual(undefined);
+  });
+
   it("should enable/disable layers", function(done) {
     var params;
     namedMap.layers.push({


### PR DESCRIPTION
when we had:

``` 
cartodb.createLayer(map, {
          user_name: 'andye',
          type: 'namedmap',
          named_map: {
             name: "namedmap_ex_test_interactive"
             }
  })
  .addTo(map)
  .done(function(layer) {

          layer.getSubLayer(0).setInteraction(true)
          layer.getSubLayer(0).on('featureOver', function(e, pos, pixel, data) {
            console.log("Event #" + data.cartodb_id + ", magnitude " + data.mag);
			// alert("Event #" + data.cartodb_id + ", magnitude " + data.mag);
          });
})
```

this was failing because with named maps we don't know client side how many layers are. I fixed this assuming the user knows it and adding client side the objects needed to deal with those layers