### PR TITLE
Makes the slider have the correct range every time it changes

### DIFF
--- a/src/geo/ui/time_slider.js
+++ b/src/geo/ui/time_slider.js
@@ -195,7 +195,9 @@ cdb.geo.ui.TimeSlider = cdb.geo.ui.InfoBox.extend({
       start: this._start,
       slide: this._slide
     });
-    this.updateSliderRange({"steps": torqueLayer.provider.getSteps()});
+    if(torqueLayer.provider){
+      this.updateSliderRange({"steps": torqueLayer.provider.getSteps()});
+    }
   },
 
   toggleTime: function(e) {

--- a/src/geo/ui/time_slider.js
+++ b/src/geo/ui/time_slider.js
@@ -195,6 +195,7 @@ cdb.geo.ui.TimeSlider = cdb.geo.ui.InfoBox.extend({
       start: this._start,
       slide: this._slide
     });
+    this.updateSliderRange({"steps": torqueLayer.provider.getSteps()});
   },
 
   toggleTime: function(e) {


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/3951

... by using always the number of steps given by the torque provider, as opposed to the one in the cartocss properties.

@javisantana 