### PR TITLE
Fix fullscreen in Safari

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,5 @@
+- Fixes a bug with fullscreen in Safari #361
+
 3.12.12 (12//03//2015)
 - Fixes a bug that prevented generating previews of torque layers with named maps
 

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-- Fixes a bug with fullscreen in Safari #361
+- Fixes a bug with fullscreen in Safari #361 
 
 3.12.12 (12//03//2015)
 - Fixes a bug that prevented generating previews of torque layers with named maps

--- a/src/geo/ui/fullscreen.js
+++ b/src/geo/ui/fullscreen.js
@@ -71,7 +71,10 @@ cdb.ui.common.FullScreen = cdb.core.View.extend({
     if (!doc.fullscreenElement && !doc.mozFullScreenElement && !doc.webkitFullscreenElement && !doc.msFullscreenElement) {
 
       if (docEl.webkitRequestFullScreen) {
-        requestFullScreen.call(docEl, Element.ALLOW_KEYBOARD_INPUT);
+        // Cartodb.js #361 :: Full screen button not working on Safari 8.0.3 #361
+        // Safari has a bug that fullScreen doestn't work with Element.ALLOW_KEYBOARD_INPUT);
+        // Reference: Ehttp://stackoverflow.com/questions/8427413/webkitrequestfullscreen-fails-when-passing-element-allow-keyboard-input-in-safar
+        requestFullScreen.call(docEl, undefined);
       } else {
         requestFullScreen.call(docEl);
       }


### PR DESCRIPTION
Ref. [ticket #361](https://github.com/CartoDB/cartodb.js/issues/361) : **Full screen button not working on Safari 8.0.3**

This seems to be a Safari bug. In the ticket I pointed several references.

And, I've written this patch using [this reference](http://stackoverflow.com/questions/8427413/webkitrequestfull
screen-fails-when-passing-element-allow-keyboard-input-in-safar)  --> **...(/Safari/.test(navigator.userAgent) ? undefined : Element.ALLOW_KEYBOARD_INPUT)**

Because of that, I used *undefined* as parameter.

I tested it with Safari 8.0 (10600.1.25), Chrome (41.0.2272.76) and Firefox (35.0.1) in MacOS, and Chrome (Android-4.4) and it works ok.

Please, @javierarce , could you check it? Thanks!