### PR TITLE
Extract the CDN host configuration from the vizjson

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 3.12.8 ()
 - Allows to override the default use of the bounding box to generate an image, using the center instead.
+- Extracts the CDN host configuration from the vizjson.
 
 3.12.7 (23//02//2015)
 - By default we now serve the Static API images through CartoDB's CDN.

--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -128,7 +128,10 @@
         var baseLayer = data.layers[0];
         var dataLayer = data.layers[1];
 
-        this.options.user_name = dataLayer.options.user_name;
+        if (dataLayer.options) {
+          this.options.user_name = dataLayer.options.user_name;
+          this.cdn_url = dataLayer.options.cdn_url;
+        }
 
         this._setupTilerConfiguration(dataLayer.options.tiler_protocol, dataLayer.options.tiler_domain, dataLayer.options.tiler_port);
 

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -70,6 +70,20 @@ describe("Image", function() {
 
   });
 
+  it("should extract the cdn_url from the vizjson", function(done) {
+
+    var vizjson = "http://documentation.cartodb.com/api/v2/viz/e7b04b62-b901-11e4-b0d7-0e018d66dc29/viz.json";
+
+    var image = cartodb.Image(vizjson);
+
+    image.getUrl(function(err, url) {
+      expect(image.options.cdn_url.http).toEqual("api.cartocdn.com");
+      expect(image.options.cdn_url.https).toEqual("cartocdn.global.ssl.fastly.net");
+      done();
+    });
+
+  });
+
   it("should allow to set the zoom", function(done) {
 
     var vizjson = "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"


### PR DESCRIPTION
Right now we are using the default one, which works in production, but we need to use the one specified in the the vizjson so it works locally and in staging.