### PR TITLE
Cdb-336_IE10 fails to load infowindow data thats already been viewed

### DIFF
--- a/src/api/sql.js
+++ b/src/api/sql.js
@@ -155,9 +155,15 @@
         xhr = resp;
         resp = JSON.parse(resp.response);
       }
-      promise.trigger('done', resp, status, xhr);
-      if(success) success(resp, status, xhr);
-      if(callback) callback(resp);
+      //Timeout explanation. CartoDB.js ticket #336
+      //From St.Ov.: "what setTimeout does is add a new event to the browser event queue 
+      //and the rendering engine is already in that queue (not entirely true, but close enough) 
+      //so it gets executed before the setTimeout event."
+      setTimeout(function() {
+        promise.trigger('done', resp, status, xhr);
+        if(success) success(resp, status, xhr);
+        if(callback) callback(resp);
+      }, 0);
     }
 
     // call ajax

--- a/test/spec/api/sql.spec.js
+++ b/test/spec/api/sql.spec.js
@@ -156,7 +156,7 @@ describe('SQL api client', function() {
       expect(data).toEqual(TEST_DATA);
       expect(data_callback).toEqual(TEST_DATA);
       done()
-    }, 1);
+    }, 500); //Fix cartodb.js issue #336
   });
   it("should call promise on error", function(done) {
     throwError = true;


### PR DESCRIPTION
The explanation is in this [StackOverflow post](http://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-so
metimes-useful) : 
Recaping: (there's a more large explanation in that post)
> what setTimeout does is add a new event to the browser event queue and the rendering engine is already in that queue (not entirely true, but close enough) so it gets executed before the setTimeout event. . 

Also, it was 'hard' to reproduce. I was using Windows 8.1 and InternetExplorer 11 **emulating IE 10**, but it was working correctly. So, I had to use a virtual machine from [modern.ie](https://www.modern.ie/) with Win8/IE10. There, I could reproduce the problem, but it wasn't happening always. I think that the Internet connection and speed in events are related.

Also, I've modified  the test 'should call promise on error' to allow this fix (adding more time to setTimeout)