### PR TITLE
Updates version of Torque to 2.11.2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 3.14.1 (30//04//2015)
 * Fixes a bug that prevented setting the maxZoom and minZoom of a map.
+* Updates Torque to 2.11.2
 
 3.14.0 (23//04//2015)
 * Infowindow in anonymous maps are requested by attributes endpoint in maps api so SQL API is not used anymore

--- a/vendor/mod/torque.uncompressed.js
+++ b/vendor/mod/torque.uncompressed.js
@@ -669,6 +669,7 @@ module.exports.TorqueLayer = TorqueLayer;
   // types
   var types = {
     Uint8Array: typeof(global['Uint8Array']) !== 'undefined' ? global.Uint8Array : Array,
+    Uint8ClampedArray: typeof(global['Uint8ClampedArray']) !== 'undefined' ? global.Uint8ClampedArray: Array,
     Uint32Array: typeof(global['Uint32Array']) !== 'undefined' ? global.Uint32Array : Array,
     Int16Array: typeof(global['Int16Array']) !== 'undefined' ? global.Int16Array : Array,
     Int32Array: typeof(global['Int32Array']) !== 'undefined' ? global.Int32Array: Array
@@ -1613,6 +1614,7 @@ GMapsTorqueLayer.prototype = torque.extend({},
 
     this.provider = new this.providers[this.options.provider](this.options);
     this.renderer = new this.renderers[this.options.renderer](this.getCanvas(), this.options);
+    this.renderer.options.errorCallback = this.options.errorCallback;
 
     // this listener should be before tile loader
     this._cacheListener = google.maps.event.addListener(this.options.map, 'zoom_changed', function() {
@@ -1643,6 +1645,7 @@ GMapsTorqueLayer.prototype = torque.extend({},
   },
 
   setSQL: function(sql) {
+    if (this.provider.options.named_map) throw new Error("SQL queries on named maps are read-only");
     if (!this.provider || !this.provider.setSQL) {
       throw new Error("this provider does not support SQL");
     }
@@ -1787,6 +1790,7 @@ GMapsTorqueLayer.prototype = torque.extend({},
    * set the cartocss for the current renderer
    */
   setCartoCSS: function(cartocss) {
+    if (this.provider.options.named_map) throw new Error("CartoCSS style on named maps is read-only");
     var shader = new carto.RendererJS().render(cartocss);
     this.shader = shader;
     if (this.renderer) {
@@ -1815,6 +1819,7 @@ GMapsTorqueLayer.prototype = torque.extend({},
   },
 
   onRemove: function() {
+    this.fire('remove');
     CanvasLayer.prototype.onRemove.call(this);
     this.animator.stop();
     this._removeTileLoader();
@@ -1855,6 +1860,11 @@ GMapsTorqueLayer.prototype = torque.extend({},
       }
     }
     return sum;
+  },
+  
+  error: function (callback) {
+    this.options.errorCallback = callback;
+    return this;
   }
 
 });
@@ -2135,6 +2145,11 @@ L.CanvasLayer = L.Class.extend({
 
   addTo: function (map) {
     map.addLayer(this);
+    return this;
+  },
+
+  error: function (callback) {
+    this.provider.options.errorCallback = callback;
     return this;
   },
 
@@ -2493,6 +2508,7 @@ L.TorqueLayer = L.CanvasLayer.extend({
   },
 
   onRemove: function(map) {
+    this.fire('remove');
     this._removeTileLoader();
     map.off({
       'zoomend': this._clearCaches,
@@ -2533,6 +2549,7 @@ L.TorqueLayer = L.CanvasLayer.extend({
   },
 
   setSQL: function(sql) {
+    if (this.provider.options.named_map) throw new Error("SQL queries on named maps are read-only");
     if (!this.provider || !this.provider.setSQL) {
       throw new Error("this provider does not support SQL");
     }
@@ -2693,6 +2710,7 @@ L.TorqueLayer = L.CanvasLayer.extend({
    * set the cartocss for the current renderer
    */
   setCartoCSS: function(cartocss) {
+    if (this.provider.options.named_map) throw new Error("CartoCSS style on named maps is read-only");
     if (!this.renderer) throw new Error('renderer is not valid');
     var shader = new carto.RendererJS().render(cartocss);
     this.renderer.setShader(shader);
@@ -3867,6 +3885,7 @@ var Profiler = require('../profiler');
   var Uint8Array = torque.types.Uint8Array;
   var Int32Array = torque.types.Int32Array;
   var Uint32Array = torque.types.Uint32Array;
+  var Uint8ClampedArray = torque.types.Uint8ClampedArray;
 
   // format('hello, {0}', 'rambo') -> "hello, rambo"
   function format(str) {
@@ -3945,7 +3964,7 @@ var Profiler = require('../profiler');
         dates = (1 + maxDateSlots) * rows.length;
       }
 
-      var type = this.options.cumulative ? Uint32Array: Uint8Array;
+      var type = this.options.cumulative ? Uint32Array: Uint8ClampedArray;
 
       // reserve memory for all the dates
       var timeIndex = new Int32Array(maxDateSlots + 1); //index-size
@@ -4322,6 +4341,10 @@ var Profiler = require('../profiler');
       torque.net.jsonp(url, function (data) {
         map_instance_time.end();
         if (data) {
+          if (data.errors){
+            self.options.errorCallback && self.options.errorCallback(data.errors);
+            return;
+          }
           var torque_key = Object.keys(data.metadata.torque)[0]
           var opt = data.metadata.torque[torque_key];
           for(var k in opt) {


### PR DESCRIPTION
Changes since last replacement:

```
- Added error handling to Torque
- Fixed 'remove' event triggering when removing a Torque layer.
- Value is now capped at 255 instead of performing modulo on higher values.
```

@javierarce ;)