### PR TITLE
Wax pr6 updating wax.cartodb.js - IE, gmaps and mobile issues

### DIFF
--- a/src/geo/gmaps/gmaps_cartodb_layergroup.js
+++ b/src/geo/gmaps/gmaps_cartodb_layergroup.js
@@ -237,7 +237,7 @@ CartoDBLayerGroupBase.prototype._findPos = function (map,o) {
   var obj = map.getDiv();
 
   var x, y;
-  if (o.e.changedTouches && o.e.changedTouches.length > 0) {
+  if (o.e.changedTouches && o.e.changedTouches.length > 0 && (o.e.changedTouches[0] !== undefined) ) {
     x = o.e.changedTouches[0].clientX + window.scrollX;
     y = o.e.changedTouches[0].clientY + window.scrollY;
   } else {
@@ -279,6 +279,8 @@ CartoDBLayerGroupBase.prototype._manageOnEvents = function(map,o) {
     case 'touchend':
     case 'touchmove': // for some reason android browser does not send touchend
     case 'mspointerup':
+    case 'pointerup':
+    case 'pointermove':
       if (this.options.featureClick) {
         this.options.featureClick(o.e,latlng, point, o.data, o.layer);
       }


### PR DESCRIPTION
Updating wax.cartodb.js
This commit fixes the following issues:
- #346 : Dragging the map triggers the info window
- #313 : Pan/Zoom event don’t work as appropriate on touch-screen
Windows 8
- #223 : Pointer events in IE11 on touch-screen Windows laptops do not
trigger popups
- #139: Layer interaciton in IE10/IE11 not working when dragging a
leaflet marker

*Note:* The [PR 334](https://github.com/CartoDB/cartodb.js/pull/334) is included here because I tested all the fixes together (because of IE 11 mobile case)