### PR TITLE
Allows to override the bbox

### DIFF
--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -366,7 +366,7 @@
 
       var url = this._host() + this.endPoint;
 
-      if (bbox && bbox.length) {
+      if (bbox && bbox.length && !this.userOptions.override_bbox) {
         return [url, "static/bbox" , layergroupid, bbox.join(","), width, height + "." + format].join("/");
       } else {
         return [url, "static/center" , layergroupid, zoom, lat, lon, width, height + "." + format].join("/");

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -110,6 +110,20 @@ describe("Image", function() {
 
   });
 
+  it("should allow to override the bounding box", function(done) {
+
+    var vizjson = "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"
+
+    var regexp = new RegExp("http://api.cartocdn.com/documentation/api/v1/map/static/center/(.*?)/52\.5897007687178/52\.734375/400/300\.png");
+
+    cartodb.Image(vizjson, { override_bbox: true }).size(400,300).getUrl(function(error, url) {
+      expect(error).toEqual(null);
+      expect(url).toMatch(regexp);
+      done();
+    });
+
+  });
+
   it("shouldn't generate a bbox URL without a bouding box", function(done) {
 
     var vizjson = "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"


### PR DESCRIPTION
This PR adds a new user option (`override_bbox`) that allows to override the default use of the bounding box to generate the image, using the center instead.

Plus: [wiki updated](https://github.com/CartoDB/cartodb.js/wiki/CartoDB-Map-API#override_bbox).

@CartoDB/frontend / @javisantana: review this, please :)