### PR TITLE
Prevent tooltips from being shown when no fields have been selected

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@
 * Hide <img> tag of infowindow covers when the url is invalid.
 * Expose legend model in sublayers/layers so that users can customize legends (#480).
 * Handle tooltip overflow (#482).
+* Only show tooltips when they have fields (#486).
 
 3.14.2 (06//05//2015)
 * Allow to specify a template for the items of a custom legend.

--- a/src/geo/ui/tooltip.js
+++ b/src/geo/ui/tooltip.js
@@ -51,9 +51,7 @@ cdb.geo.ui.Tooltip = cdb.geo.ui.InfoBox.extend({
       this.options.layer.unbind(null, null, this);
       this.options.layer
         .on('mouseover', function(e, latlng, pos, data) {
-          // this flag is used to be compatible with previous templates
-          // where the data is not enclosed a content variable
-          if (this.options.fields) {
+          if (this.options.fields && this.options.fields.length > 0) {
 
             var non_valid_keys = ['fields', 'content'];
 
@@ -64,6 +62,7 @@ cdb.geo.ui.Tooltip = cdb.geo.ui.InfoBox.extend({
             var c = cdb.geo.ui.InfowindowModel.contentForFields(data, this.options.fields, {
               empty_fields: this.options.empty_fields
             });
+
             // Remove fields and content from data
             // and make them visible for custom templates
             data.content = _.omit(data, non_valid_keys);
@@ -79,9 +78,12 @@ cdb.geo.ui.Tooltip = cdb.geo.ui.InfoBox.extend({
                 f.title = names[f.title] || f.title;
               }
             }
+            this.show(pos, data);
+            this.showing = true;
+          } else if (this.showing) {
+            this.hide();
+            this.showing = false;
           }
-          this.show(pos, data);
-          this.showing = true;
         }, this)
         .on('mouseout', function() {
           if (this.showing) {

--- a/test/spec/geo/ui/tooltip.spec.js
+++ b/test/spec/geo/ui/tooltip.spec.js
@@ -45,8 +45,38 @@ describe('cdb.geo.Tooltip', function() {
       huracan: 'hurecan'
     });
     expect(tooltip.$el.html()).not.toEqual('test2,test1,huracan,');
-
   });
+
+  it("should not show the tooltip if there are no fields", function() {
+    tooltip.setFields([]);
+    tooltip.enable();
+
+    layer.trigger('mouseover', new $.Event('e'), [0, 0], [0, 0], {});
+
+    // Tooltip is hidden
+    expect(tooltip.showing).toBeFalsy();
+  });
+
+  it("should hide the tooltip if it was visible and there are no fields now", function() {
+    tooltip.setFields([{
+      name:'test2'
+    }]);
+    tooltip.enable();
+
+    // mouseover a layer whose tooltip has fields
+    layer.trigger('mouseover', new $.Event('e'), [0, 0], [0, 0], { name: 'wadus' });
+
+    // Tooltip is visible
+    expect(tooltip.showing).toBeTruthy();
+
+    tooltip.setFields([]);
+
+    // mouseover a layer whose tooltip doesn NOT has fields
+    layer.trigger('mouseover', new $.Event('e'), [0, 0], [0, 0], {});
+
+    // Tooltip is hidden
+    expect(tooltip.showing).toBeFalsy();
+  })
 
   it ("should use alternate_names ", function() {
     tooltip.setTemplate('{{#fields}}{{{ title }}},{{/fields}}');


### PR DESCRIPTION
This fixes cartodb/cartodb#3617. The problems were:

1. There was a layer filled with features (timezones) on top of the map. So we were hovering a feature all the time.
2. We were adding the tooltip cause the other layer had a tooltip (with fields) and we were not checking if layers have fields in the tooltip when we enable.

This PR fixes that by preventing a tooltip from being shown if there are no fields.

cc// @javisantana 
