### PR TITLE
Expose legend model in layer views

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 3.14.X ()
-* Hide <img> tag of infowindow covers when the url is invalid
+* Hide <img> tag of infowindow covers when the url is invalid.
+* Expose legend model in sublayers/layers so that users can customize layers (#480).
 
 3.14.2 (06//05//2015)
 * Allow to specify a template for the items of a custom legend.

--- a/doc/API.md
+++ b/doc/API.md
@@ -658,7 +658,7 @@ Toggles the visibility of the sublayer and returns a boolean that indicates the 
 
 **sublayer.infowindow** is a Backbone model where we modify the parameters of the infowindow.
 
-##### Arguments
+##### Attributes
 
 - **template**: Custom HTML template for the infowindow. You can write simple HTML or use [Mustache templates](http://mustache.github.com/).
 - **sanitizeTemplate**: By default all templates are sanitized from unsafe tags/attrs (e.g. `<script>`), set this to `false`
@@ -697,6 +697,16 @@ to skip sanitization, or a function to provide your own sanitization (e.g. `func
 
 [Grab the complete example source code](https://github.com/CartoDB/cartodb.js/blob/develop/examples/custom_infowindow.html)
 
+#### sublayer.legend
+
+**sublayer.legend** is a Backbone model with the information about the legend.
+
+##### Attributes
+
+- **template**: Custom HTML template for the legend. You can write simple HTML.
+- **title**: Title of the legend.
+- **show_title**: Set this to `false` if you don't want the title to be displayed.
+- **items**: An array with the items that are displayed in the legend.
 
 ## Events
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -707,6 +707,7 @@ to skip sanitization, or a function to provide your own sanitization (e.g. `func
 - **title**: Title of the legend.
 - **show_title**: Set this to `false` if you don't want the title to be displayed.
 - **items**: An array with the items that are displayed in the legend.
+- **visible**: Set this to `false` if you want to hide the legend.
 
 ## Events
 

--- a/src/geo/ui/legend.js
+++ b/src/geo/ui/legend.js
@@ -223,6 +223,12 @@ cdb.geo.ui.Legend = cdb.core.View.extend({
       } else {
         this.$el.html(this.view.render().$el.html());
       }
+
+      if (this.model.get("visible") === false) {
+        this.hide();
+      } else {
+        this.show();
+      }
     }
 
     return this;
@@ -1021,7 +1027,8 @@ cdb.geo.ui.LegendModel = cdb.core.Model.extend({
     type: null,
     show_title: false,
     title: "",
-    template: ""
+    template: "",
+    visible: true
   },
 
   initialize: function() {

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -816,6 +816,7 @@ var Vis = cdb.core.View.extend({
 
       if ((legend.items && legend.items.length) || legend.template) {
         var view = new cdb.geo.ui.Legend(layer.legend);
+        layerView.legend = view.model; // cdb.geo.ui.LegendModel
         layerView.bind('change:visibility', function(layer, hidden) {
           view[hidden? 'hide': 'show']();
         });

--- a/test/spec/api/layers/cartodb.spec.js
+++ b/test/spec/api/layers/cartodb.spec.js
@@ -97,6 +97,53 @@ describe('api.layers.cartodb', function() {
       }, 100);
     });
 
+    it("should expose the legend", function(done) {
+
+      var legend = {
+        type: "custom",
+        show_title: true,
+        title: "wadus",
+        template: "",
+        items: [
+          {
+            name: "item1",
+            visible: true,
+            value: "#FFCC00",
+            sync: true
+          },
+          {
+            name: "item2",
+            visible: true,
+            value: "#3B007F",
+            sync: true
+          }
+        ]
+      };
+
+      cartodb.createLayer(map, {
+        kind: 'cartodb',
+        options: {
+          table_name: 'test',
+          user_name: 'test',
+          tile_style: 'tesst'
+        },
+        infowindow: {
+          template: '<div></div>',
+          fields: [{name: 'test', title: true, order: 0}]
+        },
+        legend: legend
+      }, function(l) {
+        addFn(map, l);
+        layer = l;
+      });
+
+      setTimeout(function() {
+        expect(layer.legend instanceof cdb.geo.ui.LegendModel).toBeTruthy();
+        expect(layer.legend.get('items')).toEqual(legend.items);
+        done();
+      }, 100);
+    });
+
     it("should add interactivity if there is infowindow", function(done) {
       cartodb.createLayer(map, { 
           kind: 'cartodb', 

--- a/test/spec/geo/ui/legend.spec.js
+++ b/test/spec/geo/ui/legend.spec.js
@@ -141,6 +141,22 @@ describe("common.geo.ui.Legend", function() {
 
     });
 
+    it("should show/hide the legend when the visible attribute changes", function() {
+      legend.model.set({ type: "custom" });
+
+      legend.render();
+
+      expect(legend.$el.css('display')).toEqual('block');
+
+      legend.model.set({ visible: false });
+
+      expect(legend.$el.css('display')).toEqual('none');
+
+      legend.model.set({ visible: true });
+
+      expect(legend.$el.css('display')).toEqual('block');
+    });
+
     it("should render the title if title and show_title are set", function() {
       var title = "Hi, I'm a title";
       legend.model.set({ type: "custom", title: title, show_title: true });


### PR DESCRIPTION
This is part of #101. It exposes a legend model on layers/sublayers so that users can do some custom things, such us:
- Changing the template of the legend.
- Customizing the title of the legend.
- Showing/hiding the title of the legend.
- Getting/Setting the items that are displayed in the legend.
- Showing/hiding the legend.

@javisantana what do you think?