### PR TITLE
Fix issue with infowindow scrolling due to slow image loading:

### DIFF
--- a/src/geo/ui/infowindow.js
+++ b/src/geo/ui/infowindow.js
@@ -347,8 +347,8 @@ cdb.geo.ui.Infowindow = cdb.core.View.extend({
         var actual_height = self.$(".cartodb-popup-content").outerHeight();
         if (self.model.get('maxHeight') <= actual_height)
           self.$(".cartodb-popup-content").jScrollPane({
-            maintainPosition:       false,
-            verticalDragMinHeight:  20
+            verticalDragMinHeight: 20,
+            autoReinitialise: true
           });
       }, 1);
 


### PR DESCRIPTION
Fixes cartodb/cartodb#3515:

- Enables jscrollpane's autoReinitialise option so that the plugin
  correctly scrolls after the image has been loaded.
- Enables jscrollpane's maintainPosition option.

More info about these options [here](http://jscrollpane.kelvinluck.com/settings.html).

Before:

![before](https://cloud.githubusercontent.com/assets/390398/7796759/186a0704-02e3-11e5-98dd-7f0681ba677d.gif)

After:

![after](https://cloud.githubusercontent.com/assets/390398/7796761/1e816d4e-02e3-11e5-8b15-30662e599627.gif)

@xavijam PTAL. Thanks!

