### PR TITLE
Uses local time in timeslider instead of UTC

### DIFF
--- a/src/geo/ui/time_slider.js
+++ b/src/geo/ui/time_slider.js
@@ -117,11 +117,11 @@ cdb.geo.ui.TimeSlider = cdb.geo.ui.InfoBox.extend({
     }
 
     function toUSDateStr(date) {
-      return pad(date.getUTCMonth() + 1) + "/" + pad(date.getUTCDate()) + "/" + pad(date.getUTCFullYear());
+      return pad(date.getMonth() + 1) + "/" + pad(date.getDate()) + "/" + pad(date.getFullYear());
     }
 
     function toTimeStr(date) {
-      return pad(date.getUTCHours()) + ":" + pad(date.getUTCMinutes());
+      return pad(date.getHours()) + ":" + pad(date.getMinutes());
     }
 
     function toDateRange(date, torqueLayer) {
@@ -130,14 +130,14 @@ cdb.geo.ui.TimeSlider = cdb.geo.ui.InfoBox.extend({
       var stepDurationMS = (new Date(tb.end).getTime() - new Date(tb.start).getTime()) / torqueLayer.options.steps;
       var stepEndTime = new Date(stepStartTimeMS + stepDurationMS);
       var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-      return pad(months[date.getUTCMonth()]) + " " + pad(date.getUTCDate())  + " - " 
-        + pad(months[stepEndTime.getUTCMonth()]) + " " + pad(stepEndTime.getUTCDate());
+      return pad(months[date.getMonth()]) + " " + pad(date.getDate())  + " - " 
+        + pad(months[stepEndTime.getMonth()]) + " " + pad(stepEndTime.getDate());
     }
 
     
 
     if (range < THREE_DAYS) {
-      if (start.getUTCDate() === end.getUTCDate()) {
+      if (start.getDate() === end.getDate()) {
         return toTimeStr;
       } else {
         // range is less than a day, but the range spans more than one day so render the date in addition to the time
@@ -156,7 +156,7 @@ cdb.geo.ui.TimeSlider = cdb.geo.ui.InfoBox.extend({
 
     // >= ONE_YEAR
     return function(date) {
-      return pad(date.getUTCMonth() + 1) + "/" + pad(date.getUTCFullYear());
+      return pad(date.getMonth() + 1) + "/" + pad(date.getFullYear());
     };
   },
 

--- a/test/spec/geo/ui/time_slider.spec.js
+++ b/test/spec/geo/ui/time_slider.spec.js
@@ -31,9 +31,9 @@ describe('cdb.geo.ui.TimeSlider', function() {
         formatter = view.formatterForRange(start, end)
       });
 
-      it("should return a formatter function that renders the UTC time of given moment", function() {
+      it("should return a formatter function that renders the local time of given moment", function() {
         var moment = new Date("2014-11-19T15:04:00Z");
-        expect(formatter(moment)).toEqual("15:04");
+        expect(formatter(moment)).toEqual("16:04");
       });
     });
 

--- a/test/spec/geo/ui/time_slider.spec.js
+++ b/test/spec/geo/ui/time_slider.spec.js
@@ -98,9 +98,9 @@ describe('cdb.geo.ui.TimeSlider', function() {
         formatter = view.formatterForRange(start, end)
       });
 
-      it("should return a formatter function that renders both date and UTC time", function() {
+      it("should return a formatter function that renders both date and local time", function() {
         var moment = new Date("2014-11-20T01:16:00Z");
-        expect(formatter(moment)).toEqual("11/20/2014 01:16")
+        expect(formatter(moment)).toEqual("02:16")
       });
     });
   });


### PR DESCRIPTION
![nogmt](https://cloud.githubusercontent.com/assets/3707222/8282375/80146660-18f0-11e5-8f87-eb3a194b8292.gif)

Fixes https://github.com/CartoDB/cartodb/issues/4135
@alonsogarciapablo mind a quick CR? :)

cc @saleiva