### PR TITLE
Only show legends and torque controls for visible layers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@
 * Expose legend model in sublayers/layers so that users can customize legends (#480).
 * Handle tooltip overflow (#482).
 * Only show tooltips when they have fields (#486).
+* Only display legends and torque controls when layers are visible.
 
 3.14.2 (06//05//2015)
 * Allow to specify a template for the items of a custom legend.

--- a/src/geo/ui/tooltip.js
+++ b/src/geo/ui/tooltip.js
@@ -51,10 +51,7 @@ cdb.geo.ui.Tooltip = cdb.geo.ui.InfoBox.extend({
       this.options.layer.unbind(null, null, this);
       this.options.layer
         .on('mouseover', function(e, latlng, pos, data) {
-<<<<<<< HEAD
 
-=======
->>>>>>> origin/develop
           if (this.options.fields && this.options.fields.length > 0) {
 
             var non_valid_keys = ['fields', 'content'];

--- a/src/geo/ui/tooltip.js
+++ b/src/geo/ui/tooltip.js
@@ -51,9 +51,8 @@ cdb.geo.ui.Tooltip = cdb.geo.ui.InfoBox.extend({
       this.options.layer.unbind(null, null, this);
       this.options.layer
         .on('mouseover', function(e, latlng, pos, data) {
-          // this flag is used to be compatible with previous templates
-          // where the data is not enclosed a content variable
-          if (this.options.fields) {
+
+          if (this.options.fields && this.options.fields.length > 0) {
 
             var non_valid_keys = ['fields', 'content'];
 
@@ -79,9 +78,15 @@ cdb.geo.ui.Tooltip = cdb.geo.ui.InfoBox.extend({
                 f.title = names[f.title] || f.title;
               }
             }
+
+            this.show(pos, data);
+            this.showing = true;
+          } else {
+            if (this.showing) {
+              this.hide();
+              this.showing = false;
+            }
           }
-          this.show(pos, data);
-          this.showing = true;
         }, this)
         .on('mouseout', function() {
           if (this.showing) {

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -513,7 +513,7 @@ var Vis = cdb.core.View.extend({
   _addTimeSlider: function() {
     var self = this;
     var torque = _(this.getLayers()).find(function(layer) {
-      return layer.model.get('type') === 'torque';
+      return layer.model.get('type') === 'torque' && layer.model.get('visible');
     });
     if (torque) {
       this.torqueLayer = torque;
@@ -832,8 +832,10 @@ var Vis = cdb.core.View.extend({
     for (var i = layers.length - 1; i >= 0; --i) {
       var cid = layers.at(i).cid;
       var layer = layers.at(i).attributes
-      var layerView = this.mapView.getLayerByCid(cid);
-      legends.push(this._createLayerLegendView(layer, layerView));
+      if (layer.visible) {
+        var layerView = this.mapView.getLayerByCid(cid);
+        legends.push(this._createLayerLegendView(layer, layerView));
+      }
     }
     return _.flatten(legends);
   },

--- a/test/spec/geo/ui/tooltip.spec.js
+++ b/test/spec/geo/ui/tooltip.spec.js
@@ -1,4 +1,3 @@
-
 describe('cdb.geo.Tooltip', function() {
 
   var tooltip, layer, container, mapView;
@@ -45,7 +44,25 @@ describe('cdb.geo.Tooltip', function() {
       huracan: 'hurecan'
     });
     expect(tooltip.$el.html()).not.toEqual('test2,test1,huracan,');
+  });
 
+  it ("should show the tooltip on mouseover if model has fields", function() {
+    tooltip.setFields([{ name: 'test2' }]);
+    tooltip.enable();
+    layer.trigger('mouseover', new $.Event('e'), [0, 0], [0, 0], {
+      test2: 'test2'
+    });
+
+    expect(tooltip.showing).toBeTruthy();
+  });
+
+  it ("should not show the tooltip on mouseover if model has no fields", function() {
+    tooltip.setFields([]);
+    tooltip.enable();
+
+    layer.trigger('mouseover', new $.Event('e'), [0,0], [0, 0], { });
+
+    expect(tooltip.showing).toBeFalsy();
   });
 
   it ("should use alternate_names ", function() {

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -37,7 +37,6 @@ describe("Vis", function() {
 
     this.vis = new cdb.vis.Vis({el: this.container});
     this.vis.load(this.mapConfig);
-
   })
 
   it("should insert  default max and minZoom values when not provided", function() {
@@ -406,8 +405,6 @@ describe("Vis", function() {
   });
 
   it ("should load modules", function(done) {
-    // var self = this;
-    console.log(this.vis);
     this.mapConfig.layers = [
       {kind: 'torque', options: { tile_style: 'test', user_name: 'test', table_name: 'test'}}
     ];
@@ -446,4 +443,94 @@ describe("Vis", function() {
     expect(this.vis.map.layers.at(0).get('type')).toEqual('GMapsBase');
   });
 
+  describe("Legends", function() {
+
+    it('should only display legends for visible layers', function() {
+      this.mapConfig.layers = [
+        {
+          kind: 'tiled',
+          legend: {
+            type: "custom",
+            show_title: false,
+            title: "",
+            template: "",
+            items: [
+              {
+                name: "visible legend item",
+                visible: true,
+                value: "#cccccc",
+                sync: true
+              }
+            ]
+          },
+          options: {
+            urlTemplate: 'https://dnv9my2eseobd.cloudfront.net/v3/{z}/{x}/{y}.png'
+          }
+        },
+        {
+          visible: false,
+          kind: 'tiled',
+          legend: {
+            type: "custom",
+            show_title: false,
+            title: "",
+            template: "",
+            items: [
+              {
+                name: "invisible legend item",
+                visible: true,
+                value: "#cccccc",
+                sync: true
+              }
+            ]
+          },
+          options: {
+            urlTemplate: 'https://dnv9my2eseobd.cloudfront.net/v3/{z}/{x}/{y}.png'
+          }
+        }
+      ]
+      this.vis.load(this.mapConfig);
+
+      expect(this.vis.legends.$('.cartodb-legend').length).toEqual(1);
+      expect(this.vis.legends.$el.html()).toContain('visible legend item');
+      expect(this.vis.legends.$el.html()).not.toContain('invisible legend item');
+    })
+  })
+
+  describe("Torque time slider", function() {
+
+    beforeEach(function() {
+      // Load torque module
+      cartodb.torque = torque;
+    })
+
+    it ("should display the time slider if a torque layer is present", function(done) {
+      this.mapConfig.layers = [
+        {
+          kind: 'torque',
+          options: { user_name: 'test', table_name: 'test', tile_style: 'Map { -torque-frame-count: 10;} #test { marker-width: 10; }'}
+        }
+      ];
+
+      this.vis.load(this.mapConfig).done(function(vis, layers){
+        expect(vis.timeSlider).toBeDefined();
+        done();
+      });
+    });
+
+    it ("should NOT display the time slider if a torque layer is not visible", function(done) {
+      this.mapConfig.layers = [
+        {
+          kind: 'torque',
+          visible: false,
+          options: { user_name: 'test', table_name: 'test', tile_style: 'Map { -torque-frame-count: 10;} #test { marker-width: 10; }'}
+        }
+      ];
+
+      this.vis.load(this.mapConfig).done(function(vis, layers){
+        expect(vis.timeSlider).toBeUndefined();
+        done();
+      });
+    });
+  })
 });


### PR DESCRIPTION
Fixes cartodb/cartodb#3351.

With this PR, cartodb.js will only:

- Display legends for visible layers.
- Display torque controls if torque layer is visible.

@fdansv can you please take a look? thanks!