### PR TITLE
Updates torque to 2.11.3

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@
 * Expose legend model in sublayers/layers so that users can customize legends (#480).
 * Handle tooltip overflow (#482).
 * Only show tooltips when they have fields (#486).
+* Updated Torque to 2.11.3
 
 3.14.2 (06//05//2015)
 * Allow to specify a template for the items of a custom legend.


### PR DESCRIPTION
Changes since last update:
>- Limited sprite radius to a maximum of 255px
>- Fixed custom marker-file functionality in Firefox
>- **Fixed inertia mismatch of Torque's canvas layer**
>- Added opacity get/setter to canvas layer in Google Maps
>- Fixed issue with `_super` being removed from listeners

@javisantana 