### PR TITLE
Update cartocss.js

### DIFF
--- a/src/api/cartocss.js
+++ b/src/api/cartocss.js
@@ -113,7 +113,7 @@ var CSS = {
         tableID + " {",
         '  marker-width: 3;',
         '  marker-fill-opacity: 0.8;',
-        '  marker-fill: #FEE391; ',
+        '  marker-fill: #FF6347; ',
         '  comp-op: "lighten";',
         '  [value > 2] { marker-fill: #FEC44F; }',
         '  [value > 3] { marker-fill: #FE9929; }',


### PR DESCRIPTION
Changed the default cartocss in pecan to FF6347 (tomato because miguel will be so happy) so it pops more on the light basemap.
i couldn't tell if you had intentionally made it different than the wizard default of 0F3B82 but i thought maybe you were making pecan be different, so i went with different too...

cc / @javierarce @saleiva @fdansv 