### PR TITLE
Allows to force the https protocol via param

### DIFF
--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -164,20 +164,13 @@
 
     _setupTilerConfiguration: function(protocol, domain, port) {
 
-      var vizjson = this.imageOptions.vizjson;
-
       this.options.tiler_domain   = domain;
       this.options.tiler_protocol = protocol;
       this.options.tiler_port     = port;
 
-      if (vizjson.indexOf("http") === 0) {
-        var isHTTPS = vizjson.indexOf("https") !== -1 ? true : false;
-
-        if (isHTTPS) {
-          this.options.tiler_protocol = "https";
-          this.options.tiler_port     = 443;
-        }
-
+      if (this.userOptions.https || this.imageOptions.vizjson.indexOf("https") === 0) {
+        this.options.tiler_protocol = "https";
+        this.options.tiler_port     = 443;
       }
 
     },

--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -166,16 +166,18 @@
 
       var vizjson = this.imageOptions.vizjson;
 
-      var isHTTPS = vizjson.indexOf("https") !== -1 ? true : false;
-
       this.options.tiler_domain   = domain;
+      this.options.tiler_protocol = protocol;
+      this.options.tiler_port     = port;
 
-      if (isHTTPS) {
-        this.options.tiler_protocol = "https";
-        this.options.tiler_port     = 443;
-      } else {
-        this.options.tiler_protocol = protocol;
-        this.options.tiler_port     = port;
+      if (vizjson.indexOf("http") === 0) {
+        var isHTTPS = vizjson.indexOf("https") !== -1 ? true : false;
+
+        if (isHTTPS) {
+          this.options.tiler_protocol = "https";
+          this.options.tiler_port     = 443;
+        }
+
       }
 
     },

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -196,7 +196,7 @@ describe("Image", function() {
 
   });
 
-  it("should set the protocol and port depending on the URL", function(done) {
+  it("should set the protocol and port depending on the URL (https)", function(done) {
 
     var vizjson = "https://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"
 
@@ -209,11 +209,15 @@ describe("Image", function() {
       done();
     });
 
-    vizjson = "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"
+  });
 
-    image = cartodb.Image(vizjson).size(400, 300);
+  it("should set the protocol and port depending on the URL (http)", function(done) {
 
-    regexp = new RegExp("http://documentation\.cartodb\.com:80/api/v1/map/static/bbox/(.*?)/-155\.7421875,-31\.05293398570514,261\.2109375,82\.58610635020881/400/300\.png");
+    var vizjson = "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"
+
+    var image = cartodb.Image(vizjson).size(400, 300);
+
+    var regexp = new RegExp("http://documentation\.cartodb\.com:80/api/v1/map/static/bbox/(.*?)/-155\.7421875,-31\.05293398570514,261\.2109375,82\.58610635020881/400/300\.png");
 
     image.getUrl(function(err, url) {
       expect(url).toMatch(regexp);

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -205,12 +205,36 @@ describe("Image", function() {
     var regexp = new RegExp("https://documentation\.cartodb\.com:443/api/v1/map/static/bbox/(.*?)/-155\.7421875,-31\.05293398570514,261\.2109375,82\.58610635020881/400/300\.png");
 
     image.getUrl(function(err, url) {
-      console.log(url);
+      expect(url).toMatch(regexp);
+      done();
+    });
+
+    vizjson = "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"
+
+    image = cartodb.Image(vizjson).size(400, 300);
+
+    regexp = new RegExp("http://documentation\.cartodb\.com:80/api/v1/map/static/bbox/(.*?)/-155\.7421875,-31\.05293398570514,261\.2109375,82\.58610635020881/400/300\.png");
+
+    image.getUrl(function(err, url) {
       expect(url).toMatch(regexp);
       done();
     });
 
   });
 
+  it("should set force the https protocol", function(done) {
+
+    var vizjson = "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"
+
+    var image = cartodb.Image(vizjson, { https: true }).size(400, 300);
+
+    var regexp = new RegExp("https://documentation\.cartodb\.com:443/api/v1/map/static/bbox/(.*?)/-155\.7421875,-31\.05293398570514,261\.2109375,82\.58610635020881/400/300\.png");
+
+    image.getUrl(function(err, url) {
+      expect(url).toMatch(regexp);
+      done();
+    });
+
+  });
 
 });


### PR DESCRIPTION
We now support to force the `https` protocol via param: 

```var image = cartodb.Image(vizjson, { https: true }).size(400, 300);```

@javisantana or @CartoDB/frontend: can you review it, please?