### PR TITLE
Sanitize infowindow output on render only

### DIFF
--- a/src/geo/ui/infowindow.js
+++ b/src/geo/ui/infowindow.js
@@ -190,7 +190,7 @@ cdb.geo.ui.InfowindowModel = Backbone.Model.extend({
       if(options.empty_fields || (value !== undefined && value !== null)) {
         render_fields.push({
           title: field.title ? field.name : null,
-          value: cdb.core.sanitize.html(attributes[field.name]),
+          value: attributes[field.name],
           index: j
         });
       }
@@ -298,7 +298,7 @@ cdb.geo.ui.Infowindow = cdb.core.View.extend({
       if ($jscrollpane.length > 0 && $jscrollpane.data() != null) {
         $jscrollpane.data().jsp && $jscrollpane.data().jsp.destroy();
       }
-      
+
       // Clone fields and template name
       var fields = _.map(this.model.attributes.content.fields, function(field){
         return _.clone(field);
@@ -328,7 +328,9 @@ cdb.geo.ui.Infowindow = cdb.core.View.extend({
           }
         },values);
 
-      this.$el.html(this.template(obj));
+      this.$el.html(
+        cdb.core.sanitize.html(this.template(obj), this.model.get('sanitizeTemplate'))
+      );
 
       // Set width and max-height from the model only
       // If there is no width set, we don't force our infowindow
@@ -389,7 +391,7 @@ cdb.geo.ui.Infowindow = cdb.core.View.extend({
 
     if(typeof(template) !== 'function') {
       this.template = new cdb.core.Template({
-        template: cdb.core.sanitize.html(template, this.model.get('sanitizeTemplate')),
+        template: template,
         type: this.model.get('template_type') || 'mustache'
       }).asFunction()
     } else {


### PR DESCRIPTION
While debugging the [issue with broken <img> that contained `&`s](https://github.com/CartoDB/cartodb/issues/3010) more thoroughly I found the real issue, infowindows are rendered differently in editor vs. using cartodb.js (why the images/URLs break only on embeds). 

The culprit is that [infowindow model's content fields are sanitized on update](https://github.com/CartoDB/cartodb.js/blob/develop/src/geo/ui/infowindow.js#L193), so these values will be double-escaped upon render (due to the default mustache template, i.e. `{{ img_url }}`). For the editor the code don't use this way of rendering so was just injected as-is.

With these changes the render is consistent for both the editor and cartodb.js usage by default, i.e. what the user sees in the editor is how it will look in the embed too.