### PR TITLE
Fixes generating a static map with a plain layer 

### DIFF
--- a/examples/images/basemap.html
+++ b/examples/images/basemap.html
@@ -27,7 +27,6 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.11/themes/css/cartodb.css" />
     <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
     <script>
       var basemap = {

--- a/examples/images/core.html
+++ b/examples/images/core.html
@@ -30,7 +30,6 @@
     <script src="http://www.google.com/jsapi"></script>
     <script>google.load("jquery", "1.7.1");</script>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.11/themes/css/cartodb.css" />
     <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.core.js"></script>
     <script>
 

--- a/examples/images/format.html
+++ b/examples/images/format.html
@@ -27,7 +27,6 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.11/themes/css/cartodb.css" />
     <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
   </head>
   <body>

--- a/examples/images/image.html
+++ b/examples/images/image.html
@@ -27,7 +27,6 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.11/themes/css/cartodb.css" />
     <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
     <script>
 

--- a/examples/images/layer_definition.html
+++ b/examples/images/layer_definition.html
@@ -28,7 +28,6 @@
       .map img { display: none; }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.11/themes/css/cartodb.css" />
     <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
     <script>
 

--- a/examples/images/plain-color.html
+++ b/examples/images/plain-color.html
@@ -28,13 +28,12 @@
       .map img { display: none; }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.11/themes/css/cartodb.css" />
     <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
     <script>
 
       var layer_definition = {
-        user_name: "arcerui",
-        tiler_domain: "cartodb-staging.com",
+        user_name: "documentation",
+        tiler_domain: "cartodb.com",
         tiler_port: "80",
         tiler_protocol: "http",
         layers: [{
@@ -45,8 +44,8 @@
         }, {
           type: "cartodb",
           options: {
-            sql: "SELECT * FROM spotimap_cities",
-            cartocss: "#spotimap_cities{ marker-fill-opacity: 0.9; marker-line-color: #FFF; marker-line-width: 1.5; marker-line-opacity: 1; marker-placement: point; marker-type: ellipse; marker-width: 10; marker-fill: #FF6600; marker-allow-overlap: true; } ",
+            sql: "SELECT * FROM spreading_network",
+            cartocss: "#spreading_network{ marker-fill-opacity: 0.9; marker-line-color: #FFF; marker-line-width: 1.5; marker-line-opacity: 1; marker-placement: point; marker-type: ellipse; marker-width: 10; marker-fill: #FF6600; marker-allow-overlap: true; } ",
             cartocss_version: "2.1.1"
           }
         }

--- a/examples/images/torque.html
+++ b/examples/images/torque.html
@@ -28,7 +28,6 @@
       .map img { display: none; }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.11/themes/css/cartodb.css" />
     <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
     <script>
       var layer_definition = {

--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -240,9 +240,9 @@
 
       if (basemap) {
 
-        var type = basemap.type.toLowerCase();
+        var type = basemap.options.type.toLowerCase();
 
-        if (type === "plain") return this._getPlainBasemapLayer(basemap.color);
+        if (type === "plain") return this._getPlainBasemapLayer(basemap.options.color);
         else                  return this._getHTTPBasemapLayer(basemap);
 
       }

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -68,6 +68,8 @@
   
   <script src="../src/core/decorator.js"></script>
   
+  <script src="../src/core/loader.js"></script>
+  
   <script src="../src/core/log.js"></script>
   
   <script src="../src/core/model.js"></script>
@@ -77,8 +79,6 @@
   <script src="../src/core/template.js"></script>
   
   <script src="../src/core/view.js"></script>
-
-  <script src="../src/core/loader.js"></script>
   
   <script src="../src/geo/geometry.js"></script>
   
@@ -173,7 +173,7 @@
   <script src="../src/ui/common/dropdown.js"></script>
   
   <script src="../src/vis/vis.js"></script>
-
+  
   <script src="../src/vis/image.js"></script>
   
   <script src="../src/vis/layers.js"></script>

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -196,6 +196,37 @@ describe("Image", function() {
 
   });
 
+  it("should generate an image using a layer definition for a plain color", function(done) {
+
+    var layer_definition = {
+      user_name: "documentation",
+      tiler_domain: "cartodb.com",
+      tiler_port: "80",
+      tiler_protocol: "http",
+      layers: [{
+        type: "plain",
+        options: {
+          color: "lightblue"
+        }
+      }, {
+        type: "cartodb",
+        options: {
+          sql: "SELECT * FROM nyc_wifi",
+          cartocss: "#ncy_wifi{ marker-fill-opacity: 0.8; marker-line-color: #FFFFFF; marker-line-width: 3; marker-line-opacity: .8; marker-placement: point; marker-type: ellipse; marker-width: 16; marker-fill: #6ac41c; marker-allow-overlap: true; }",
+          cartocss_version: "2.1.1"
+        }
+      }]
+    };
+
+    var regexp = new RegExp("http://documentation\.cartodb\.com:80/api/v1/map/static/center/(.*?)/2/0/0/250/250\.png");
+
+    cartodb.Image(layer_definition).size(250, 250).zoom(2).getUrl(function(error, url) {
+      expect(url).toMatch(regexp);
+      done();
+    });
+
+  });
+
   it("should set the protocol and port depending on the URL (https)", function(done) {
 
     var vizjson = "https://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"


### PR DESCRIPTION
We weren't getting the correct type from the basemap, and as a result the "plain static maps" (as in a map with one plain color as the basemap) weren't getting generated.

Could you please review it, @javisantana, @CartoDB/frontend?

