### PR TITLE
Uses internal version of jQuery in maps with Torque

### DIFF
--- a/grunt/tasks/concat.js
+++ b/grunt/tasks/concat.js
@@ -142,6 +142,7 @@ module.exports = {
         files: {
           // Torque library
           '<%= config.dist %>/cartodb.mod.torque.uncompressed.js': [
+            './grunt/templates/torque_header.js',
             'vendor/mod/carto.js',
             'vendor/mod/torque.uncompressed.js',
             'src/geo/gmaps/torque.js',

--- a/grunt/templates/torque_footer.js
+++ b/grunt/templates/torque_footer.js
@@ -1,3 +1,7 @@
+// Restores any previous global libraries, e.g. jQuery
+for (var lib in window._prev){
+	window[lib] = window._prev[lib];
+}
 
 cartodb.moduleLoad('torque', torque);
 

--- a/grunt/templates/torque_header.js
+++ b/grunt/templates/torque_header.js
@@ -1,0 +1,7 @@
+if(cartodb){
+	// Keep the global version of jQuery, if there is any
+	if(window.$){
+		window._prev = {jQuery: window.$, $: window.$} 
+	}
+	window.$ = window.jQuery = cartodb.$;
+} 


### PR DESCRIPTION
Ref. #414 

A header in the Torque module of Cartodb.js that makes sure that the bundled version of jquery (1.7.2) is used, and not one specified in the DOM. Also, as in the visualisations without torque, it restores the user-specified version if there is any.

@javisantana 