### PR TITLE
Stop adding a new image in infowindow-with-image-header template [do not merge]

### DIFF
--- a/src/geo/ui/infowindow.js
+++ b/src/geo/ui/infowindow.js
@@ -553,16 +553,14 @@ cdb.geo.ui.Infowindow = cdb.core.View.extend({
    *  Attempts to load the cover URL and show it
    */
   _loadCover: function() {
-
     if (!this._containsCover()) return;
 
-    var
-    self = this,
-    $cover = this.$(".cover"),
-    $shadow = this.$(".shadow"),
-    url = this._getCoverURL();
+    var $cover = this.$(".cover");
+    var $shadow = this.$(".shadow");
+    var $img = $cover.find("img");
+    var url = $img.attr('src');
 
-    if (!this._isValidURL(url)) {
+    if (!this._isValidURL(url) || $img.length === 0) {
       $shadow.hide();
       cdb.log.info("Header image url not valid");
       return;
@@ -573,16 +571,6 @@ cdb.geo.ui.Infowindow = cdb.core.View.extend({
     target  = document.getElementById('spinner'),
     opts    = { lines: 9, length: 4, width: 2, radius: 4, corners: 1, rotate: 0, color: '#ccc', speed: 1, trail: 60, shadow: true, hwaccel: false, zIndex: 2e9 },
     spinner = new Spinner(opts).spin(target);
-
-    // create the image
-    var $img = $cover.find("img");
-
-    $img.hide(function() {
-      this.remove();
-    });
-
-    $img = $("<img />").attr("src", url);
-    $cover.append($img);
 
     $img.load(function(){
       spinner.stop();

--- a/test/spec/geo/infowindow.spec.js
+++ b/test/spec/geo/infowindow.spec.js
@@ -439,4 +439,6 @@ describe("cdb.geo.ui.infowindow", function() {
       model.set("content", { fields: fields });
       model.set('template', '<div class="cover"><img src="http://hello.png" /></div>');
       expect(view.$(".cover img").attr('style')).toBe(undefined);
-   
+    });
+  });
+});

--- a/test/spec/geo/infowindow.spec.js
+++ b/test/spec/geo/infowindow.spec.js
@@ -435,7 +435,7 @@ describe("cdb.geo.ui.infowindow", function() {
       expect(view.$(".cover img").attr('style')).toBe(undefined);
     });
 
-    it("if the theme doesn't have cover don't edit the image", function() {
+    it("if the theme doesn't have a cover don't style the image", function() {
       model.set("content", { fields: fields });
       model.set('template', '<div class="cover"><img src="http://hello.png" /></div>');
       expect(view.$(".cover img").attr('style')).toBe(undefined);

--- a/test/spec/geo/infowindow.spec.js
+++ b/test/spec/geo/infowindow.spec.js
@@ -425,23 +425,18 @@ describe("cdb.geo.ui.infowindow", function() {
       expect(view._containsCover()).toEqual(true);
     });
 
-    it("should append the image", function() {
+    it("should not append an image anymore", function() {
       model.set('template', '<div class="cartodb-popup header" data-cover="true"><div class="cover"></div></div>');
-      expect(view.$el.find("img").length).toEqual(1);
+      expect(view.$(".cover img").length).toEqual(0);
     });
 
-    it("if the image is invalid it shouldn't append it", function() {
-      model.set("content", { fields: fieldsWithoutURL });
-      model.set('template', '<div class="cartodb-popup header" data-cover="true"><div class="cover"></div></div>');
-      expect(view.$el.find("img").length).toEqual(0);
+    it("should not edit <img> if it is not valid", function() {
+      model.set('template', '<div class="cartodb-popup header" data-cover="true"><div class="cover"><img src="hello"/></div></div>');
+      expect(view.$(".cover img").attr('style')).toBe(undefined);
     });
 
-    it("if the theme doesn't have cover don't append the image", function() {
+    it("if the theme doesn't have cover don't edit the image", function() {
       model.set("content", { fields: fields });
-      model.set('template', '<div class="cover"></div>');
-      expect(view.$el.find("img").length).toEqual(0);
-    });
-
-  });
-
-});
+      model.set('template', '<div class="cover"><img src="http://hello.png" /></div>');
+      expect(view.$(".cover img").attr('style')).toBe(undefined);
+   


### PR DESCRIPTION
We have found several problems here:

- We shouldn't get first field value as url. Value should be the one that appears as src in the image tag.
- We have to stop adding magically a new <img> element within the infowindow element, it causes problems with custom templates.

cc @javisantana @javierarce 