### PR TITLE
Don't use the hidden layers to generate images

### DIFF
--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -326,6 +326,9 @@
     _getLayergroupLayerDefinition: function(layer) {
 
       var options = layer.options;
+
+      options.layer_definition.layers = this._getVisibleLayers(options.layer_definition.layers);
+
       var layerDefinition = new LayerDefinition(options.layer_definition, options);
 
       return layerDefinition.toJSON().layers;
@@ -338,14 +341,16 @@
 
       var layerDefinition = new NamedMap(options.named_map, options);
 
-      //layerDefinition.options.type = "named";
-
       return { type: "named",
         options: {
           name: layerDefinition.named_map.name
         }
       }
 
+    },
+
+    _getVisibleLayers: function(layers) {
+      return _.filter(layers, function(layer) { return layer.visible; });
     },
 
     _getUrl: function() {

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -72,8 +72,7 @@ describe("Image", function() {
 
   it("shouldn't use hidden layers to generate the image", function(done) { 
 
-    // TODO: replace vizjson with one from the docs / local
-    var vizjson = "https://team.cartodb.com/api/v2/viz/205862b2-1e55-11e4-a972-0e73339ffa50/viz.json";
+    var vizjson = "http://documentation.cartodb.com/api/v2/viz/42e98b9a-bcce-11e4-9d68-0e9d821ea90d/viz.json";
 
     var image = cartodb.Image(vizjson);
 

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -70,6 +70,20 @@ describe("Image", function() {
 
   });
 
+  it("shouldn't use hidden layers to generate the image", function(done) { 
+
+    // TODO: replace vizjson with one from the docs / local
+    var vizjson = "https://team.cartodb.com/api/v2/viz/205862b2-1e55-11e4-a972-0e73339ffa50/viz.json";
+
+    var image = cartodb.Image(vizjson);
+
+    image.getUrl(function(err, url) {
+      expect(image.options.layers.layers.length).toEqual(2);
+      done();
+    });
+
+  });
+
   it("should allow to set the zoom", function(done) {
 
     var vizjson = "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"


### PR DESCRIPTION
This PR fixes a problem where images were being generated using all the layers. We now only use the visible ones.