### PR TITLE
Add generated css to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Gemfile.lock
 test/SpecRunner.html
 .rvmrc
 .idea/
+themes/css/cartodb.css


### PR DESCRIPTION
At least when building CartoDB with `grunt` this is a bit of a pain for switching branches and some other git operations.

@javierarce can you please review and merge? thanks!