### PR TITLE
Fixes problems setting maxZoom and minZoom

### DIFF
--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -379,14 +379,14 @@ cdb.geo.Map = cdb.core.Model.extend({
     var maxZoom = layer.get('maxZoom');
     var minZoom = layer.get('minZoom');
 
-    if (_.isNumber(maxZoom)) {
+    if (_.isNumber(parseInt(maxZoom))) {
 
       if ( this.get("zoom") > maxZoom ) this.set({ zoom: maxZoom, maxZoom: maxZoom });
       else this.set("maxZoom", maxZoom);
 
     }
 
-    if (_.isNumber(minZoom)) {
+    if (_.isNumber(parseInt(minZoom))) {
 
       if ( this.get("zoom") < minZoom ) this.set({ minZoom: minZoom, zoom: minZoom });
       else this.set("minZoom", minZoom);

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -376,17 +376,17 @@ cdb.geo.Map = cdb.core.Model.extend({
 
   _adjustZoomtoLayer: function(layer) {
 
-    var maxZoom = layer.get('maxZoom');
-    var minZoom = layer.get('minZoom');
+    var maxZoom = parseInt(layer.get('maxZoom'), 10);
+    var minZoom = parseInt(layer.get('minZoom'), 10);
 
-    if (_.isNumber(parseInt(maxZoom))) {
+    if (_.isNumber(maxZoom)) {
 
       if ( this.get("zoom") > maxZoom ) this.set({ zoom: maxZoom, maxZoom: maxZoom });
       else this.set("maxZoom", maxZoom);
 
     }
 
-    if (_.isNumber(parseInt(minZoom))) {
+    if (_.isNumber(minZoom)) {
 
       if ( this.get("zoom") < minZoom ) this.set({ minZoom: minZoom, zoom: minZoom });
       else this.set("minZoom", minZoom);

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -107,6 +107,20 @@ describe("geo.map", function() {
       expect(map.get('zoom')).toEqual(10);
     });
 
+    it("should adjust zoom to layer", function() {
+      expect(map.get('maxZoom')).toEqual(40);
+      expect(map.get('minZoom')).toEqual(0);
+
+      var layer = new cdb.geo.PlainLayer({ minZoom: 5, maxZoom: 20 });
+      map.layers.reset(layer);
+      expect(map.get('maxZoom')).toEqual(20);
+      expect(map.get('minZoom')).toEqual(5);
+
+      var layer = new cdb.geo.PlainLayer({ minZoom: "7", maxZoom: "31" });
+      map.layers.reset(layer);
+      expect(map.get('maxZoom')).toEqual(31);
+      expect(map.get('minZoom')).toEqual(7);
+    });
 
   });
 


### PR DESCRIPTION
This PR attempts to fix a problem that occurs when changing between basemaps with different zoom configurations.

See related issue: https://github.com/CartoDB/cartodb/issues/2250

`maxZoom` and `minZoom` get returned as a string (except in development, where they are returned as an integer), so the zoom is never correctly updated.


