### PR TITLE
Cdb-412-Fullscreen button is throwing errors

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+
+- Fixes fullscreen button is throwing errors (#412)
+
 3.12.13 (18//03//2015)
 - Changes how infowindows handle null values (#406)
 - Updates the version of wax and upgrades mustache.js to v1.1.0 (403)

--- a/src/geo/ui/fullscreen.js
+++ b/src/geo/ui/fullscreen.js
@@ -76,8 +76,8 @@ cdb.ui.common.FullScreen = cdb.core.View.extend({
         // Reference: Ehttp://stackoverflow.com/questions/8427413/webkitrequestfullscreen-fails-when-passing-element-allow-keyboard-input-in-safar
         requestFullScreen.call(docEl, undefined);
       } else {
-        // CartoDB.js #412 : 
-        // Nowadays (2015/03/25), fullscreen is not supported in iOS Mobile. Reference: http://caniuse.com/#feat=fullscreen
+        // CartoDB.js #412 :: Fullscreen button is throwing errors
+        // Nowadays (2015/03/25), fullscreen is not supported in iOS Safari. Reference: http://caniuse.com/#feat=fullscreen
         if (requestFullScreen !== undefined) {
           requestFullScreen.call(docEl);
         }

--- a/src/geo/ui/fullscreen.js
+++ b/src/geo/ui/fullscreen.js
@@ -76,7 +76,11 @@ cdb.ui.common.FullScreen = cdb.core.View.extend({
         // Reference: Ehttp://stackoverflow.com/questions/8427413/webkitrequestfullscreen-fails-when-passing-element-allow-keyboard-input-in-safar
         requestFullScreen.call(docEl, undefined);
       } else {
-        requestFullScreen.call(docEl);
+        // CartoDB.js #412 : 
+        // Nowadays (2015/03/25), fullscreen is not supported in iOS Mobile. Reference: http://caniuse.com/#feat=fullscreen
+        if (requestFullScreen !== undefined) {
+          requestFullScreen.call(docEl);
+        }
       }
 
       if (mapView) {

--- a/src/geo/ui/fullscreen.js
+++ b/src/geo/ui/fullscreen.js
@@ -78,7 +78,7 @@ cdb.ui.common.FullScreen = cdb.core.View.extend({
       } else {
         // CartoDB.js #412 :: Fullscreen button is throwing errors
         // Nowadays (2015/03/25), fullscreen is not supported in iOS Safari. Reference: http://caniuse.com/#feat=fullscreen
-        if (requestFullScreen !== undefined) {
+        if (requestFullScreen) {
           requestFullScreen.call(docEl);
         }
       }


### PR DESCRIPTION
Ref. ticket #412 : https://github.com/CartoDB/cartodb.js/issues/412

Track.js was reporting that the error was throw with the following info:
- Browser: Mobile Safari 8.0
- Operating System: iOS 8.2

A fullscreen action was being executed from a mobile device, so the option *force_mobile=false* would be necessary (thanks @xavijam ).

Indeed, I tried it with desktop (OS X 10.10.1) browsers (Chrome/Fixefox/Safari) and it worked. But, I [emulated](http://www.macinstruct.com/node/494) an iOS 8.1 and I was able to reproduce the error.

So, the issue is:
**Nowadays (2015/03/25), fullscreen is not supported in iOS Safari. [Reference](http://caniuse.com/#feat=fullscreen)**

With this patch, I'm avoiding the error messages. Also, I think that it would be better if we don't allow to put on screen the fullscreen button in cases like that, but I think that it would be another (and more complex) issue. 

Please, @xavijam @alonsogarciapablo , could you check it? Thanks!