### PR TITLE
prepare for bower

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/SpecRunner.html
 .rvmrc
 .idea/
 themes/css/cartodb.css
+cartodb.js-bower/

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ This library allows to embed visualizations created with CartoDB in your map or 
       cartodb.createLayer(map, layerUrl).addTo(map);
     ```
 
+### Usage with Bower
+
+You can install **cartodb.js** with [bower](http://bower.io/) by running
+
+```sh
+bower install cartodb.js
+```
+
+
 ## Documentation
 You can find the documentation online [here](http://docs.cartodb.com/cartodb-platform/cartodb-js.html) and the [source](https://github.com/CartoDB/cartodb.js/blob/develop/doc/API.md) inside this repository.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,6 +51,12 @@ git push --all
 git push --tags
 ```
 
+- Publish to the [cartodb.js bower repo](https://github.com/CartoDB/cartodb.js-bower)
+
+```
+./bower.sh
+```
+
 - If possible, don't forget to change CartoDB.js docs.
 
 - Done. Celebrate! :)

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,8 @@
 {
   "name": "cartodb.js",
   "main": [
-    "dist/cartodb.js",
-    "dist/themes/css/cartodb.css"
+    "cartodb.js",
+    "themes/css/cartodb.css"
   ],
   "version": "3.15.1",
   "homepage": "https://github.com/CartoDB/cartodb.js",

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,20 @@
 {
   "name": "cartodb.js",
-  "version": "0.0.1",
-  "dependencies": {},
-  "devDependencies": {
-    "backbone": "~1.1.2",
-    "modernizr": "~2.8.3",
-    "jquery": "~2.1.1"
-  }
+  "main": [
+    "dist/cartodb.js",
+    "dist/themes/css/cartodb.css"
+  ],
+  "version": "3.15.1",
+  "homepage": "https://github.com/CartoDB/cartodb.js",
+  "authors": [
+    "CartoDB <support@cartodb.com>"
+  ],
+  "description": "CartoDB javascript library",
+  "license": "BSD",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test"
+  ]
 }

--- a/bower.sh
+++ b/bower.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Script for updating the cartodb.js bower repo from current local build.
+
+echo "#################################"
+echo "#### Update bower ###############"
+echo "#################################"
+
+ORG=CartoDB
+REPO=cartodb.js-bower
+
+# prepare repo folder
+if [ -d $REPO ]
+  then
+    rm -rf $REPO
+fi
+
+# clone repo
+echo "-- Cloning $REPO"
+git clone git@github.com:$ORG/$REPO.git
+
+# clean up cloned files
+rm -rf $REPO/*
+
+# move js files from the build
+cp -r dist/cartodb*.js $REPO/
+
+# move css and images files from the build
+mkdir $REPO/themes/ && cp -r dist/themes/* $REPO/themes/
+
+cp -R bower.json $REPO/bower.json
+
+cp -R LICENSE $REPO/LICENSE.md
+
+# commit and tag repo
+echo "-- Committing and tagging $REPO"
+cd $REPO
+git add -A
+CARTODBJS_VER=$(git diff bower.json | grep version | cut -d':' -f2 | cut -d'"' -f2 | sort -g -r | head -1) && if [ $(echo $CARTODBJS_VER | wc -m | tr -d ' ') = '1' ]; then echo 'VERSION DID NOT CHANGE'; else git tag -a $CARTODBJS_VER -m "Version $CARTODBJS_VER"; fi
+git tag -a $CARTODBJS_VER -m "Version $CARTODBJS_VER"
+git commit -m "v$CARTODBJS_VER"
+
+echo "-- Pushing $REPO"
+git push -fq origin master
+git push -fq origin --tags
+
+cd ..
+
+echo "-- Finished"


### PR DESCRIPTION
as long as we check-in the dist files this issue https://github.com/CartoDB/cartodb.js/issues/367 would be solved

this is for example what Backbone or Bootstrap do
https://github.com/jashkenas/backbone
https://github.com/twbs/bootstrap

or, in order to not to pollute the history the dist files could be pushed to a different repo, like Foundation does after a successful publish

https://github.com/zurb/foundation/blob/master/.travis.yml
https://github.com/zurb/bower-foundation

your call @javisantana @alonsogarciapablo, what do you guys think should be the best approach here?

on the long term, it would be great to pull the dependencies from bower, too