### PR TITLE
Handle null values in Infowindows and Tooltips

### DIFF
--- a/src/geo/ui/infowindow.js
+++ b/src/geo/ui/infowindow.js
@@ -185,13 +185,13 @@ cdb.geo.ui.InfowindowModel = Backbone.Model.extend({
     options = options || {};
     var render_fields = [];
     for(var j = 0; j < fields.length; ++j) {
-      var f = fields[j];
-      var value = String(attributes[f.name]);
-      if(options.empty_fields || (attributes[f.name] !== undefined && value != "")) {
+      var field = fields[j];
+      var value = attributes[field.name];
+      if(options.empty_fields || (value !== undefined && value !== null)) {
         render_fields.push({
-          title: f.title ? f.name : null,
-          value: attributes[f.name],
-          index: j ? j : null
+          title: field.title ? field.name : null,
+          value: attributes[field.name],
+          index: j
         });
       }
     }
@@ -201,7 +201,7 @@ cdb.geo.ui.InfowindowModel = Backbone.Model.extend({
       render_fields.push({
         title: null,
         value: 'No data available',
-        index: j ? j : null,
+        index: 0,
         type: 'empty'
       });
     }

--- a/test/spec/geo/infowindow.spec.js
+++ b/test/spec/geo/infowindow.spec.js
@@ -218,7 +218,106 @@ describe("cdb.geo.ui.infowindow", function() {
       expect(view.render).not.toHaveBeenCalled();
       expect(view.$el.html()).toEqual('');
     });
+  });
 
+  describe("contentForFields", function() {
+
+    it('should return the title and value of each field', function() {
+      var attributes = { field1: 'value1' };
+      var fields = [{ name: 'field1', title: true }];
+      var content = cdb.geo.ui.InfowindowModel.contentForFields(attributes, fields, {})
+
+      expect(content.fields.length).toEqual(1);
+      expect(content.fields[0].title).toEqual('field1');
+      expect(content.fields[0].value).toEqual('value1');
+    });
+
+    it('should not return the title if not specified', function() {
+      var attributes = { field1: 'value1' };
+      var fields = [{ name: 'field1' }]; // Field doesn't have a title attribute
+      var content = cdb.geo.ui.InfowindowModel.contentForFields(attributes, fields, {})
+
+      expect(content.fields.length).toEqual(1);
+      expect(content.fields[0].title).toEqual(null);
+    });
+
+    it('should return the index of each field', function() {
+      var attributes = { field1: 'value1', field2: 'value2' };
+      var fields = [{ name: 'field1' }, { name: 'field2' }];
+      var content = cdb.geo.ui.InfowindowModel.contentForFields(attributes, fields, {})
+
+      expect(content.fields.length).toEqual(2);
+      expect(content.fields[0].index).toEqual(0);
+      expect(content.fields[1].index).toEqual(1);
+    });
+
+    it('should return empty fields', function() {
+      var attributes = { field1: 'value1' };
+      var fields = [{ name: 'field1' }, { name: 'field2' }];
+      var options = { empty_fields: true };
+      var content = cdb.geo.ui.InfowindowModel.contentForFields(attributes, fields, options)
+
+      expect(content.fields.length).toEqual(2);
+      expect(content.fields[0]).toEqual({
+        title: null,
+        value: 'value1',
+        index: 0
+      });
+      expect(content.fields[1]).toEqual({
+        title: null,
+        value: undefined,
+        index: 1
+      });
+    });
+
+    it('should not return empty fields', function() {
+      var attributes = { field1: 'value1' };
+      var fields = [{ name: 'field1' }, { name: 'field2' }];
+      var options = { empty_fields: false };
+      var content = cdb.geo.ui.InfowindowModel.contentForFields(attributes, fields, options)
+
+      expect(content.fields.length).toEqual(1);
+      expect(content.fields[0]).toEqual({
+        title: null,
+        value: 'value1',
+        index: 0
+      });
+    });
+
+    it('should not return fields with a null value', function() {
+      var attributes = { field1: 'wadus', field2: null };
+      var fields = [{ name: 'field1' }, { name: 'field2' }];
+      var content = cdb.geo.ui.InfowindowModel.contentForFields(attributes, fields, {})
+
+      expect(content.fields.length).toEqual(1);
+      expect(content.fields[0]).toEqual({
+        title: null,
+        value: 'wadus',
+        index: 0
+      });
+    });
+
+    it('should return the attributes as data', function() {
+      var attributes = { field1: 'value1' };
+      var fields = [{ name: 'field1' }];
+      var content = cdb.geo.ui.InfowindowModel.contentForFields(attributes, fields, {})
+
+      expect(content.data).toEqual(attributes);
+    });
+
+    it('should return an empty field when no data is available', function() {
+      var attributes = {};
+      var fields = [{ name: 'field1' }, { name: 'field2' }];
+      var content = cdb.geo.ui.InfowindowModel.contentForFields(attributes, fields, {})
+
+      expect(content.fields.length).toEqual(1);
+      expect(content.fields[0]).toEqual({
+        title: null,
+        value: 'No data available',
+        index: 0,
+        type: 'empty'
+      });
+    });
   });
 
 
@@ -365,7 +464,6 @@ describe("cdb.geo.ui.infowindow", function() {
       expect(view._sanitizeField).not.toHaveBeenCalled();
     });
   });
-
 
   describe("image template", function() {
     var model, view, container, fields, fieldsWithoutURL, url;


### PR DESCRIPTION
This PR fixes cartodb/cartodb#2420.

I have modified `cdb.geo.ui.infowindow.contentForFields`, which is the function that generates the fields that will get rendered in tooltips and infowindows. After these changes, this function will only return empty fields, when `options.empty_fields` is set to true (something that only happens for tooltips in the editor).

I added some tests for it. 

@xavijam @javisantana PTAL

