### PR TITLE
adds a way to build the current dist without user input

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -108,8 +108,9 @@ module.exports = function(grunt) {
   grunt.registerTask('test', [ 'jasmine' ]);
 
   grunt.registerTask('release', [
-    'build',
     'prompt:bump',
+    'build',
+    'publish'
   ]);
 
   grunt.registerTask('publish', function (target) {

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,7 +19,7 @@ git flow release start 3.15.1
 - Build CartoDB.js files, choosing the new version:
 
 ```
-grunt build
+grunt release
 ```
 
 - Update the NEWS file and commit the changes. Take into account that new CartoDB.js version will be replaced in ```API.md```, ```RELEASING.md```, ```README.md```, ```package.json```, ```cartodb.js``` and ```examples``` files.
@@ -65,7 +65,7 @@ In case you screw up all things, don't worry, rollback cartodb.js to a previous 
 
 ```
 git checkout PREVIOUS_VERSION_TAG
-grunt build
+grunt
 grunt publish
 ```
 
@@ -73,6 +73,6 @@ For example, if we are in 3.15.1 and we want to go back to 3.13.4
 
 ```
 git checkout 3.13.4
-grunt build
+grunt
 grunt publish
 ```


### PR DESCRIPTION
so now we have:

- dist task to build the current version
- default task is dist
- the release task is the one that ask about new version

there were several problems:
- imagemin was failing silently when prompt task was being run so when it's not run everything failed because a bug in imagemin. Does make sense to use imagemin?
- the build was working by chance, some of the needed variables were being added to the config when they should be part of the config from the start
- grunt was not reporting any error and it took 3 hours to realize then the process freeze