### PR TITLE
Allows to specify a custom template for the custom legend items

### DIFF
--- a/src/geo/ui/legend.js
+++ b/src/geo/ui/legend.js
@@ -1066,9 +1066,7 @@ cdb.geo.ui.CustomLegend = cdb.geo.ui.BaseLegend.extend({
   template: _.template('<% if (title && show_title) { %>\n<div class="legend-title"><%- title %></div><% } %><ul></ul>'),
 
   initialize: function() {
-
     this.items = this.model.items;
-
   },
 
   setData: function(data) {
@@ -1087,10 +1085,12 @@ cdb.geo.ui.CustomLegend = cdb.geo.ui.BaseLegend.extend({
 
   _renderItem: function(item) {
 
+    var template = this.options.itemTemplate || '\t\t<div class="bullet" style="background:<%= value %>"></div>\n\t\t<%- name || "null" %>';
+
     view = new cdb.geo.ui.LegendItem({
       model: item,
       className: (item.get("value") && item.get("value").indexOf("http") >= 0) ? "bkg" : "",
-      template: '\t\t<div class="bullet" style="background:<%= value %>"></div>\n\t\t<%- name || "null" %>'
+      template: template
     });
 
     this.$el.find("ul").append(view.render());

--- a/test/spec/geo/legend.spec.js
+++ b/test/spec/geo/legend.spec.js
@@ -404,6 +404,21 @@ describe("common.geo.ui.Legend", function() {
         expect(legend.$el.find("li:last-child .bullet").css("background")).toEqual("rgb(255, 0, 255)");
       });
 
+      it("should allow to specify a custom template for the items", function() {
+
+        var title = "Custom title";
+
+        var legend = new cdb.geo.ui.Legend.Custom({
+          title: title,
+          data: custom_data,
+          itemTemplate: '<div class="myCustomClass" style="background:#f1f1f1;"></div><%= name %>: <%= value %>'
+        });
+
+        legend.render();
+
+        expect(legend.$el.find("li:first-child").html()).toEqual('<div class="myCustomClass" style="background:#f1f1f1;"></div>Natural Parks: #58A062');
+      });
+
     });
 
     describe("Category Legend", function() {

--- a/test/spec/geo/legend.spec.js
+++ b/test/spec/geo/legend.spec.js
@@ -226,24 +226,6 @@ describe("common.geo.ui.Legend", function() {
 
     });
 
-    xit("should have a collection of items", function() {
-      expect(stackedLegend.items instanceof cdb.geo.ui.StackedLegendItems).toEqual(true);
-    });
-
-    xit("should populate the collection", function() {
-      expect(stackedLegend.items.length).toEqual(2);
-
-      //for (var i = 0; i < legends.length; i++) {
-      //expect(stackedLegend.items.at(i).toJSON()).toEqual(legends[i]);
-      //}
-
-    });
-
-    //it("should generate one element", function() {
-    //stackedLegend.render();
-    //expec(stackedLegend.$el);
-    //});
-
   });
 
   describe("ColorLegend", function() {


### PR DESCRIPTION
This PR allows to specify a template for the items of a Custom Legend.

Related issue: https://github.com/CartoDB/cartodb.js/issues/109