### PR TITLE
Fixes error generating a map preview for torque layers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+3.12.2 ()
+- Fixes error generating a map preview of a visualization with a torque layer.
+
 3.12.1 (13//02/2015)
 - Allows to force the https protocol when requesting a vizjson to generate a static image
 

--- a/examples/images/torque.html
+++ b/examples/images/torque.html
@@ -30,38 +30,8 @@
 
     <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
     <script>
-      var layer_definition = {
-        user_name: "rochoa-st",
-        tiler_domain: "cartodb-staging.com",
-        tiler_port: "80",
-        tiler_protocol: "http",
-        version: "1.3.0-alpha",
-        layers: [
-          {
-          "type": "http",
-          "options": {
-            "urlTemplate": "http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png",
-            "subdomains": [
-              "a",
-              "b",
-              "c"
-            ]
-          }
-        },
-        {
-          "type": "torque",
-          "options": {
-            "sql": "select *, (CASE WHEN \"road_type\" = '6' THEN 1 WHEN \"road_type\" = '3' THEN 2 WHEN \"road_type\" = '1' THEN 3 WHEN \"road_type\" = '2' THEN 4 WHEN \"road_type\" = '7' THEN 5 WHEN \"road_type\" = '9' THEN 6 ELSE 7 END) as torque_category FROM (SELECT to_timestamp(date || ' ' || time, 'DD/MM/YYYY HH24:MI') date_time, * FROM dftroadsafety_accidents_3) _cdb_wrap",
-            "cartocss": "Map { -torque-frame-count:512; -torque-animation-duration:30; -torque-time-attribute:\"date_time\"; -torque-aggregation-function:\"CDB_Math_Mode(torque_category)\"; -torque-resolution:1; -torque-data-aggregation:linear; }  #dftroadsafety_accidents_3{   comp-op: multiply;   marker-fill-opacity: 0.9;   marker-line-color: #FFF;   marker-line-width: 0;   marker-line-opacity: 1;   marker-type: ellipse;   marker-width: 3;   marker-fill: #FF9900; } #dftroadsafety_accidents_3[frame-offset=1] {  marker-width:5;  marker-fill-opacity:0.45;  } #dftroadsafety_accidents_3[frame-offset=2] {  marker-width:7;  marker-fill-opacity:0.225;  } #dftroadsafety_accidents_3[value=1] {    marker-fill: #A6CEE3; } #dftroadsafety_accidents_3[value=2] {    marker-fill: #1F78B4; } #dftroadsafety_accidents_3[value=3] {    marker-fill: #B2DF8A; } #dftroadsafety_accidents_3[value=4] {    marker-fill: #33A02C; } #dftroadsafety_accidents_3[value=5] {    marker-fill: #FB9A99; } #dftroadsafety_accidents_3[value=6] {    marker-fill: #E31A1C; }",
-            "cartocss_version": "1.0.0",
-            "step": 128
-          }
-        }
-        ]
-      };
 
-      // and now we just ask for the URL and append it to the page
-      cartodb.Image("http://arce.cartodb.com/api/v2/viz/c8cdb78e-ad3f-11e4-a472-0e018d66dc29/viz.json").size(500, 500).getUrl(function(error, url) {
+      cartodb.Image("http://documentation.cartodb.com/api/v2/viz/3ec995a8-b6ae-11e4-849e-0e4fddd5de28/viz.json").size(500, 500).getUrl(function(error, url) {
 
         var img = new Image();
 

--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -150,14 +150,27 @@
           this.imageOptions.basemap = baseLayer;
         }
 
-        if (dataLayer.type === "torque") {
-          this.options.layers = this._getTorqueLayerDefinition(dataLayer);
-        } else if (dataLayer.type === "namedmap") {
-          this.options.layers = this._getNamedmapLayerDefinition(dataLayer.options);
-        } else {
-          this.options.layers = this._getLayergroupLayerDefinition(dataLayer.options);
+        var layers = [ this._getDefaultBasemapLayer() ];
+
+        for (var i = 1; i < data.layers.length; i++) {
+
+          var layer = data.layers[i];
+
+          if (layer.type === "torque") {
+            layers.push(this._getTorqueLayerDefinition(layer));
+          } else if (layer.type === "namedmap") {
+            layers.push(this._getNamedmapLayerDefinition(layer));
+          } else {
+            var ll = this._getLayergroupLayerDefinition(layer);
+
+            for (var j = 0; j < ll.length; j++) {
+              layers.push(ll[j]);
+            }
+
+          }
         }
 
+        this.options.layers = { layers: layers };
         this._requestLayerGroupID();
 
       }
@@ -257,7 +270,7 @@
 
       var layerDefinition = new LayerDefinition(layer_definition, layer_definition.options);
 
-      var torqueLayer = {
+      return {
         type: "torque",
         options: {
           sql: layerDefinition.options.query,
@@ -265,47 +278,30 @@
         }
       };
 
-      var layers  =  [ this._getBasemapLayer(), torqueLayer ];
-
-      var ld = {
-        stat_tag: layer_definition.options.stat_tag,
-        layers: layers
-      };
-
-      return ld;
-
     },
 
-    _getLayergroupLayerDefinition: function(options) {
+    _getLayergroupLayerDefinition: function(layer) {
 
+      var options = layer.options;
       var layerDefinition = new LayerDefinition(options.layer_definition, options);
-      var ld = layerDefinition.toJSON();
 
-      ld.layers.unshift(this._getBasemapLayer());
-
-      return ld;
+      return layerDefinition.toJSON().layers;
 
     },
 
-    _getNamedmapLayerDefinition: function(options) {
+    _getNamedmapLayerDefinition: function(layer) {
+
+      var options = layer.options;
 
       var layerDefinition = new NamedMap(options.named_map, options);
 
-      layerDefinition.options.type = "named";
+      //layerDefinition.options.type = "named";
 
-      var layers  =  [
-        this._getBasemapLayer(), {
-        type: "named",
+      return { type: "named",
         options: {
           name: layerDefinition.named_map.name
         }
-      }];
-
-      var ld = {
-        layers: layers
-      };
-
-      return ld;
+      }
 
     },
 

--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -253,10 +253,18 @@
 
       if (basemap) {
 
-        var type = basemap.options.type.toLowerCase();
+        // TODO: refactor this
+        var type = basemap.type.toLowerCase();
 
-        if (type === "plain") return this._getPlainBasemapLayer(basemap.options.color);
-        else                  return this._getHTTPBasemapLayer(basemap);
+        if (basemap.options && basemap.options.type) {
+          type = basemap.options.type.toLowerCase();
+        }
+
+        if (type === "plain") {
+          return this._getPlainBasemapLayer(basemap.options.color);
+        } else {
+          return this._getHTTPBasemapLayer(basemap);
+        }
 
       }
 

--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -150,7 +150,9 @@
           this.imageOptions.basemap = baseLayer;
         }
 
-        if (dataLayer.type === "namedmap") {
+        if (dataLayer.type === "torque") {
+          this.options.layers = this._getTorqueLayerDefinition(dataLayer);
+        } else if (dataLayer.type === "namedmap") {
           this.options.layers = this._getNamedmapLayerDefinition(dataLayer.options);
         } else {
           this.options.layers = this._getLayergroupLayerDefinition(dataLayer.options);
@@ -248,6 +250,29 @@
       }
 
       return this._getDefaultBasemapLayer();
+
+    },
+
+    _getTorqueLayerDefinition: function(layer_definition) {
+
+      var layerDefinition = new LayerDefinition(layer_definition, layer_definition.options);
+
+      var torqueLayer = {
+        type: "torque",
+        options: {
+          sql: layerDefinition.options.query,
+          cartocss: layer_definition.options.tile_style
+        }
+      };
+
+      var layers  =  [ this._getBasemapLayer(), torqueLayer ];
+
+      var ld = {
+        stat_tag: layer_definition.options.stat_tag,
+        layers: layers
+      };
+
+      return ld;
 
     },
 

--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -150,7 +150,7 @@
           this.imageOptions.basemap = baseLayer;
         }
 
-        var layers = [ this._getDefaultBasemapLayer() ];
+        var layers = [ this._getBasemapLayer() ];
 
         for (var i = 1; i < data.layers.length; i++) {
 
@@ -162,11 +162,9 @@
             layers.push(this._getNamedmapLayerDefinition(layer));
           } else {
             var ll = this._getLayergroupLayerDefinition(layer);
-
             for (var j = 0; j < ll.length; j++) {
               layers.push(ll[j]);
             }
-
           }
         }
 

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -37,6 +37,21 @@ describe("Image", function() {
 
   });
 
+  it("should generate the URL for a torque layer", function(done) {
+
+    var vizjson = "http://documentation.cartodb.com/api/v2/viz/3ec995a8-b6ae-11e4-849e-0e4fddd5de28/viz.json"
+
+    var image = cartodb.Image(vizjson);
+
+    var regexp = new RegExp("http://documentation\.cartodb\.com:80/api/v1/map/static/bbox/(.*?)/-138\.6474609375,27\.761329874505233,-83\.408203125,51\.26191485308451/320/240\.pn");
+
+    image.getUrl(function(err, url) {
+      expect(url).toMatch(regexp);
+      done();
+    });
+
+  });
+
   it("should allow to set the zoom", function(done) {
 
     var vizjson = "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"


### PR DESCRIPTION
This PR adds:

- A new method (`_getTorqueLayerDefinition`) to generate basemaps of vizjsons with one torque layer.
- A spec for that case.
- Updates the torque example.