### PR TITLE
Properly generates leaflet point for touch events

### DIFF
--- a/src/geo/leaflet/leaflet_cartodb_layergroup.js
+++ b/src/geo/leaflet/leaflet_cartodb_layergroup.js
@@ -287,8 +287,8 @@ L.CartoDBGroupLayerBase = L.TileLayer.extend({
     } else {
       var rect = obj.getBoundingClientRect();
       var p = new L.Point(
-            o.e.clientX - rect.left - obj.clientLeft - window.scrollX,
-            o.e.clientY - rect.top - obj.clientTop - window.scrollY);
+            (o.e.clientX? o.e.clientX: x) - rect.left - obj.clientLeft - window.scrollX,
+            (o.e.clientY? o.e.clientY: y) - rect.top - obj.clientTop - window.scrollY);
       return map.containerPointToLayerPoint(p);
     }
   }


### PR DESCRIPTION
Ref. #333

Coordinates of the return value of ```findPos()``` were ```NaN``` when passing a touch event on a map in fixed position. Using x and y as a fallback when clientX/clientY are undefined solves this.

@xavijam