### PR TITLE
Unbind dropdown bound events on clean

### DIFF
--- a/src/ui/common/dropdown.js
+++ b/src/ui/common/dropdown.js
@@ -138,6 +138,12 @@ cdb.ui.common.Dropdown = cdb.core.View.extend({
     this.isOpen = true;
   },
 
+  clean: function() {
+    $(this.options.target).unbind({"click": this._handleClick});
+    $(document).unbind('keydown', this._keydown);
+    cdb.core.View.prototype.clean.apply(this, arguments);
+  },
+
   _fireClick: function(ev) {
     this.trigger("optionClicked", ev, this.el);
   }

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -262,6 +262,8 @@
   
   <script src="spec/ui/common/dialog.spec.js"></script>
   
+  <script src="spec/ui/common/dropdown.spec.js"></script>
+  
   <script src="spec/ui/common/notification.spec.js"></script>
   
   <script src="spec/ui/common/table.spec.js"></script>

--- a/test/spec/ui/common/dropdown.spec.js
+++ b/test/spec/ui/common/dropdown.spec.js
@@ -1,0 +1,44 @@
+describe('common.ui.Dropdown', function() {
+  beforeEach(function() {
+    this.$el = $('<div><button id="btn"></button></div>');
+    this.view = new cdb.ui.common.Dropdown({
+      el: $('<div>'),
+      target: this.$el.find('#btn')
+    });
+  });
+
+  describe('.clean', function() {
+    it('should unbind click handler on target', function() {
+      this.targetClickSpy = jasmine.createSpy('click');
+      this.$el.on('click', this.targetClickSpy);
+
+      // Event should not bubble up since there is a handler that prevents it
+      this.$el.find('#btn').click();
+      expect(this.targetClickSpy).not.toHaveBeenCalled();
+
+      // Verify click bubbles up as expected again
+      this.view.clean();
+      this.$el.find('#btn').click();
+      expect(this.targetClickSpy).toHaveBeenCalled();
+    });
+
+    it('should unbind event handlers on document', function() {
+      // spy on internal call, since spying on _keydown fn do not work for some reason
+      spyOn(this.view, 'hide');
+      var keyEsc = function() {
+        var e = $.Event('keydown');
+        e.keyCode = 27; // ESC
+        $(document).trigger(e);
+      };
+
+      // Should hide on ESC
+      keyEsc();
+      expect(this.view.hide).toHaveBeenCalled();
+
+      // Callback should not be triggered again
+      this.view.clean();
+      keyEsc();
+      expect(this.view.hide.calls.count()).toEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #491, by overriding clean to unbind the event bindings done on none-view elements in the constructor.