### PR TITLE
Fix vis.addInfowindow() method name in doc/API.md

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -263,7 +263,7 @@ Overlay objects are always created using the **addOverlay** method of a cartodb.
 
 An overlay is internally a [**Backbone.View**](http://backbonejs.org/#View) so if you know how Backbone works you can use it. If you want to use plain DOM objects you can access **overlay.el** (**overlay.$el** for jQuery object).
 
-#### vis.addInfoWindow(_map, layer, fields [, options]_)
+#### vis.addInfowindow(_map, layer, fields [, options]_)
 
 Adds an infowindow to the map controlled by layer events. It enables interaction and overrides the layer interactivity.
 


### PR DESCRIPTION
I was searching for the actual definition of ```vis.addInfoWindow``` in the cartodb.js source code after reading about it in the API docs but couldn't find anything with that name. Happens that the method itself is defined as ```addInfowindow``` and not ```addInfoWindow``` (notice the lower case w).