### PR TITLE
Take `visible` attribute into account when serialising maps 

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+3.X ()
+* Take `visible` attribute into account when determining visibility of layers and serializing maps (#546)
+
 3.15 (24//06//2015)
 * cartodb.js knows how to work with multiple types of sublayers (#508):
   * cartodb.createLayer accepts a `filter` option to specify wich types of layers must

--- a/src/geo/layer_definition.js
+++ b/src/geo/layer_definition.js
@@ -612,11 +612,19 @@ MapBase.prototype = {
     var layers = [];
     for(var i = 0; i < this.layers.length; ++i) {
       var layer = this.layers[i];
-      if(layer.options && !layer.options.hidden) {
+      if (this._isLayerVisible(layer)) {
         layers.push(layer);
       }
     }
     return layers;
+  },
+
+  _isLayerVisible: function(layer) {
+    if (layer.options && 'hidden' in layer.options) {
+      return !layer.options.hidden;
+    }
+
+    return layer.visible !== false;
   },
 
   setLayer: function(layer, def) {
@@ -952,7 +960,7 @@ NamedMap.prototype = _.extend({}, MapBase.prototype, {
     var payload = this.named_map.params || {};
     for(var i = 0; i < this.layers.length; ++i) {
       var layer = this.layers[i];
-      payload['layer' + i] = layer.options.hidden ? 0: 1;
+      payload['layer' + i] = this._isLayerVisible(layer) ? 1 : 0;
     }
     return payload;
   },

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -199,8 +199,6 @@ var Vis = cdb.core.View.extend({
             this.timeSlider.hide();
           }
         }
-      } else {
-        if (o.visible === false) subLayer.hide();
       }
     }
   },

--- a/test/spec/geo/layer_definition.spec.js
+++ b/test/spec/geo/layer_definition.spec.js
@@ -86,7 +86,8 @@ describe("LayerDefinition", function() {
             sql: 'select * from ne_10m_populated_places_simple',
             cartocss: '#layer { marker-fill: red; }',
             interactivity: ['test', 'cartodb_id']
-          }
+          },
+          visible: true
         },
         {
           type: 'cartodb',
@@ -95,7 +96,8 @@ describe("LayerDefinition", function() {
             cartocss: '#layer { polygon-fill: #000; polygon-opacity: 0.8;}',
             cartocss_version : '2.0.0',
             interactivity: ['       test2    ', 'cartodb_id2']
-          }
+          },
+          visible: true
         }
       ]
     };
@@ -115,13 +117,14 @@ describe("LayerDefinition", function() {
       layerDefinition.removeLayer(0);
       expect(layerDefinition.getLayerCount()).toEqual(1);
       expect(layerDefinition.getLayer(0)).toEqual({
-         type: 'cartodb', 
-         options: {
-           sql: "select * from european_countries_export",
-           cartocss: '#layer { polygon-fill: #000; polygon-opacity: 0.8;}',
-           cartocss_version: '2.0.0',
-           interactivity: ['       test2    ', 'cartodb_id2']
-         }
+        type: 'cartodb', 
+        options: {
+          sql: "select * from european_countries_export",
+          cartocss: '#layer { polygon-fill: #000; polygon-opacity: 0.8;}',
+          cartocss_version: '2.0.0',
+          interactivity: ['       test2    ', 'cartodb_id2']
+        },
+        visible: true
       });
     });
   });
@@ -260,21 +263,17 @@ describe("LayerDefinition", function() {
     });
 
     it("should not include hidden layers", function() {
+      // Hide layer 0 using sublayer.hide
       layerDefinition.getSubLayer(0).hide();
 
+      // Hide layer 1 updating visible
+      layerDefinition.layers[1].visible = false;
+
+      // No layers are present
       expect(layerDefinition.toJSON()).toEqual({
         version: '1.0.0',
         stat_tag: 'vis_id',
-        layers: [{
-           type: 'cartodb', 
-           options: {
-             sql: "select * from european_countries_export",
-             cartocss: '#layer { polygon-fill: #000; polygon-opacity: 0.8;}',
-             cartocss_version: '2.0.0',
-             interactivity: ['test2', 'cartodb_id2']
-           }
-         }
-        ]
+        layers: []
       });
     });
   });
@@ -292,6 +291,7 @@ describe("LayerDefinition", function() {
       expect(layerDefinition.getLayerNumberByIndex(0)).toEqual(1);
       expect(layerDefinition.getLayerNumberByIndex(1)).toEqual(-1);
 
+      expect(layerDefinition.getLayerIndexByNumber(0)).toEqual(0);
       expect(layerDefinition.getLayerIndexByNumber(1)).toEqual(0);
     });
   });
@@ -1337,6 +1337,11 @@ describe("NamedMap", function() {
               "hidden": true
             }
           },
+          {
+            "type": "cartodb",
+            "options": { },
+            "visible": false
+          }
         ]
       };
       var namedMap = new NamedMap(config, {});
@@ -1345,7 +1350,8 @@ describe("NamedMap", function() {
       expect(namedMap.toJSON()).toEqual({
         layer0: 1,
         layer1: 1,
-        layer2: 0
+        layer2: 0,
+        layer3: 0
       });
     })
   })


### PR DESCRIPTION
Fixes #541. We were using `options.hidden` to determine if layers in "LayerDefinition"s or "NamedMap"s were visible.  But that is something that only gets set after invoking `sublayer.hide()` or `sublayer.show()`. With this PR, we also take into account the `visible` attribute that (sub)layers have in viz.json files so that layers are correctly displayed after loading a viz.json file.

@javisantana, can you please take a look at this? Thanks!

