### PR TITLE
Makes sure values named zero are not legended as NULL

### DIFF
--- a/src/geo/ui/legend.js
+++ b/src/geo/ui/legend.js
@@ -42,7 +42,7 @@ cdb.geo.ui.LegendItem = cdb.core.View.extend({
   render: function() {
 
     var value;
-
+    this.model.attributes.name = ""+this.model.attributes.name;
     if (this.model.get("type") == 'image' && this.model.get("value")) {
       value = "url( " + this.model.get("value") + ")";
     } else {

--- a/test/spec/geo/legend.spec.js
+++ b/test/spec/geo/legend.spec.js
@@ -463,6 +463,19 @@ describe("common.geo.ui.Legend", function() {
         expect(legend.$el.find(".legend-title").text().trim()).toEqual("New title");
       });
 
+      it("shouldn't evaluate name 0 to null", function() {
+        custom_data = [
+          { name: 0,  value: "#58A062" },
+          { name: 2,  value: "#54BFDE" },
+          { name: 3,  value: "#9BC562" },
+          { name: 4,  value: "#FABB5C" }
+        ];
+        properties = { title: "Category title", data: custom_data };
+        legend     = new cdb.geo.ui.Legend.Category( properties );
+        legend.render();
+        expect(legend.$el.find("li:first-child").text().trim()).toEqual("" + custom_data[0].name);
+      });
+
     });
 
     describe("Bubble Legend", function() {


### PR DESCRIPTION
Ref. CartoDB/cartodb#1944

Basically the template checks for falsy values for name when making the legends' html. As 0 is a falsy value (```0 == false``` is true, god bless javascript ;) ), is was adding its label as ```NULL```. This makes sure that non-string values (in this case, numbers) are turned into strings before passing them to the template (```"0" == false``` is false).

![screen shot 2015-02-16 at 17 46 59](https://cloud.githubusercontent.com/assets/3707222/6215823/5bcb1a82-b604-11e4-9ec2-6cccefc8038c.png)


@xavijam CR please? :) 
cc @ohasselblad