### PR TITLE
Disables the CDN if the server doesn't send us the configuration

### DIFF
--- a/src/geo/layer_definition.js
+++ b/src/geo/layer_definition.js
@@ -598,18 +598,26 @@ Map.prototype = {
   },
 
   _host: function(subhost) {
+
     var opts = this.options;
-    if (opts.no_cdn) {
+    var has_empty_cdn = opts.cdn_url && (!opts.cdn_url.http && !opts.cdn_url.https);
+
+    if (opts.no_cdn || has_empty_cdn) {
       return this._tilerHost();
     } else {
+
       var h = opts.tiler_protocol + "://";
+
       if (subhost) {
         h += subhost + ".";
       }
+
       var cdn_host = opts.cdn_url || cdb.CDB_HOST;
-      if(!cdn_host.http && !cdn_host.https) {
+
+      if (!cdn_host.http && !cdn_host.https) {
         throw new Error("cdn_host should contain http and/or https entries");
       }
+
       h += cdn_host[opts.tiler_protocol] + "/" + opts.user_name;
       return h;
     }

--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -251,7 +251,12 @@
 
         if (data) {
           self.imageOptions.layergroupid = data.layergroupid;
-          self.cdn_url = data.cdn_url;
+
+          if (!data.cdn_url || (!data.cdn_url.http && !data.cdn_url.https)) {
+            self.no_cdn = true;
+          } else {
+            self.cdn_url = data.cdn_url;
+          }
         }
 
         self.queue.flush(this);

--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -251,12 +251,7 @@
 
         if (data) {
           self.imageOptions.layergroupid = data.layergroupid;
-
-          if (!data.cdn_url || (!data.cdn_url.http && !data.cdn_url.https)) {
-            self.no_cdn = true;
-          } else {
-            self.cdn_url = data.cdn_url;
-          }
+          self.cdn_url = data.cdn_url;
         }
 
         self.queue.flush(this);

--- a/test/spec/geo/layer_definition.spec.js
+++ b/test/spec/geo/layer_definition.spec.js
@@ -174,6 +174,17 @@
     expect(layerDefinition._host('a')).toEqual('https://a.cartocdn.global.ssl.fastly.net/rambo');
   });
 
+  it("should use the tiler url when there's explicitly empty cdn defined", function() {
+    layerDefinition.options.cdn_url = {
+      http: "", https: ""
+    };
+    expect(layerDefinition._host()).toEqual('http://rambo.cartodb.com:8081');
+    expect(layerDefinition._host('0')).toEqual('http://rambo.cartodb.com:8081');
+    layerDefinition.options.tiler_protocol = "https";
+    expect(layerDefinition._host()).toEqual('https://rambo.cartodb.com:8081');
+    expect(layerDefinition._host('a')).toEqual('https://rambo.cartodb.com:8081');
+  });
+
   it("should use cdn_url from tiler when present", function(done) {
     var params;
     delete layerDefinition.options.no_cdn;


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb-onpremise/issues/180

In some cases, the server could send an empty CDN config:

![screen shot 2015-02-27 at 11 27 46](https://cloud.githubusercontent.com/assets/4933/6411519/a5ddd510-be79-11e4-923d-bdc310fc181a.png)

In this case, we should set the `no_cdn` flag to `false`, to avoid an [error in layer_definition.js](https://github.com/CartoDB/cartodb.js/blob/develop/src/geo/layer_definition.js#L611)