### PR TITLE
Use the right indexes when fetching grids and attributes

### DIFF
--- a/src/geo/layer_definition.js
+++ b/src/geo/layer_definition.js
@@ -1,3 +1,33 @@
+/**
+ * Wrapper for map properties returned by the tiler
+ */
+function MapProperties(mapProperties) {
+  this.mapProperties = mapProperties;
+}
+
+MapProperties.prototype.getMapId = function() {
+  return this.mapProperties.layergroupid;
+}
+
+/**
+ * Returns the index of a layer of a given type, as the tiler kwows it.
+ */
+MapProperties.prototype.getLayerIndexByType = function(index, layerType) {
+  var layers = this.mapProperties.metadata.layers;
+  var tilerLayerIndex = {}
+  var j = 0;
+  for (var i = 0; i < layers.length; i++) {
+    if (layers[i].type == layerType) {
+      tilerLayerIndex[j] = i;
+      j++;
+    }
+  }
+  if (tilerLayerIndex[index] == undefined) {
+    return -1;
+  }
+  return tilerLayerIndex[index];
+}
+
 function MapBase(options) {
   var self = this;
   this.options = _.defaults(options, {
@@ -12,7 +42,7 @@ function MapBase(options) {
     }
   });
 
-  this.layerToken = null;
+  this.mapProperties = null;
   this.urls = null;
   this.silent = false;
   this.interactionEnabled = []; //TODO: refactor, include inside layer
@@ -248,7 +278,6 @@ MapBase.prototype = {
     }
   },
 
-  // for named maps, attributes are fetched from the attributes service
   fetchAttributes: function(layer_index, feature_id, columnNames, callback) {
     this._attrCallbackName = this._attrCallbackName || this._callbackName();
     var ajax = this.options.ajax;
@@ -275,27 +304,27 @@ MapBase.prototype = {
   },
 
   invalidate: function() {
-    this.layerToken = null;
+    this.mapProperties = null;
     this.urls = null;
     this.onLayerDefinitionUpdated();
   },
 
   getTiles: function(callback) {
     var self = this;
-    if(self.layerToken) {
-      callback && callback(self._layerGroupTiles(self.layerToken, self.options.extra_params));
+    if(self.mapProperties) {
+      callback && callback(self._layerGroupTiles(self.mapProperties, self.options.extra_params));
       return this;
     }
     this.getLayerToken(function(data, err) {
       if(data) {
-        self.layerToken = data.layergroupid;
+        self.mapProperties = new MapProperties(data);
         // if cdn_url is present, use it
         if (data.cdn_url) {
           var c = self.options.cdn_url = self.options.cdn_url || {};
           c.http = data.cdn_url.http || c.http;
           c.https = data.cdn_url.https || c.https;
         }
-        self.urls = self._layerGroupTiles(data.layergroupid, self.options.extra_params);
+        self.urls = self._layerGroupTiles(self.mapProperties, self.options.extra_params);
         callback && callback(self.urls);
       } else {
         if ((self.named_map !== null) && (err) ){
@@ -316,7 +345,8 @@ MapBase.prototype = {
     return this.options.maps_api_template.indexOf('https') === 0;
   },
 
-  _layerGroupTiles: function(layerGroupId, params) {
+  _layerGroupTiles: function(mapProperties, params) {
+    var layerGroupId = mapProperties.getMapId();
     var subdomains = this.options.subdomains || ['0', '1', '2', '3'];
     if(this.isHttps()) {
       subdomains = [null]; // no subdomain
@@ -334,8 +364,9 @@ MapBase.prototype = {
 
       var gridParams = this._encodeParams(params, this.options.gridParams);
       for(var layer = 0; layer < this.layers.length; ++layer) {
+        var index = mapProperties.getLayerIndexByType(layer, "mapnik");
         grids[layer] = grids[layer] || [];
-        grids[layer].push(cartodb_url + "/" + layer +  tileTemplate + ".grid.json" + (gridParams ? "?" + gridParams: ''));
+        grids[layer].push(cartodb_url + "/" + index +  tileTemplate + ".grid.json" + (gridParams ? "?" + gridParams: ''));
       }
     }
 
@@ -800,15 +831,12 @@ LayerDefinition.prototype = _.extend({}, MapBase.prototype, {
   },
 
   _attributesUrl: function(layer, feature_id) {
-    // /api/maps/:map_id/:layer_index/attributes/:feature_id
     var host = this._host();
     var url = [
       host,
-      //'api',
-      //'v1',
       MapBase.BASE_URL.slice(1),
-      this.layerToken,
-      this.getLayerIndexByNumber(layer),
+      this.mapProperties.getMapId(),
+      this.mapProperties.getLayerIndexByType(layer, "mapnik"),
       'attributes',
       feature_id].join('/');
 
@@ -923,15 +951,12 @@ NamedMap.prototype = _.extend({}, MapBase.prototype, {
   },
 
   _attributesUrl: function(layer, feature_id) {
-    // /api/maps/:map_id/:layer_index/attributes/:feature_id
     var host = this._host();
     var url = [
       host,
-      //'api',
-      //'v1',
       MapBase.BASE_URL.slice(1),
-      this.layerToken,
-      layer,
+      this.mapProperties.getMapId(),
+      this.mapProperties.getLayerIndexByType(layer, "mapnik"),
       'attributes',
       feature_id].join('/');
 


### PR DESCRIPTION
Fixes #518. We know use the metadata returned by the tiler to determine the right indexes of mapnik layers in the map (anonymous or named map). This is important in when generating the urls for grids and the urls to fetch the attributes of mapnik layers.

@javisantana, what do you think?