### PR TITLE
Do not enable layer interaction if tooltip is empty

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+3.X.X ()
+* Do not enable layer interaction if tooltip is empty (#513)
+
 3.14.3 (29//05//2015)
 * Hide <img> tag of infowindow covers when the url is invalid.
 * Expose legend model in sublayers/layers so that users can customize legends (#480).

--- a/src/geo/layer_definition.js
+++ b/src/geo/layer_definition.js
@@ -530,7 +530,11 @@ MapBase.prototype = {
   },
 
   getTooltipData: function(layer) {
-    return this.layers[layer].tooltip;
+    var tooltip = this.layers[layer].tooltip;
+    if (tooltip && tooltip.fields && tooltip.fields.length) {
+      return tooltip
+    }
+    return null;
   },
 
   getInfowindowData: function(layer) {

--- a/src/geo/layer_definition.js
+++ b/src/geo/layer_definition.js
@@ -532,7 +532,7 @@ MapBase.prototype = {
   getTooltipData: function(layer) {
     var tooltip = this.layers[layer].tooltip;
     if (tooltip && tooltip.fields && tooltip.fields.length) {
-      return tooltip
+      return tooltip;
     }
     return null;
   },

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -1117,7 +1117,7 @@ var Vis = cdb.core.View.extend({
     }
     for(var i = 0; i < layerView.getLayerCount(); ++i) {
       var t = layerView.getTooltipData(i);
-      if (t) {
+      if (t && t.fields && t.fields.length) {
         if (!layerView.tooltip) {
           var tooltip = new cdb.geo.ui.Tooltip({
             mapView: this.mapView,

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -1117,7 +1117,7 @@ var Vis = cdb.core.View.extend({
     }
     for(var i = 0; i < layerView.getLayerCount(); ++i) {
       var t = layerView.getTooltipData(i);
-      if (t && t.fields && t.fields.length) {
+      if (t) {
         if (!layerView.tooltip) {
           var tooltip = new cdb.geo.ui.Tooltip({
             mapView: this.mapView,

--- a/test/spec/geo/layer_definition.spec.js
+++ b/test/spec/geo/layer_definition.spec.js
@@ -83,6 +83,32 @@ describe("LayerDefinition", function() {
     });
   });
 
+  describe("getTooltipData", function() {
+
+    it ('should return tooltip data if tooltip is present and has fields', function() {
+      var tooltip = layerDefinition.getTooltipData(0);
+      expect(tooltip).toEqual({ fields: ['wadus'] });
+    });
+
+    it ('should return NULL if tooltip is not present or does NOT have fields', function() {
+      layerDefinition.layers = [{
+        tooltip: {}
+      }];
+
+      var tooltip = layerDefinition.getTooltipData(0);
+      expect(tooltip).toBeNull()
+
+      layerDefinition.layers = [{
+        tooltip: {
+          fields: []
+        }
+      }];
+
+      var tooltip = layerDefinition.getTooltipData(0);
+      expect(tooltip).toBeNull()
+    });
+  })
+
   describe('.toJSON', function() {
 
     it("should return json spec of visible layers", function() {

--- a/test/spec/geo/layer_definition.spec.js
+++ b/test/spec/geo/layer_definition.spec.js
@@ -86,6 +86,12 @@ describe("LayerDefinition", function() {
   describe("getTooltipData", function() {
 
     it ('should return tooltip data if tooltip is present and has fields', function() {
+      layerDefinition.layers = [{
+        tooltip: {
+          fields: ['wadus']
+        }
+      }];
+
       var tooltip = layerDefinition.getTooltipData(0);
       expect(tooltip).toEqual({ fields: ['wadus'] });
     });


### PR DESCRIPTION
Fixes cartodb/cartodb#3949.

We're enabling interaction on every sublayer created using the editor and that was causing some issues. We should only enable interaction when tooltips have 

@javierarce can you PTAL? Thanks!