### PR TITLE
Fix GMaps and IEMobile click event:

### DIFF
--- a/src/geo/gmaps/gmaps_cartodb_layergroup.js
+++ b/src/geo/gmaps/gmaps_cartodb_layergroup.js
@@ -237,7 +237,7 @@ CartoDBLayerGroupBase.prototype._findPos = function (map,o) {
   var obj = map.getDiv();
 
   var x, y;
-  if (o.e.changedTouches && o.e.changedTouches.length > 0) {
+  if (o.e.changedTouches && o.e.changedTouches.length > 0 && (o.e.changedTouches[0] !== undefined) ) {
     x = o.e.changedTouches[0].clientX + window.scrollX;
     y = o.e.changedTouches[0].clientY + window.scrollY;
   } else {
@@ -279,6 +279,8 @@ CartoDBLayerGroupBase.prototype._manageOnEvents = function(map,o) {
     case 'touchend':
     case 'touchmove': // for some reason android browser does not send touchend
     case 'mspointerup':
+    case 'pointerup':
+    case 'pointermove':
       if (this.options.featureClick) {
         this.options.featureClick(o.e,latlng, point, o.data, o.layer);
       }


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/cartodb.js/issues/313

Click event and its infowindows wasn’t being triggered with Internet Explore
Mobile and GMaps.
 It was working with Leaflet maps, and the reason was that in
leaflet_cartodb_leaflet.js file it has the ‘case:’ like in this commit.

Also, I've added a condition in the other *if* because it was returning some errors when I was debugging with MS Visual Studio. It's protecting if the properties clientX and clientY aren't defined in o.e.changedTouches[0]