### PR TITLE
Torque layer with named map must request the named map 

### DIFF
--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -186,11 +186,11 @@
 
           var layer = data.layers[i];
 
-          if (layer.type === "torque" && !ignoreTorqueLayer) {
+          if (layer.type === "torque" && !ignoreTorqueLayer && (layer.options.named_map === undefined)) {
 
             layers.push(this._getTorqueLayerDefinition(layer));
 
-          } else if (layer.type === "namedmap") {
+          } else if (layer.type === "namedmap" || (!namedMap && layer.type === "torque" && layer.options.named_map)) {
 
             layers.push(this._getNamedmapLayerDefinition(layer));
 

--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -186,11 +186,11 @@
 
           var layer = data.layers[i];
 
-          if (layer.type === "torque" && !ignoreTorqueLayer && (layer.options.named_map === undefined)) {
+          if (layer.type === "torque" && !ignoreTorqueLayer) {
 
             layers.push(this._getTorqueLayerDefinition(layer));
 
-          } else if (layer.type === "namedmap" || (!namedMap && layer.type === "torque" && layer.options.named_map)) {
+          } else if (layer.type === "namedmap") {
 
             layers.push(this._getNamedmapLayerDefinition(layer));
 
@@ -327,6 +327,10 @@
     },
 
     _getTorqueLayerDefinition: function(layer_definition) {
+
+      if (layer_definition.options.named_map) { // If the layer contains a named map inside, use it instead
+        return this._getNamedmapLayerDefinition(layer_definition);
+      }
 
       var layerDefinition = new LayerDefinition(layer_definition, layer_definition.options);
 

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -56,9 +56,24 @@ describe("Image", function() {
 
   });
 
-  it("should generate the right layer configuration for a torque layer with a named map ", function(done) {
+  it("should generate the right layer configuration for a torque layer and a named map", function(done) {
 
     var vizjson = "http://documentation.cartodb.com/api/v2/viz/e7b04b62-b901-11e4-b0d7-0e018d66dc29/viz.json";
+
+    var image = cartodb.Image(vizjson);
+
+    image.getUrl(function(err, url) {
+      expect(image.options.layers.layers.length).toEqual(2);
+      expect(image.options.layers.layers[0].type).toEqual("http");
+      expect(image.options.layers.layers[1].type).toEqual("named");
+      done();
+    });
+
+  });
+
+  it("should generate the right layer configuration for a torque layer with a named map inside", function(done) {
+
+    var vizjson = "http://documentation.cartodb.com/api/v2/viz/6b447f26-c80b-11e4-8164-0e018d66dc29/viz.json";
 
     var image = cartodb.Image(vizjson);
 


### PR DESCRIPTION
Please, see the description of the original issue: https://github.com/CartoDB/cartodb.js/issues/397

Basically, in the cases where we have a vizjson of a torque with a named map inside (= a torque that was created with a private table, for example) we need to use the named map to do the request.