### PR TITLE
Defines userOptions for the layer_definition loader

### DIFF
--- a/src/vis/image.js
+++ b/src/vis/image.js
@@ -97,7 +97,7 @@
 
     },
 
-    loadLayerDefinition: function(layerDefinition) {
+    loadLayerDefinition: function(layerDefinition, options) {
 
       var self = this;
 
@@ -108,12 +108,15 @@
         return;
       }
 
+      this.userOptions = options;
+
       this.options.user_name      = layerDefinition.user_name;
       this.options.tiler_protocol = layerDefinition.tiler_protocol;
       this.options.tiler_domain   = layerDefinition.tiler_domain;
       this.options.tiler_port     = layerDefinition.tiler_port;
       this.options.maps_api_template = layerDefinition.maps_api_template;
       this.endPoint = "/api/v1/map";
+
       if (!this.options.maps_api_template) {
         this._buildMapsApiTemplate(this.options);
       }
@@ -541,7 +544,7 @@
     if (typeof data === 'string') {
       image.load(data, options);
     } else {
-      image.loadLayerDefinition(data);
+      image.loadLayerDefinition(data, options);
     }
 
     return image;

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -307,6 +307,39 @@ describe("Image", function() {
 
   });
 
+  it("should generate an image using a layer definition in a certain bbox", function(done) {
+
+    var layer_definition = {
+      user_name: "documentation",
+      tiler_domain: "cartodb.com",
+      tiler_port: "80",
+      tiler_protocol: "http",
+      layers: [{
+        type: "http",
+        options: {
+          urlTemplate: "http://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png",
+          subdomains: [ "a", "b", "c" ]
+        }
+      }, {
+        type: "cartodb",
+        options: {
+          sql: "SELECT * FROM nyc_wifi",
+          cartocss: "#ncy_wifi{ marker-fill-opacity: 0.8; marker-line-color: #FFFFFF; marker-line-width: 3; marker-line-opacity: .8; marker-placement: point; marker-type: ellipse; marker-width: 16; marker-fill: #6ac41c; marker-allow-overlap: true; }",
+          cartocss_version: "2.1.1"
+        }
+      }]
+    };
+
+    var regexp = new RegExp("http://a.ashbu.cartocdn.com/documentation/api/v1/map/static/bbox/8c67df0046ce227a89a65d0e3f87e80e:1398886221740.03/-87.82814025878906,41.88719899247721,-27.5936508178711,41.942765696654604/250/250\.png");
+
+    cartodb.Image(layer_definition).size(250, 250).bbox([[-87.82814025878906,41.88719899247721], [ -27.5936508178711,41.942765696654604]]).getUrl(function(error, url) {
+      expect(url.match(regexp).length).toEqual(1);
+      expect(url).toMatch(regexp);
+      done();
+    });
+
+  });
+
   it("should use maps_api_template when provided", function() {
 
     var layer_definition = {


### PR DESCRIPTION
`userOptions` wasn't defined for the `loadLayerDefinition`, so in some cases an exception was triggered.

Fixes: https://github.com/CartoDB/cartodb.js/issues/439