### PR TITLE
Image core

### DIFF
--- a/examples/images/basemap.html
+++ b/examples/images/basemap.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Single image example | CartoDB.js</title>
+    <title>Basemap | CartoDB.js</title>
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
     <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
     <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
@@ -29,12 +29,21 @@
 
     <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.11/themes/css/cartodb.css" />
     <script src="../../dist/cartodb.uncompressed.js"></script>
+    <script>
+      var basemap = {
+        type: "http",
+        options: {
+          urlTemplate: "http://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
+          subdomains: ["a", "b", "c"]
+        }
+      };
+    </script>
   </head>
   <body>
     <div id="content">
       <div class="map">
         <script>
-          cartodb.Image("https://arcerui.cartodb-staging.com/api/v2/viz/3e778558-6b57-11e4-927b-040111176f01/viz.json", { basemap_url: "http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png"}).bbox([-87.82814025878906,41.88719899247721,  -87.5936508178711,41.942765696654604]).size(500, 500).write();
+          cartodb.Image("https://arcerui.cartodb-staging.com/api/v2/viz/3e778558-6b57-11e4-927b-040111176f01/viz.json").bbox([-87.82814025878906,41.88719899247721,  -87.5936508178711,41.942765696654604]).size(500, 500).write();
         </script>
       </div>
     </div>

--- a/examples/images/core.html
+++ b/examples/images/core.html
@@ -27,8 +27,11 @@
       }
     </style>
 
+    <script src="http://www.google.com/jsapi"></script>
+    <script>google.load("jquery", "1.7.1");</script>
+
     <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.11/themes/css/cartodb.css" />
-    <script src="../../dist/cartodb.js"></script>
+    <script src="../../dist/cartodb.core.js"></script>
     <script>
 
       /* 1: We can create an image using a custom build layer definition: */

--- a/examples/images/format.html
+++ b/examples/images/format.html
@@ -28,7 +28,7 @@
     </style>
 
     <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.11/themes/css/cartodb.css" />
-    <script src="http://development.localhost.lan:3000/assets/3.4.3/javascripts/cdb.js"></script>
+    <script src="../../dist/cartodb.uncompressed.js"></script>
   </head>
   <body>
     <div id="content">

--- a/examples/images/index.html
+++ b/examples/images/index.html
@@ -28,7 +28,7 @@
     </style>
 
     <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.11/themes/css/cartodb.css" />
-    <script src="http://development.localhost.lan:3000/assets/3.4.3/javascripts/cdb.js"></script>
+    <script src="../../dist/cartodb.uncompressed.js"></script>
     <script>
 
       /* 1: We can create an image using a custom build layer definition: */

--- a/examples/images/index.html
+++ b/examples/images/index.html
@@ -28,7 +28,8 @@
     </style>
 
     <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.11/themes/css/cartodb.css" />
-    <script src="../../dist/cartodb.js"></script>
+    <script src="http://development.localhost.lan:3000/assets/3.4.3/javascripts/cdb.js"></script>
+    <!--<script src="../../dist/cartodb.js"></script>-->
     <script>
 
       /* 1: We can create an image using a custom build layer definition: */
@@ -72,14 +73,22 @@
 
       });
 
+      var basemap = {
+        type: "http",
+        options: {
+          urlTemplate: "http://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
+          subdomains: ["a", "b", "c"]
+        }
+      };
+
       /* 2: Another option: with a vizjson defined in the CartoDB editor */
       var vizjsons = [
         { zoom: 2,  url: "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json" },
         { zoom: 17, url: "http://documentation.cartodb.com/api/v2/viz/c3dd77a6-d5e4-11e3-a5b4-0e73339ffa50/viz.json" },
         { zoom: 12, url: "https://documentation.cartodb.com/api/v2/viz/df45a412-d5dc-11e3-855b-0e10bcd91c2b/viz.json" },
         { zoom: 2,  url: "https://documentation.cartodb.com/api/v2/viz/e7132460-d5e8-11e3-8459-0e10bcd91c2b/viz.json" },
-        { basemap_url:"http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png", zoom: 8, url: "https://documentation.cartodb.com/api/v2/viz/d5c2419c-d08d-11e3-80a5-0e230854a1cb/viz.json" },
-        { basemap_url:"http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png", zoom: 5,  url: "https://team.cartodb.com/api/v2/viz/a5a2b18a-5ea0-11e4-a944-0e4fddd5de28/viz.json" }
+        { zoom: 8,  url: "https://documentation.cartodb.com/api/v2/viz/d5c2419c-d08d-11e3-80a5-0e230854a1cb/viz.json" },
+        { basemap: basemap, zoom: 5,  url: "https://team.cartodb.com/api/v2/viz/a5a2b18a-5ea0-11e4-a944-0e4fddd5de28/viz.json" }
       ];
 
       // Let's load all those URLs and add them to the page
