### PR TITLE
Allows to specify a step for torque layers

### DIFF
--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -348,6 +348,7 @@
       return {
         type: "torque",
         options: {
+          step: this.userOptions.step || 0,
           sql: query,
           cartocss: cartocss
         }

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -86,6 +86,22 @@ describe("Image", function() {
 
   });
 
+  it("should allow to use a step for a torque layer", function(done) {
+
+    var vizjson = "http://documentation.cartodb.com/api/v2/viz/3ec995a8-b6ae-11e4-849e-0e4fddd5de28/viz.json"
+
+    var image = cartodb.Image(vizjson, { step: 10 });
+
+    var regexp = new RegExp("http://a.ashbu.cartocdn.com/documentation/api/v1/map/static/bbox/(.*?)/-138\.6474609375,27\.761329874505233,-83\.408203125,51\.26191485308451/320/240\.pn");
+
+    image.getUrl(function(err, url) {
+      expect(image.options.userOptions.step).toEqual(10);
+      expect(image.options.layers.layers[1].options.step).toEqual(10);
+      done();
+    });
+
+  });
+
   it("shouldn't use hidden layers to generate the image", function(done) { 
 
     var vizjson = "http://documentation.cartodb.com/api/v2/viz/42e98b9a-bcce-11e4-9d68-0e9d821ea90d/viz.json";


### PR DESCRIPTION
This PR adds the possibility to specify a `step` param to render a specific frame of a torque layer.

`cartodb.Image(vizjson, { step: 100 }).size(500, 500)`

Original issue: https://github.com/CartoDB/cartodb.js/issues/351. Related to: https://github.com/CartoDB/cartodb/issues/3268