### PR TITLE
We don't allow to force the https anymore. Removed unnecesary specs

### DIFF
--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -239,11 +239,6 @@
       this.options.tiler_protocol = protocol;
       this.options.tiler_port     = port;
 
-      if (this.imageOptions.vizjson.indexOf("https") === 0) {
-        this.options.tiler_protocol = "https";
-        this.options.tiler_port     = 443;
-      }
-
       this._buildMapsApiTemplate(this.options);
 
     },

--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -239,7 +239,7 @@
       this.options.tiler_protocol = protocol;
       this.options.tiler_port     = port;
 
-      if (this.userOptions.https || this.imageOptions.vizjson.indexOf("https") === 0) {
+      if (this.imageOptions.vizjson.indexOf("https") === 0) {
         this.options.tiler_protocol = "https";
         this.options.tiler_port     = 443;
       }

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -401,38 +401,6 @@ describe("Image", function() {
 
   });
 
-  it("should set force the https protocol", function(done) {
-
-    var vizjson = "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"
-
-    var image = cartodb.Image(vizjson, { https: true }).size(400, 300);
-
-    var regexp = new RegExp("https://cartocdn-ashbu.global.ssl.fastly.net/documentation/api/v1/map/static/bbox/(.*?)400/300\.png");
-
-    image.getUrl(function(err, url) {
-      expect(url.match(regexp).length).toEqual(2);
-      expect(url).toMatch(regexp);
-      done();
-    });
-
-  });
-
-  it("should set force the https protocol (no_cdn)", function(done) {
-
-    var vizjson = "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"
-
-    var image = cartodb.Image(vizjson, { https: true, no_cdn: true }).size(400, 300);
-
-    var regexp = new RegExp("https://documentation.cartodb.com:443/api/v1/map/static/bbox/(.*?)400/300\.png");
-
-    image.getUrl(function(err, url) {
-      expect(url.match(regexp).length).toEqual(2);
-      expect(url).toMatch(regexp);
-      done();
-    });
-
-  });
-
   it("should set the protocol and port depending on the URL (http, no_cdn)", function(done) {
 
     var vizjson = "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"


### PR DESCRIPTION
This PR removes the option to force the `https` protocol of a static map and fixes the specs accordingly (as in removing them completely)