### PR TITLE
Explicitly loads the image url + adds spec

### DIFF
--- a/grunt/tasks/jasmine.js
+++ b/grunt/tasks/jasmine.js
@@ -37,6 +37,8 @@ module.exports = {
           "src/geo/ui/infowindow.js",
           "src/geo/ui/search.js",
           "src/geo/ui/mobile.js",
+          "src/geo/ui/text.js",
+          "src/geo/ui/image.js",
           "src/geo/ui/annotation.js",
           "src/geo/ui/layer_selector.js",
           'src/geo/ui/slides_controller.js',

--- a/src/geo/ui/image.js
+++ b/src/geo/ui/image.js
@@ -52,7 +52,51 @@ cdb.geo.ui.Image = cdb.geo.ui.Text.extend({
       backgroundColor: rgbaCol
     });
 
+    var url = this.model.get("extra").url;
+
+    this._loadImage(url)
+
     this.$el.find("img").css({ width: boxWidth });
+
+  },
+
+  _loadImage: function(url) {
+
+    var self = this;
+
+    var success = function() {
+      self._onLoadSuccess(url);
+    };
+
+    var error = function() {
+      self._onLoadError(url);
+    };
+
+    $("<img/>")
+    .load(success)
+    .error(error)
+    .attr("src", url);
+
+  },
+
+  _onLoadError: function(url) {
+    this.$el.addClass('error');
+  },
+
+  _onLoadSuccess: function(url) {
+
+    var style     = this.model.get("style");
+    var boxWidth  = style["box-width"];
+    var extra     = this.model.get("extra");
+    var img       = "<img src='" + url + "' style='width: " + boxWidth + "px'/>";
+
+    extra.rendered_text = img;
+
+    this.model.set({ extra: extra }, { silent: true });
+
+    this.$text.html(img);
+
+    this.show();
 
   },
 
@@ -60,7 +104,10 @@ cdb.geo.ui.Image = cdb.geo.ui.Text.extend({
 
     var content = this.model.get("extra").rendered_text;
 
-    if (this.model.get("extra").has_default_image) content = '<img src="' + this.model.get("extra").public_default_image_url + '" />';
+    if (this.model.get("extra").has_default_image) {
+      var url = this.model.get("extra").public_default_image_url;
+      content = '<img src="' + url + '" />';
+    }
 
     this.$el.html(this.template(_.extend(this.model.attributes, { content: content })));
 
@@ -71,9 +118,7 @@ cdb.geo.ui.Image = cdb.geo.ui.Text.extend({
     setTimeout(function() {
       self._applyStyle();
       self._place();
-      self.show();
-    }, 900);
-
+    }, 500);
 
     return this;
 

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -94,6 +94,10 @@
   
   <script src="../src/geo/ui/mobile.js"></script>
   
+  <script src="../src/geo/ui/text.js"></script>
+  
+  <script src="../src/geo/ui/image.js"></script>
+  
   <script src="../src/geo/ui/annotation.js"></script>
   
   <script src="../src/geo/ui/layer_selector.js"></script>
@@ -171,7 +175,7 @@
   <script src="../src/ui/common/dropdown.js"></script>
   
   <script src="../src/vis/vis.js"></script>
-
+  
   <script src="../src/vis/image.js"></script>
   
   <script src="../src/vis/layers.js"></script>
@@ -237,6 +241,8 @@
   <script src="spec/geo/mobile.spec.js"></script>
   
   <script src="spec/geo/overlays/annotation.spec.js"></script>
+  
+  <script src="spec/geo/overlays/image.spec.js"></script>
   
   <script src="spec/geo/ui/header.spec.js"></script>
   

--- a/test/spec/geo/overlays/image.spec.js
+++ b/test/spec/geo/overlays/image.spec.js
@@ -1,0 +1,69 @@
+describe("cdb.geo.ui.Image", function() {
+
+  var data, view;
+
+  var public_default_image_url = "http://cartodb.s3.amazonaws.com/static/overlay_placeholder_cartofante.png";
+  var default_image_url        = "http://cartodb.s3.amazonaws.com/static/overlay_placeholder.png";
+
+  describe("Image", function() {
+
+    beforeEach(function() {
+
+      var defaultOptions = {
+        has_default_image: true,
+        url: default_image_url,
+        rendered_text: "<img src='" + default_image_url + "' />",
+        default_image_url: default_image_url,
+        public_default_image_url: public_default_image_url
+      };
+
+      var defaultStyle = {
+        textAlign: "left",
+        zIndex: 1000,
+        textAlign: "right",
+        "font-size": "13",
+        fontFamilyName: "Helvetica",
+        "box-color": "#F84F40",
+        boxOpacity: 0.7,
+        boxPadding: 10,
+        "line-width": 50
+      };
+
+      var model = new cdb.core.Model({
+        type: "image",
+        display: true,
+        width: 200,
+        height: 200,
+        device: "desktop",
+        x: 0,
+        y: 0,
+        extra: defaultOptions,
+        style: defaultStyle
+    });
+
+    var template = cdb.core.Template.compile('\
+      <div class="content">\
+      <div class="text widget_text">{{{ content }}}</div>\
+      </div>','mustache');
+
+    view = new cdb.geo.ui.Image({ template: template, model: model });
+
+    });
+
+    afterEach(function() {
+      view.clean();
+    });
+
+    it("should render the image", function(done) {
+
+      view.render();
+
+      setTimeout(function() {
+        expect(view.$el.find("img")).toBeDefined();
+        expect(view.$el.find("img").attr("src")).toBe(default_image_url);
+        done();
+      }, 1000);
+
+    });
+  });
+});


### PR DESCRIPTION
Instead of rendering the URL in the template, we explicitly load it and append it to the overlay.