### PR TITLE
Don't assume mapType is defined

### DIFF
--- a/vendor/wax.cartodb.js
+++ b/vendor/wax.cartodb.js
@@ -3771,7 +3771,7 @@ wax.g.interaction = function() {
             var zoom = map.getZoom();
             var mapOffset = wax.u.offset(map.getDiv());
             var get = function(mapType) {
-                if (!mapType.interactive) return;
+                if (!mapType || !mapType.interactive) return;
                 for (var key in mapType.cache) {
                     if (key.split('/')[0] != zoom) continue;
                     var tileOffset = wax.u.offset(mapType.cache[key]);


### PR DESCRIPTION
When using Google Map's `map.overlayMapTypes.setAt(index, mapType)`, the in betweens are set to `undefined`, which causes an error.