### PR TITLE
Removes default CDN host

### DIFF
--- a/src/geo/layer_definition.js
+++ b/src/geo/layer_definition.js
@@ -600,7 +600,8 @@ Map.prototype = {
   _host: function(subhost) {
 
     var opts = this.options;
-    var has_empty_cdn = opts.cdn_url && (!opts.cdn_url.http && !opts.cdn_url.https);
+    var cdn_host = opts.cdn_url;
+    var has_empty_cdn = !cdn_host || (cdn_host && (!cdn_host.http && !cdn_host.https));
 
     if (opts.no_cdn || has_empty_cdn) {
       return this._tilerHost();
@@ -610,12 +611,6 @@ Map.prototype = {
 
       if (subhost) {
         h += subhost + ".";
-      }
-
-      var cdn_host = opts.cdn_url || cdb.CDB_HOST;
-
-      if (!cdn_host.http && !cdn_host.https) {
-        throw new Error("cdn_host should contain http and/or https entries");
       }
 
       h += cdn_host[opts.tiler_protocol] + "/" + opts.user_name;

--- a/test/spec/geo/layer_definition.spec.js
+++ b/test/spec/geo/layer_definition.spec.js
@@ -142,12 +142,23 @@
 
   it("should generate url for with cdn", function() {
     layerDefinition.options.no_cdn = false;
+    layerDefinition.options.cdn_url = { http: "api.cartocdn.com" }
     layerDefinition.options.subdomains = ['a', 'b', 'c', 'd'];
     var tiles = layerDefinition._layerGroupTiles('test_layer');
     expect(tiles.tiles[0]).toEqual('http://a.api.cartocdn.com/rambo/api/v1/map/test_layer/{z}/{x}/{y}.png');
     expect(tiles.tiles[1]).toEqual('http://b.api.cartocdn.com/rambo/api/v1/map/test_layer/{z}/{x}/{y}.png');
     expect(tiles.grids[0][0]).toEqual('http://a.api.cartocdn.com/rambo/api/v1/map/test_layer/0/{z}/{x}/{y}.grid.json');
     expect(tiles.grids[0][1]).toEqual('http://b.api.cartocdn.com/rambo/api/v1/map/test_layer/0/{z}/{x}/{y}.grid.json');
+  });
+
+  it("should generate url for without cdn", function() {
+    layerDefinition.options.no_cdn = false;
+    layerDefinition.options.subdomains = ['a', 'b', 'c', 'd'];
+    var tiles = layerDefinition._layerGroupTiles('test_layer');
+    expect(tiles.tiles[0]).toEqual('http://rambo.cartodb.com:8081/api/v1/map/test_layer/{z}/{x}/{y}.png');
+    expect(tiles.tiles[1]).toEqual('http://rambo.cartodb.com:8081/api/v1/map/test_layer/{z}/{x}/{y}.png');
+    expect(tiles.grids[0][0]).toEqual('http://rambo.cartodb.com:8081/api/v1/map/test_layer/0/{z}/{x}/{y}.grid.json');
+    expect(tiles.grids[0][1]).toEqual('http://rambo.cartodb.com:8081/api/v1/map/test_layer/0/{z}/{x}/{y}.grid.json');
   });
 
   it("grid url should not include interactivity", function() {
@@ -165,19 +176,19 @@
     expect(layerDefinition.toJSON().layers[0].options.interactivity).toEqual(['cartodb_id', 'john']);
   });
 
-  it("should use cdn_url as default", function() {
-    delete layerDefinition.options.no_cdn;
-    expect(layerDefinition._host()).toEqual('http://api.cartocdn.com/rambo');
-    expect(layerDefinition._host('0')).toEqual('http://0.api.cartocdn.com/rambo');
-    layerDefinition.options.tiler_protocol = "https";
-    expect(layerDefinition._host()).toEqual('https://cartocdn.global.ssl.fastly.net/rambo');
-    expect(layerDefinition._host('a')).toEqual('https://a.cartocdn.global.ssl.fastly.net/rambo');
-  });
-
   it("should use the tiler url when there's explicitly empty cdn defined", function() {
     layerDefinition.options.cdn_url = {
       http: "", https: ""
     };
+    expect(layerDefinition._host()).toEqual('http://rambo.cartodb.com:8081');
+    expect(layerDefinition._host('0')).toEqual('http://rambo.cartodb.com:8081');
+    layerDefinition.options.tiler_protocol = "https";
+    expect(layerDefinition._host()).toEqual('https://rambo.cartodb.com:8081');
+    expect(layerDefinition._host('a')).toEqual('https://rambo.cartodb.com:8081');
+  });
+
+  it("should use the tiler url when there's explicitly no cdn", function() {
+    layerDefinition.options.cdn_url = undefined;
     expect(layerDefinition._host()).toEqual('http://rambo.cartodb.com:8081');
     expect(layerDefinition._host('0')).toEqual('http://rambo.cartodb.com:8081');
     layerDefinition.options.tiler_protocol = "https";


### PR DESCRIPTION
We'll now trust the tiler and use whatever CDN configuration we get (or nothing, if `cdn_url` is empty).