### PR TITLE
Shows password protected visualizations

### DIFF
--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -1,6 +1,6 @@
 (function() {
 
-  function Queue() {
+  Queue = function() {
 
     // callback storage
     this._methods = [];
@@ -52,7 +52,7 @@
 
   };
 
-  var Image = function() {
+  StaticImage = function() {
 
     Map.call(this, this); 
 
@@ -75,7 +75,7 @@
 
   };
 
-  Image.prototype = _.extend({}, Map.prototype, {
+  StaticImage.prototype = _.extend({}, Map.prototype, {
 
     load: function(vizjson, options) {
 
@@ -530,7 +530,7 @@
 
     if (!options) options = {};
 
-    var image = new Image();
+    var image = new StaticImage();
 
     if (typeof data === 'string') {
       image.load(data, options);

--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -132,6 +132,8 @@
           this.options.user_name = dataLayer.options.user_name;
         }
 
+        this.auth_tokens = data.auth_tokens;
+
         this._setupTilerConfiguration(dataLayer.options.tiler_protocol, dataLayer.options.tiler_domain, dataLayer.options.tiler_port);
 
         this.endPoint = "/api/v1/map";
@@ -365,10 +367,17 @@
 
       var layerDefinition = new NamedMap(options.named_map, options);
 
-      return { type: "named",
-        options: {
-          name: layerDefinition.named_map.name
-        }
+      var options = {
+        name: layerDefinition.named_map.name
+      };
+
+      if (this.auth_tokens && this.auth_tokens.length > 0) {
+        options.auth_tokens = this.auth_tokens;
+      }
+
+      return {
+        type: "named",
+        options: options
       }
 
     },

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -435,7 +435,7 @@ describe("Image", function() {
 
   it("should send the auth_tokens", function(done) {
 
-    var vizjson = "http://documentation.cartodb.com/api/v2/viz/8639778a-d6ea-11e4-861c-0e018d66dc29/viz.json"
+    var vizjson = "http://documentation.cartodb.com/api/v2/viz/e11db0aa-d77e-11e4-9039-0e853d047bba/viz.json"
 
     var image = cartodb.Image(vizjson).size(400, 300);
 

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -433,4 +433,17 @@ describe("Image", function() {
 
   });
 
+  it("should send the auth_tokens", function(done) {
+
+    var vizjson = "http://documentation.cartodb.com/api/v2/viz/8639778a-d6ea-11e4-861c-0e018d66dc29/viz.json"
+
+    var image = cartodb.Image(vizjson).size(400, 300);
+
+    image.getUrl(function(err, url) {
+      expect(image.options.layers.layers[1].options.auth_tokens.length > 0).toBe(true);
+      done();
+    });
+
+  });
+
 });

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -436,11 +436,29 @@ describe("Image", function() {
   it("should send the auth_tokens", function(done) {
 
     var vizjson = "http://documentation.cartodb.com/api/v2/viz/e11db0aa-d77e-11e4-9039-0e853d047bba/viz.json"
+    var json = {"id":"e11db0aa-d77e-11e4-9039-0e853d047bba","version":"0.1.0","title":"password_protected_map","likes":0,"description":null,"scrollwheel":false,"legends":true,"url":null,"map_provider":"leaflet","bounds":[[0.0,0.0],[0.0,0.0]],"center":"[30, 0]","zoom":3,"updated_at":"2015-03-31T08:21:18+00:00","layers":[{"options":{"visible":true,"type":"Tiled","urlTemplate":"http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png","subdomains":"1234","name":"Positron","className":"positron_rainbow","attribution":"\u00a9 <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors \u00a9 <a href=\"http://cartodb.com/attributions#basemaps\">CartoDB</a>"},"infowindow":null,"tooltip":null,"id":"c850d654-ab61-441d-9860-b3c2e42424fb","order":0,"parent_id":null,"children":[],"type":"tiled"},{"type":"namedmap","order":1,"options":{"type":"namedmap","user_name":"documentation","tiler_protocol":"https","tiler_domain":"cartodb.com","tiler_port":"443","cdn_url":{"http":"api.cartocdn.com","https":"cartocdn.global.ssl.fastly.net"},"dynamic_cdn":false,"named_map":{"name":"tpl_e11db0aa_d77e_11e4_9039_0e853d047bba","stat_tag":"e11db0aa-d77e-11e4-9039-0e853d047bba","params":{"layer0":1},"layers":[{"layer_name":"untitled_table_5","interactivity":"cartodb_id","visible":true}]}}}],"overlays":[{"type":"logo","order":9,"options":{"display":true,"x":10,"y":40},"template":""},{"type":"loader","order":8,"options":{"display":true,"x":20,"y":150},"template":"<div class=\"loader\" original-title=\"\"></div>"},{"type":"zoom","order":6,"options":{"display":true,"x":20,"y":20},"template":"<a href=\"#zoom_in\" class=\"zoom_in\">+</a> <a href=\"#zoom_out\" class=\"zoom_out\">-</a>"},{"type":"search","order":3,"options":{"display":true,"x":60,"y":20},"template":""},{"type":"share","order":2,"options":{"display":true,"x":20,"y":20},"template":""}],"prev":null,"next":null,"transition_options":{"time":0},"auth_tokens":["e900fe76cc3c1eed4fc018d027d82c8b0e59b2c484d1941954f34b4818a5d660"]}
+
+    StaticImage.prototype.load = function(vizjson, options) {
+
+      this.queue = new Queue;
+
+      this.no_cdn = options.no_cdn;
+
+      this.userOptions = options;
+
+      options = _.defaults({ vizjson: vizjson, temp_id: "s" + this._getUUID() }, this.defaults);
+
+      this.imageOptions = options;
+
+      this._onVisLoaded(json); // do the callback
+
+    };
 
     var image = cartodb.Image(vizjson).size(400, 300);
 
     image.getUrl(function(err, url) {
       expect(image.options.layers.layers[1].options.auth_tokens.length > 0).toBe(true);
+      expect(image.options.layers.layers[1].options.auth_tokens[0]).toBe("e900fe76cc3c1eed4fc018d027d82c8b0e59b2c484d1941954f34b4818a5d660");
       done();
     });
 


### PR DESCRIPTION
Password protected visualizations require to get an array with the `auth_tokens`. This PR solves that.

@javisantana: can you :eyes:, please?