@@ -87,7 +96,7 @@
 
         var v = vizjsons[i];
 
-        cartodb.Image(v.url, { basemap_url: v.basemap_url }).size(250, 250).zoom(v.zoom).getUrl(function(error, url) {
+        cartodb.Image(v.url, { basemap: basemap }).size(250, 250).zoom(v.zoom).getUrl(function(error, url) {
         var img = new Image();
 
         img.onerror = function() {

--- a/examples/images/index.html
+++ b/examples/images/index.html
@@ -78,8 +78,8 @@
         { zoom: 17, url: "http://documentation.cartodb.com/api/v2/viz/c3dd77a6-d5e4-11e3-a5b4-0e73339ffa50/viz.json" },
         { zoom: 12, url: "https://documentation.cartodb.com/api/v2/viz/df45a412-d5dc-11e3-855b-0e10bcd91c2b/viz.json" },
         { zoom: 2,  url: "https://documentation.cartodb.com/api/v2/viz/e7132460-d5e8-11e3-8459-0e10bcd91c2b/viz.json" },
-        { basemap:"dark_nolabels", zoom: 8, url: "https://documentation.cartodb.com/api/v2/viz/d5c2419c-d08d-11e3-80a5-0e230854a1cb/viz.json" },
-        { basemap:"dark_nolabels", zoom: 5,  url: "https://team.cartodb.com/api/v2/viz/a5a2b18a-5ea0-11e4-a944-0e4fddd5de28/viz.json" }
+        { basemap_url:"http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png", zoom: 8, url: "https://documentation.cartodb.com/api/v2/viz/d5c2419c-d08d-11e3-80a5-0e230854a1cb/viz.json" },
+        { basemap_url:"http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png", zoom: 5,  url: "https://team.cartodb.com/api/v2/viz/a5a2b18a-5ea0-11e4-a944-0e4fddd5de28/viz.json" }
       ];
 
       // Let's load all those URLs and add them to the page
@@ -87,7 +87,7 @@
 
         var v = vizjsons[i];
 
-        cartodb.Image(v.url, { basemap: v.basemap }).size(250, 250).zoom(v.zoom).getUrl(function(error, url) {
+        cartodb.Image(v.url, { basemap_url: v.basemap_url }).size(250, 250).zoom(v.zoom).getUrl(function(error, url) {
         var img = new Image();
 
         img.onerror = function() {

--- a/examples/images/index.html
+++ b/examples/images/index.html
@@ -28,8 +28,7 @@
     </style>
 
     <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.11/themes/css/cartodb.css" />
-    <script src="http://development.localhost.lan:3000/assets/3.4.3/javascripts/cdb.js"></script>
-    <!--<script src="../../dist/cartodb.js"></script>-->
+    <script src="../../dist/cartodb.js"></script>
     <script>
 
       /* 1: We can create an image using a custom build layer definition: */

--- a/examples/images/plain-color.html
+++ b/examples/images/plain-color.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Plain color | CartoDB.js</title>
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
+    <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
+    <style>
+      html, body {
+        height: 100%;
+        padding: 0;
+        margin: 0;
+      }
+
+      #content {
+        padding: 20px;
+        text-align: center;
+      }
+
+      .map {
+        float:left;
+        margin: 10px;
+        width: 500px;
+        height: 500px;
+        border: 1px solid #ccc;
+        background-color: #f8f8f8;
+      }
+      .map img { display: none; }
+    </style>
+
+    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.11/themes/css/cartodb.css" />
+    <script src="http://development.localhost.lan:3000/assets/3.4.3/javascripts/cdb.js"></script>
+    <script>
+
+      var layer_definition = {
+        user_name: "arcerui",
+        tiler_domain: "cartodb-staging.com",
+        tiler_port: "80",
+        tiler_protocol: "http",
+        layers: [{
+          type: "plain",
+          options: {
+            color: "lightblue"
+          }
+        }, {
+          type: "cartodb",
+          options: {
+            sql: "SELECT * FROM spotimap_cities",
+            cartocss: "#spotimap_cities{ marker-fill-opacity: 0.9; marker-line-color: #FFF; marker-line-width: 1.5; marker-line-opacity: 1; marker-placement: point; marker-type: ellipse; marker-width: 10; marker-fill: #FF6600; marker-allow-overlap: true; } ",
+            cartocss_version: "2.1.1"
+          }
+        }
+        ]
+      };
+
+      cartodb.Image(layer_definition).size(500, 500).zoom(2).center([40.708517, -73.993414]).getUrl(function(error, url) {
+
+        var img = new Image();
+
+        img.onerror = function() {
+          console.log(error);
+        };
+
+        img.onload  = function() {
+          var $map = $('<div class="map"></div>');
+          var $img = $('<img src="' + url + '" />');
+          $map.append($img);
+          $("#content").append($map);
+          $img.fadeIn(250);
+        };
+
+        img.src = url;
+
+      });
+    </script>
+  </head>
+  <body>
+    <div id="content"></div>
+  </body>
+</html>

--- a/examples/images/single-image.html
+++ b/examples/images/single-image.html
@@ -28,7 +28,7 @@
     </style>
 
     <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.11/themes/css/cartodb.css" />
-    <script src="http://development.localhost.lan:3000/assets/3.4.3/javascripts/cdb.js"></script>
+    <script src="../../dist/cartodb.uncompressed.js"></script>
   </head>
   <body>
     <div id="content">

--- a/examples/images/single-image.html
+++ b/examples/images/single-image.html
@@ -34,7 +34,7 @@
     <div id="content">
       <div class="map">
         <script>
-          cartodb.Image("https://documentation.cartodb.com/api/v2/viz/df45a412-d5dc-11e3-855b-0e10bcd91c2b/viz.json").bbox([-87.82814025878906,41.88719899247721,  -87.5936508178711,41.942765696654604]).size(500, 500).write();
+          cartodb.Image("https://documentation.cartodb.com/api/v2/viz/df45a412-d5dc-11e3-855b-0e10bcd91c2b/viz.json", { basemap_url: "http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png"}).bbox([-87.82814025878906,41.88719899247721,  -87.5936508178711,41.942765696654604]).size(500, 500).write();
         </script>
       </div>
     </div>

--- a/examples/images/torque.html
+++ b/examples/images/torque.html
@@ -29,7 +29,7 @@
     </style>
 
     <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.11/themes/css/cartodb.css" />
-    <script src="http://development.localhost.lan:3000/assets/3.4.3/javascripts/cdb.js"></script>
+    <script src="../../dist/cartodb.uncompressed.js"></script>
     <script>
       var layer_definition = {
         user_name: "rochoa-st",

--- a/grunt/tasks/concat.js
+++ b/grunt/tasks/concat.js
@@ -70,6 +70,8 @@ module.exports = {
             'src/core/profiler.js',
             'src/api/sql.js',
             'src/geo/layer_definition.js',
+            'src/core/loader.js',
+            'src/vis/image.js',
             'src/api/tiles.js'
           ]
         }

--- a/grunt/tasks/jasmine.js
+++ b/grunt/tasks/jasmine.js
@@ -76,6 +76,7 @@ module.exports = {
           "src/ui/common/tabpane.js",
           "src/ui/common/dropdown.js",
           "src/vis/vis.js",
+          "src/vis/image.js",
           "src/vis/layers.js",
           "src/vis/overlays.js",
           "src/api/layers.js",

--- a/src/api/layers.js
+++ b/src/api/layers.js
@@ -47,7 +47,7 @@
       url = layer;
     }
     if(url) {
-      cdb.vis.Loader.get(url, callback);
+      cdb.core.Loader.get(url, callback);
     } else {
       _.defer(function() { callback(null); });
     }

--- a/src/cartodb.js
+++ b/src/cartodb.js
@@ -59,6 +59,7 @@
         'core/template.js',
         'core/model.js',
         'core/view.js',
+        'core/loader.js',
 
         'geo/geocoder.js',
         'geo/geometry.js',

--- a/src/core/loader.js
+++ b/src/core/loader.js
@@ -1,0 +1,70 @@
+var Loader = cdb.core.Loader = {
+
+  queue: [],
+  current: undefined,
+  _script: null,
+  head: null,
+
+  loadScript: function(src) {
+      var script = document.createElement('script');
+      script.type = 'text/javascript';
+      script.src = src;
+      script.async = true;
+      if (!Loader.head) {
+        Loader.head = document.getElementsByTagName('head')[0];
+      }
+      // defer the loading because IE9 loads in the same frame the script
+      // so Loader._script is null
+      setTimeout(function() {
+        Loader.head.appendChild(script);
+      }, 0);
+      return script;
+  },
+
+  get: function(url, callback) {
+    if (!Loader._script) {
+      Loader.current = callback;
+      Loader._script = Loader.loadScript(url + (~url.indexOf('?') ? '&' : '?') + 'callback=vizjson');
+    } else {
+      Loader.queue.push([url, callback]);
+    }
+  },
+
+  getPath: function(file) {
+    var scripts = document.getElementsByTagName('script'),
+        cartodbJsRe = /\/?cartodb[\-\._]?([\w\-\._]*)\.js\??/;
+    for (i = 0, len = scripts.length; i < len; i++) {
+      src = scripts[i].src;
+      matches = src.match(cartodbJsRe);
+
+      if (matches) {
+        var bits = src.split('/');
+        delete bits[bits.length - 1];
+        return bits.join('/') + file;
+      }
+    }
+    return null;
+  },
+
+  loadModule: function(modName) {
+    var file = "cartodb.mod." + modName + (cartodb.DEBUG ? ".uncompressed.js" : ".js");
+    var src = this.getPath(file);
+    if (!src) {
+      cartodb.log.error("can't find cartodb.js file");
+    }
+    Loader.loadScript(src);
+  }
+};
+
+window.vizjson = function(data) {
+  Loader.current && Loader.current(data);
+  // remove script
+  Loader.head.removeChild(Loader._script);
+  Loader._script = null;
+  // next element
+  var a = Loader.queue.shift();
+  if (a) {
+    Loader.get(a[0], a[1]);
+  }
+};
+

--- a/src/core/loader.js
+++ b/src/core/loader.js
@@ -1,4 +1,4 @@
-var Loader = cdb.core.Loader = {
+var Loader = cdb.vis.Loader = cdb.core.Loader = {
 
   queue: [],
   current: undefined,

--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -137,10 +137,10 @@
         bbox.push([data.bounds[0][1], data.bounds[0][0]]);
         bbox.push([data.bounds[1][1], data.bounds[1][0]]);
 
-        this.imageOptions["zoom"]   = data.zoom;
-        this.imageOptions["center"] = JSON.parse(data.center);
-        this.imageOptions["bbox"]   = bbox;
-        this.imageOptions["bounds"] = data.bounds;
+        this.imageOptions.zoom   = data.zoom;
+        this.imageOptions.center = JSON.parse(data.center);
+        this.imageOptions.bbox   = bbox;
+        this.imageOptions.bounds = data.bounds;
 
         if (dataLayer.type === "namedmap") {
           this.options.layers = this._getNamedmapLayerDefinition(dataLayer.options);
@@ -156,7 +156,7 @@
 
     _setupTilerConfiguration: function(protocol, domain, port) {
 
-      var vizjson = this.imageOptions["vizjson"];
+      var vizjson = this.imageOptions.vizjson;
 
       var isHTTPS = vizjson.indexOf("https") !== -1 ? true : false;
 
@@ -187,7 +187,7 @@
         }
 
         if (data) {
-          self.imageOptions["layergroupid"] = data.layergroupid;
+          self.imageOptions.layergroupid = data.layergroupid;
         }
 
         self.queue.flush(this);
@@ -201,7 +201,7 @@
       return {
         type: "http",
         options: {
-          urlTemplate: "http://{s}.basemaps.cartocdn.com/" + this.imageOptions["basemap"] + "/{z}/{x}/{y}.png",
+          urlTemplate: "http://{s}.basemaps.cartocdn.com/" + this.imageOptions.basemap + "/{z}/{x}/{y}.png",
           subdomains: [ "a", "b", "c" ]
         }
       };
@@ -279,7 +279,7 @@
 
     _chooseBasemap: function(basemap_layer) { 
 
-      if (this.imageOptions["basemap"]) return;
+      if (this.imageOptions.basemap) return;
 
       var type = basemap_layer.base_type;
 
@@ -292,7 +292,7 @@
         else if (type && type.indexOf("light") !== -1) basemap = "light_all";
         else basemap = "light_all";
 
-        this.imageOptions["basemap"] = basemap;
+        this.imageOptions.basemap = basemap;
 
       }
 
@@ -353,7 +353,7 @@
         return;
       }
 
-      this.imageOptions["size"] = [img.width, img.height];
+      this.imageOptions.size = [img.width, img.height];
 
       this.queue.add(function(response) {
         img.src = self._getUrl();
@@ -378,28 +378,27 @@
 
     /* Image.write(attributes)
        adds a img tag in the same place script is executed */
-      // TODO: document class, id and src attributes
 
     write: function(attributes) {
 
       var self = this;
 
-      this.imageOptions["attributes"] = attributes;
+      this.imageOptions.attributes = attributes;
 
       if (attributes && attributes.src) {
-        document.write('<img id="' + this.imageOptions["temp_id"] + '" src="'  + attributes.src + '" />');
+        document.write('<img id="' + this.imageOptions.temp_id + '" src="'  + attributes.src + '" />');
       } else {
-        document.write('<img id="' + this.imageOptions["temp_id"] + '" />');
+        document.write('<img id="' + this.imageOptions.temp_id + '" />');
       }
 
       this.queue.add(function() {
 
-        var element = document.getElementById(self.imageOptions["temp_id"]);
+        var element = document.getElementById(self.imageOptions.temp_id);
 
         element.src = self._getUrl();
         element.removeAttribute("temp_id");
 
-        var attributes = self.imageOptions["attributes"];
+        var attributes = self.imageOptions.attributes;
 
         if (attributes && attributes.class) { element.setAttribute("class", attributes.class); }
         if (attributes && attributes.id)    { element.setAttribute("id", attributes.id); }

--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -131,13 +131,21 @@
 
         var bbox = [];
 
-        bbox.push([data.bounds[0][1], data.bounds[0][0]]);
-        bbox.push([data.bounds[1][1], data.bounds[1][0]]);
+        var bounds = data.bounds;
+
+        if (bounds) {
+          bbox.push([bounds[0][1], bounds[0][0]]);
+          bbox.push([bounds[1][1], bounds[1][0]]);
+        }
 
         this.imageOptions.zoom   = data.zoom;
         this.imageOptions.center = JSON.parse(data.center);
         this.imageOptions.bbox   = bbox;
         this.imageOptions.bounds = data.bounds;
+
+        if (baseLayer && baseLayer.options) {
+          this.imageOptions.basemap = baseLayer.options;
+        }
 
         if (dataLayer.type === "namedmap") {
           this.options.layers = this._getNamedmapLayerDefinition(dataLayer.options);
@@ -205,21 +213,51 @@
 
     },
 
+    _getHTTPBasemapLayer: function(urlTemplate, subdomains) {
+
+      return {
+        type: "http",
+        options: {
+          urlTemplate: urlTemplate,
+          subdomains: subdomains || ["a", "b", "c"]
+        }
+      };
+
+    },
+
+    _getPlainBasemapLayer: function(color) {
+
+      return {
+        type: "plain",
+        options: {
+          color: color
+        }
+      };
+    
+    },
+
     _getBasemapLayer: function() {
+
+      var basemap = this.imageOptions.basemap;
 
       if (this.imageOptions.basemap_url) {
 
-        var urlTemplate = this.imageOptions.basemap_url;
+        return this._getHTTPBasemapLayer(this.imageOptions.basemap_url);
 
-        return {
-          type: "http",
-          options: {
-            urlTemplate: urlTemplate,
-            subdomains: ["a", "b", "c"]
-          }
-        };
+      } else if (basemap) {
+
+        if (basemap.type.toLowerCase() === "plain")  {
+
+          return this._getPlainBasemapLayer(basemap.color);
+
+        } else {
+
+          return this._getHTTPBasemapLayer(basemap.urlTemplate, basemap.subdomains);
+        }
       } else {
+
         return this._getDefaultBasemapLayer();
+
       }
 
     },

--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -87,7 +87,7 @@
 
       this.imageOptions = options;
 
-      cdb.vis.Loader.get(vizjson, this._onVisLoaded);
+      cdb.core.Loader.get(vizjson, this._onVisLoaded);
 
       return this;
 

--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -83,7 +83,9 @@
 
       this.queue = new Queue;
 
-      options = _.defaults(options, { vizjson: vizjson, temp_id: "s" + this._getUUID() }, this.defaults);
+      this.userOptions = options;
+
+      options = _.defaults({ vizjson: vizjson, temp_id: "s" + this._getUUID() }, this.defaults);
 
       this.imageOptions = options;
 
@@ -145,7 +147,7 @@
         this.imageOptions.bounds = data.bounds;
 
         if (baseLayer && baseLayer.options) {
-          this.imageOptions.basemap = baseLayer.options;
+          this.imageOptions.basemap = baseLayer;
         }
 
         if (dataLayer.type === "namedmap") {
@@ -214,13 +216,13 @@
 
     },
 
-    _getHTTPBasemapLayer: function(urlTemplate, subdomains) {
+    _getHTTPBasemapLayer: function(basemap) {
 
       return {
         type: "http",
         options: {
-          urlTemplate: urlTemplate,
-          subdomains: subdomains || this.defaults.basemap_subdomains
+          urlTemplate: basemap.options.urlTemplate,
+          subdomains: basemap.options.subdomains || this.defaults.basemap_subdomains
         }
       };
 
@@ -239,17 +241,14 @@
 
     _getBasemapLayer: function() {
 
-      var basemap     = this.imageOptions.basemap;
-      var basemap_url = this.imageOptions.basemap_url;
-
-      if (basemap_url) return this._getHTTPBasemapLayer(basemap_url);
+      var basemap = this.userOptions.basemap || this.imageOptions.basemap;
 
       if (basemap) {
 
         var type = basemap.type.toLowerCase();
 
         if (type === "plain") return this._getPlainBasemapLayer(basemap.color);
-        else                  return this._getHTTPBasemapLayer(basemap.urlTemplate, basemap.subdomains);
+        else                  return this._getHTTPBasemapLayer(basemap);
 
       }
 

--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -63,7 +63,8 @@
     this.supported_formats = ["png", "jpg"];
 
     this.defaults = {
-      basemap: "light_all",
+      basemap_url_template: "http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
+      basemap_subdomains: ["a", "b", "c"],
       format: "png",
       zoom: 10,
       center: [0, 0],
@@ -206,8 +207,8 @@
       return {
         type: "http",
         options: {
-          urlTemplate: "http://{s}.basemaps.cartocdn.com/" + this.defaults.basemap + "/{z}/{x}/{y}.png",
-          subdomains: [ "a", "b", "c" ]
+          urlTemplate: this.defaults.basemap_url_template,
+          subdomains:  this.defaults.basemap_subdomains
         }
       };
 
@@ -219,7 +220,7 @@
         type: "http",
         options: {
           urlTemplate: urlTemplate,
-          subdomains: subdomains || ["a", "b", "c"]
+          subdomains: subdomains || this.defaults.basemap_subdomains
         }
       };
 
@@ -233,39 +234,32 @@
           color: color
         }
       };
-    
+
     },
 
     _getBasemapLayer: function() {
 
-      var basemap = this.imageOptions.basemap;
+      var basemap     = this.imageOptions.basemap;
+      var basemap_url = this.imageOptions.basemap_url;
 
-      if (this.imageOptions.basemap_url) {
+      if (basemap_url) return this._getHTTPBasemapLayer(basemap_url);
 
-        return this._getHTTPBasemapLayer(this.imageOptions.basemap_url);
+      if (basemap) {
 
-      } else if (basemap) {
+        var type = basemap.type.toLowerCase();
 
-        if (basemap.type.toLowerCase() === "plain")  {
-
-          return this._getPlainBasemapLayer(basemap.color);
-
-        } else {
-
-          return this._getHTTPBasemapLayer(basemap.urlTemplate, basemap.subdomains);
-        }
-      } else {
-
-        return this._getDefaultBasemapLayer();
+        if (type === "plain") return this._getPlainBasemapLayer(basemap.color);
+        else                  return this._getHTTPBasemapLayer(basemap.urlTemplate, basemap.subdomains);
 
       }
+
+      return this._getDefaultBasemapLayer();
 
     },
 
     _getLayergroupLayerDefinition: function(options) {
 
       var layerDefinition = new LayerDefinition(options.layer_definition, options);
-
       var ld = layerDefinition.toJSON();
 
       ld.layers.unshift(this._getBasemapLayer());
@@ -299,22 +293,18 @@
     _getUrl: function() {
 
       var username     = this.options.user_name;
-
-      var zoom         = this.imageOptions.zoom || this.defaults.zoom;
       var bbox         = this.imageOptions.bbox;
-
+      var layergroupid = this.imageOptions.layergroupid;
+      var zoom         = this.imageOptions.zoom   || this.defaults.zoom;
       var center       = this.imageOptions.center || this.defaults.center;
+      var size         = this.imageOptions.size   || this.defaults.size;
+      var format       = this.imageOptions.format || this.defaults.format;
 
-      var lat = center[0];
-      var lon = center[1];
-
-      var size = this.imageOptions.size || this.defualts.size;
+      var lat    = center[0];
+      var lon    = center[1];
 
       var width  = size[0];
       var height = size[1];
-
-      var layergroupid = this.imageOptions.layergroupid;
-      var format       = this.imageOptions.format || this.defaults.format;
 
       var url = this._tilerHost() + this.endPoint;
 

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -85,76 +85,6 @@ var Layers = {
 
 cdb.vis.Layers = Layers;
 
-var Loader = cdb.vis.Loader = {
-
-  queue: [],
-  current: undefined,
-  _script: null,
-  head: null,
-
-  loadScript: function(src) {
-      var script = document.createElement('script');
-      script.type = 'text/javascript';
-      script.src = src;
-      script.async = true;
-      if (!Loader.head) {
-        Loader.head = document.getElementsByTagName('head')[0];
-      }
-      // defer the loading because IE9 loads in the same frame the script
-      // so Loader._script is null
-      setTimeout(function() {
-        Loader.head.appendChild(script);
-      }, 0);
-      return script;
-  },
-
-  get: function(url, callback) {
-    if (!Loader._script) {
-      Loader.current = callback;
-      Loader._script = Loader.loadScript(url + (~url.indexOf('?') ? '&' : '?') + 'callback=vizjson');
-    } else {
-      Loader.queue.push([url, callback]);
-    }
-  },
-
-  getPath: function(file) {
-    var scripts = document.getElementsByTagName('script'),
-        cartodbJsRe = /\/?cartodb[\-\._]?([\w\-\._]*)\.js\??/;
-    for (i = 0, len = scripts.length; i < len; i++) {
-      src = scripts[i].src;
-      matches = src.match(cartodbJsRe);
-
-      if (matches) {
-        var bits = src.split('/');
-        delete bits[bits.length - 1];
-        return bits.join('/') + file;
-      }
-    }
-    return null;
-  },
-
-  loadModule: function(modName) {
-    var file = "cartodb.mod." + modName + (cartodb.DEBUG ? ".uncompressed.js" : ".js");
-    var src = this.getPath(file);
-    if (!src) {
-      cartodb.log.error("can't find cartodb.js file");
-    }
-    Loader.loadScript(src);
-  }
-};
-
-window.vizjson = function(data) {
-  Loader.current && Loader.current(data);
-  // remove script
-  Loader.head.removeChild(Loader._script);
-  Loader._script = null;
-  // next element
-  var a = Loader.queue.shift();
-  if (a) {
-    Loader.get(a[0], a[1]);
-  }
-};
-
 cartodb.moduleLoad = function(name, mod) {
   cartodb[name] = mod;
   cartodb.config.modules.add({
@@ -337,7 +267,7 @@ var Vis = cdb.core.View.extend({
 
       var url = data;
 
-      cdb.vis.Loader.get(url, function(data) {
+      cdb.core.Loader.get(url, function(data) {
         if (data) {
           self.load(data, options);
         } else {

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -77,6 +77,8 @@
   <script src="../src/core/template.js"></script>
   
   <script src="../src/core/view.js"></script>
+
+  <script src="../src/core/loader.js"></script>
   
   <script src="../src/geo/geometry.js"></script>
   

--- a/test/spec/api/layers.spec.js
+++ b/test/spec/api/layers.spec.js
@@ -51,26 +51,26 @@ describe('api.layers', function() {
       });
 
       it("should fecth layer when user and pass are specified", function() {
-        spyOn(cdb.vis.Loader, 'get');
+        spyOn(cdb.core.Loader, 'get');
         cartodb.createLayer(map, {
           user: 'development',
           table: 'clubbing',
           host: 'localhost.lan:3000',
           protocol: 'http'
         });
-        expect(cdb.vis.Loader.get).toHaveBeenCalled();
+        expect(cdb.core.Loader.get).toHaveBeenCalled();
       });
 
       it("should fecth layer when a url is specified", function() {
-        spyOn(cdb.vis.Loader, 'get');
+        spyOn(cdb.core.Loader, 'get');
         cartodb.createLayer(map, 'http://test.com/layer.json');
-        expect(cdb.vis.Loader.get).toHaveBeenCalled();
+        expect(cdb.core.Loader.get).toHaveBeenCalled();
       });
 
       it("should not fecth layer when kind and options are specified", function() {
-        spyOn(cdb.vis.Loader, 'get');
+        spyOn(cdb.core.Loader, 'get');
         cartodb.createLayer(map, { kind: 'plain', options: {} });
-        expect(cdb.vis.Loader.get).not.toHaveBeenCalled();
+        expect(cdb.core.Loader.get).not.toHaveBeenCalled();
       });
 
       it("should create a layer", function(done) {

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -22,14 +22,16 @@ describe("Image", function() {
 
   });
 
-  it("should have a default basemap", function(done) {
+  it("should use the basemap defined in the vizjson", function(done) {
 
     var vizjson = "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"
 
     var image = cartodb.Image(vizjson).size(640, 480);
 
+    var basemap = { id: '0a3d9104-99c6-482b-9f8c-7c6134bddcdc', order: 0, visible: true, type: 'Tiled', name: 'CartoDB Light', className: 'default light_cartodb', base_type: 'light_cartodb', urlTemplate: 'https://cartocdn_{s}.global.ssl.fastly.net/base-light/{z}/{x}/{y}.png', read_only: true, minZoom: 0, maxZoom: 10, attribution: '', subdomains: 'abcd' };
+
     image.getUrl(function() {
-      expect(image.imageOptions["basemap"]).toEqual("light_all");
+      expect(image.imageOptions.basemap).toEqual(basemap);
       done();
     });
 

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -39,10 +39,10 @@ describe("Image", function() {
 
     var vizjson = "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"
 
-    var image = cartodb.Image(vizjson, { basemap: "my_fantastic_basemap" }).size(640, 480);
+    var image = cartodb.Image(vizjson, { basemap_url: "http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png" }).size(640, 480);
 
     image.getUrl(function() {
-      expect(image.imageOptions["basemap"]).toEqual("my_fantastic_basemap");
+      expect(image.imageOptions["basemap_url"]).toEqual("http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png");
       done();
     });
 

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -28,23 +28,10 @@ describe("Image", function() {
 
     var image = cartodb.Image(vizjson).size(640, 480);
 
-    var basemap = { id: '0a3d9104-99c6-482b-9f8c-7c6134bddcdc', order: 0, visible: true, type: 'Tiled', name: 'CartoDB Light', className: 'default light_cartodb', base_type: 'light_cartodb', urlTemplate: 'https://cartocdn_{s}.global.ssl.fastly.net/base-light/{z}/{x}/{y}.png', read_only: true, minZoom: 0, maxZoom: 10, attribution: '', subdomains: 'abcd' };
+    var basemap =  { options: { id: '0a3d9104-99c6-482b-9f8c-7c6134bddcdc', order: 0, visible: true, type: 'Tiled', name: 'CartoDB Light', className: 'default light_cartodb', base_type: 'light_cartodb', urlTemplate: 'https://cartocdn_{s}.global.ssl.fastly.net/base-light/{z}/{x}/{y}.png', read_only: true, minZoom: 0, maxZoom: 10, attribution: '', subdomains: 'abcd' }, infowindow: null, tooltip: null, id: '0a3d9104-99c6-482b-9f8c-7c6134bddcdc', order: 0, parent_id: null, children: [  ], type: 'tiled' };
 
     image.getUrl(function() {
       expect(image.imageOptions.basemap).toEqual(basemap);
-      done();
-    });
-
-  });
-
-  it("should allow to set the basemap", function(done) {
-
-    var vizjson = "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"
-
-    var image = cartodb.Image(vizjson, { basemap_url: "http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png" }).size(640, 480);
-
-    image.getUrl(function() {
-      expect(image.imageOptions["basemap_url"]).toEqual("http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png");
       done();
     });
 
@@ -99,7 +86,7 @@ describe("Image", function() {
     var regexp = new RegExp("http://documentation\.cartodb\.com:80/api/v1/map/static/center/(.*?)/2/40/10/320/240\.png");
 
     image.center([40,10]).getUrl(function(err, url) {
-      expect(image.imageOptions["zoom"]).toEqual(2);
+      expect(image.imageOptions.zoom).toEqual(2);
       expect(url).toMatch(regexp);
       done();
     });

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -16,7 +16,7 @@ describe("Image", function() {
     var image = cartodb.Image(vizjson).size(640, 480);
 
     image.getUrl(function() {
-      expect(image.model.get("size")).toEqual([640, 480]);
+      expect(image.imageOptions["size"]).toEqual([640, 480]);
       done();
     });
 
@@ -29,7 +29,7 @@ describe("Image", function() {
     var image = cartodb.Image(vizjson).size(640, 480);
 
     image.getUrl(function() {
-      expect(image.model.get("basemap")).toEqual("light_all");
+      expect(image.imageOptions["basemap"]).toEqual("light_all");
       done();
     });
 
@@ -42,7 +42,7 @@ describe("Image", function() {
     var image = cartodb.Image(vizjson, { basemap: "my_fantastic_basemap" }).size(640, 480);
 
     image.getUrl(function() {
-      expect(image.model.get("basemap")).toEqual("my_fantastic_basemap");
+      expect(image.imageOptions["basemap"]).toEqual("my_fantastic_basemap");
       done();
     });
 
@@ -55,7 +55,7 @@ describe("Image", function() {
     var image = cartodb.Image(vizjson).zoom(4);
 
     image.getUrl(function() {
-      expect(image.model.get("zoom")).toEqual(4);
+      expect(image.imageOptions["zoom"]).toEqual(4);
       done();
     });
 
@@ -68,7 +68,7 @@ describe("Image", function() {
     var image = cartodb.Image(vizjson).center([40, 30]);
 
     image.getUrl(function() {
-      expect(image.model.get("center")).toEqual([40, 30]);
+      expect(image.imageOptions["center"]).toEqual([40, 30]);
       done();
     });
 
@@ -97,7 +97,7 @@ describe("Image", function() {
     var regexp = new RegExp("http://documentation\.cartodb\.com:80/api/v1/map/static/center/(.*?)/2/40/10/320/240\.png");
 
     image.center([40,10]).getUrl(function(err, url) {
-      expect(image.model.get("zoom")).toEqual(2);
+      expect(image.imageOptions["zoom"]).toEqual(2);
       expect(url).toMatch(regexp);
       done();
     });
@@ -111,7 +111,7 @@ describe("Image", function() {
     var image = cartodb.Image(vizjson).format("jpg");
 
     image.getUrl(function() {
-      expect(image.model.get("format")).toEqual("jpg");
+      expect(image.imageOptions["format"]).toEqual("jpg");
       done();
     });
 
@@ -124,7 +124,7 @@ describe("Image", function() {
     var image = cartodb.Image(vizjson).format("pin");
 
     image.getUrl(function() {
-      expect(image.model.get("format")).toEqual("png");
+      expect(image.imageOptions["format"]).toEqual("png");
       done();
     });
 


### PR DESCRIPTION
This branch:

- Removes the backbone dependency from the Image library.
- Extracts the Loader into its own file (cdb.vis.Loader → cdb.core.Loader)
- Adds a new example that only uses cartodb.core.js
- Update specs.

Extra stuff:

- Allows to specify a custom basemap (see [example/images/basemap.html](https://github.com/CartoDB/cartodb.js/blob/fd15b4c597985f14a94b5936cb20a11962ad594e/examples/images/basemap.html))
- Adds support for Plain basemaps.
- Adds vis namespace to Loader: cdb.vis.Loader = cdb.core.Loader

/cc @javisantana 