### PR TITLE
Fixes tiler request when the vizjson contains a named map and a torque layer with a named map

### DIFF
--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -276,11 +276,14 @@
 
       var layerDefinition = new LayerDefinition(layer_definition, layer_definition.options);
 
+      var query    = layerDefinition.options.query || "SELECT * FROM " + layerDefinition.options.table_name;
+      var cartocss = layer_definition.options.tile_style;
+
       return {
         type: "torque",
         options: {
-          sql: layerDefinition.options.query,
-          cartocss: layer_definition.options.tile_style
+          sql: query,
+          cartocss: cartocss
         }
       };
 

--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -150,21 +150,49 @@
           this.imageOptions.basemap = baseLayer;
         }
 
+        /* If the vizjson contains a named map and a torque layer with a named map,
+           ignore the torque layer */
+
+        var ignoreTorqueLayer = false;
+
+        var namedMap = this._getLayerByType(data.layers, "namedmap");
+
+        if (namedMap) {
+
+          var torque = this._getLayerByType(data.layers, "torque");
+
+          if (torque && torque.options && torque.options.named_map) {
+
+            if (torque.options.named_map.name === namedMap.options.named_map.name) {
+              ignoreTorqueLayer = true;
+            }
+
+          }
+
+        }
+
         var layers = [ this._getBasemapLayer() ];
 
         for (var i = 1; i < data.layers.length; i++) {
 
           var layer = data.layers[i];
 
-          if (layer.type === "torque") {
+          if (layer.type === "torque" && !ignoreTorqueLayer) {
+
             layers.push(this._getTorqueLayerDefinition(layer));
+
           } else if (layer.type === "namedmap") {
+
             layers.push(this._getNamedmapLayerDefinition(layer));
-          } else {
+
+          } else if (layer.type !== "torque" && layer.type !== "namedmap") {
+
             var ll = this._getLayergroupLayerDefinition(layer);
+
             for (var j = 0; j < ll.length; j++) {
               layers.push(ll[j]);
             }
+
           }
         }
 
@@ -173,6 +201,10 @@
 
       }
 
+    },
+
+    _getLayerByType: function(layers, type) {
+      return _.find(layers, function(layer) { return layer.type === type; });
     },
 
     _setupTilerConfiguration: function(protocol, domain, port) {

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -46,6 +46,9 @@ describe("Image", function() {
     var regexp = new RegExp("http://documentation\.cartodb\.com:80/api/v1/map/static/bbox/(.*?)/-138\.6474609375,27\.761329874505233,-83\.408203125,51\.26191485308451/320/240\.pn");
 
     image.getUrl(function(err, url) {
+      expect(image.options.layers.layers.length).toEqual(2);
+      expect(image.options.layers.layers[0].type).toEqual("http");
+      expect(image.options.layers.layers[1].type).toEqual("torque");
       expect(url).toMatch(regexp);
       done();
     });

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -52,6 +52,19 @@ describe("Image", function() {
 
   });
 
+  it("should generate the right layer configuration for a torque layer with a named map ", function(done) {
+
+    var vizjson = "https://team.cartodb.com/api/v2/viz/9d99e242-5f9a-11e4-bc5f-0e853d047bba/viz.json";
+
+    var image = cartodb.Image(vizjson);
+
+    image.getUrl(function(err, url) {
+      expect(image.options.layers.layers.length).toEqual(2);
+      done();
+    });
+
+  });
+
   it("should allow to set the zoom", function(done) {
 
     var vizjson = "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -54,12 +54,14 @@ describe("Image", function() {
 
   it("should generate the right layer configuration for a torque layer with a named map ", function(done) {
 
-    var vizjson = "https://team.cartodb.com/api/v2/viz/9d99e242-5f9a-11e4-bc5f-0e853d047bba/viz.json";
+    var vizjson = "http://documentation.cartodb.com/api/v2/viz/e7b04b62-b901-11e4-b0d7-0e018d66dc29/viz.json";
 
     var image = cartodb.Image(vizjson);
 
     image.getUrl(function(err, url) {
       expect(image.options.layers.layers.length).toEqual(2);
+      expect(image.options.layers.layers[0].type).toEqual("http");
+      expect(image.options.layers.layers[1].type).toEqual("named");
       done();
     });
 


### PR DESCRIPTION
We [check](https://github.com/CartoDB/cartodb.js/pull/356/files#diff-e14eff99e7c7b57af717eedd1f3cc9d2R153) if the vizjson contains a named map and torque layer with a named map inside. If that's the case, we don't send the torque layer in the request.