### PR TITLE
Fixes loop functionality with Torque from cdb.js

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@
 * Infowindow in anonymous maps are requested by attributes endpoint in maps api so SQL API is not used anymore
 * Changed the way remote host is set for maps and sql API.
 * Fixed error management when map instanciation fails
+* Enabling or disabling the torque loop property not working from cartodb.js
 * Deprecation warning:
     - tiler_host, tiler_prototol, tiler_port, sql_api_domain, sql_api_protocol are deprecated, use sql_api_template and maps_api_template instead. https://github.com/CartoDB/cartodb.js/blob/develop/doc/API.md#how-to-set-a-different-host-than-cartodbcom
 

--- a/src/geo/leaflet/torque.js
+++ b/src/geo/leaflet/torque.js
@@ -46,6 +46,7 @@ var LeafLetTorqueLayer = L.TorqueLayer.extend({
       auth_token: layerModel.get('auth_token'),
       no_cdn: layerModel.get('no_cdn'),
       dynamic_cdn: layerModel.get('dynamic_cdn'),
+      loop: layerModel.get('loop'),
       instanciateCallback: function() {
         var cartocss = layerModel.get('cartocss') || layerModel.get('tile_style');
 


### PR DESCRIPTION
Ref. https://github.com/CartoDB/torque/issues/164

Basically the loop attribute wasn't being passed on to the Torque layer from cartodb.js. 

@javisantana @ohasselblad 