### PR TITLE
Hide <img> tags in infowindow covers if url is invalid

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+3.14.X ()
+* Hide <img> tag of infowindow covers when the url is invalid
+
 3.14.2 (06//05//2015)
 * Allow to specify a template for the items of a custom legend.
 * The NOKIA geocoder doesn't encode the whitespaces anymore.

--- a/src/geo/ui/infowindow.js
+++ b/src/geo/ui/infowindow.js
@@ -559,26 +559,25 @@ cdb.geo.ui.Infowindow = cdb.core.View.extend({
 
     if (!this._containsCover()) return;
 
-    var
-    self = this,
-    $cover = this.$(".cover"),
-    $shadow = this.$(".shadow"),
-    url = this._getCoverURL();
+    var self = this;
+    var $cover = this.$(".cover");
+    var $img = $cover.find("img");
+    var $shadow = this.$(".shadow");
+    var url = this._getCoverURL();
 
     if (!this._isValidURL(url)) {
+      $img.hide();
       $shadow.hide();
       cdb.log.info("Header image url not valid");
       return;
     }
 
     // configure spinner
-    var
-    target  = document.getElementById('spinner'),
-    opts    = { lines: 9, length: 4, width: 2, radius: 4, corners: 1, rotate: 0, color: '#ccc', speed: 1, trail: 60, shadow: true, hwaccel: false, zIndex: 2e9 },
-    spinner = new Spinner(opts).spin(target);
+    var target  = document.getElementById('spinner');
+    var opts    = { lines: 9, length: 4, width: 2, radius: 4, corners: 1, rotate: 0, color: '#ccc', speed: 1, trail: 60, shadow: true, hwaccel: false, zIndex: 2e9 };
+    var spinner = new Spinner(opts).spin(target);
 
     // create the image
-    var $img = $cover.find("img");
 
     $img.hide(function() {
       this.remove();

--- a/test/spec/geo/ui/infowindow.spec.js
+++ b/test/spec/geo/ui/infowindow.spec.js
@@ -560,6 +560,12 @@ describe("cdb.geo.ui.infowindow", function() {
       expect(view.$el.find("img").length).toEqual(0);
     });
 
+    it("if the them has a cover and the image is invalid it should hide it", function() {
+      model.set("content", { fields: fieldsWithoutURL });
+      model.set('template', '<div class="cartodb-popup header" data-cover="true"><div class="cover"><img src="{{ wadus }}"/></div></div>');
+      expect(view.$el.find("img").css('display')).toEqual('none');
+    });
+
     it("if the theme doesn't have cover don't append the image", function() {
       model.set("content", { fields: fields });
       model.set('template', '<div class="cover"></div>');


### PR DESCRIPTION
Fixes #461 (as [we did in CartoDB](https://github.com/CartoDB/cartodb/commit/331058ffdb4dbd5aa4a3b958504d0195c1769bf6)).

@xavijam please take a look.