### PR TITLE
Doesn't add timeslider with Torque static maps in mobile

### DIFF
--- a/src/geo/ui/time_slider.js
+++ b/src/geo/ui/time_slider.js
@@ -69,7 +69,13 @@ cdb.geo.ui.TimeSlider = cdb.geo.ui.InfoBox.extend({
   },
 
   updateSliderRange: function(changes) {
-    this.$(".slider" ).slider({ max: changes.steps - 1 });
+    if (changes.steps > 1){
+      this.show();
+      this.$(".slider" ).slider({ max: changes.steps - 1 });
+    }
+    else{
+      this.hide();
+    }
   },
 
   // each time time changes, move the slider

--- a/src/vis/overlays.js
+++ b/src/vis/overlays.js
@@ -16,9 +16,7 @@ cdb.vis.Overlay.register('slides_controller', function(data, vis) {
 });
 
 cdb.vis.Overlay.register('mobile', function(data, vis) {
-
-  var template = cdb.core.Template.compile(
-    data.template || '\
+  var temp = data.template || '\
     <div class="backdrop"></div>\
     <div class="cartodb-header">\
       <div class="content">\
@@ -34,10 +32,11 @@ cdb.vis.Overlay.register('mobile', function(data, vis) {
     </div>\
     <div class="cartodb-attribution"></div>\
     <a href="#" class="cartodb-attribution-button"></a>\
-    <div class="torque"></div>\
-    ',
-    data.templateType || 'mustache'
-  );
+    ';
+  if(data.torqueLayer.options.steps > 1){
+    temp += '<div class="torque"></div>';
+  }
+  var template = cdb.core.Template.compile(temp, data.templateType || 'mustache');
 
   var mobile = new cdb.geo.ui.Mobile({
     template: template,

--- a/src/vis/overlays.js
+++ b/src/vis/overlays.js
@@ -16,7 +16,9 @@ cdb.vis.Overlay.register('slides_controller', function(data, vis) {
 });
 
 cdb.vis.Overlay.register('mobile', function(data, vis) {
-  var temp = data.template || '\
+
+  var template = cdb.core.Template.compile(
+    data.template || '\
     <div class="backdrop"></div>\
     <div class="cartodb-header">\
       <div class="content">\
@@ -32,11 +34,10 @@ cdb.vis.Overlay.register('mobile', function(data, vis) {
     </div>\
     <div class="cartodb-attribution"></div>\
     <a href="#" class="cartodb-attribution-button"></a>\
-    ';
-  if(data.torqueLayer.options.steps > 1){
-    temp += '<div class="torque"></div>';
-  }
-  var template = cdb.core.Template.compile(temp, data.templateType || 'mustache');
+    <div class="torque"></div>\
+    ',
+    data.templateType || 'mustache'
+  );
 
   var mobile = new cdb.geo.ui.Mobile({
     template: template,


### PR DESCRIPTION
Ref. #446 

Makes sure the timeslider is not templated in when the Torque map is static.

@ohasselblad @javisantana 