### PR TITLE
Fixes bug in annotations when using a Google Maps basemaps

### DIFF
--- a/src/geo/gmaps/gmaps.js
+++ b/src/geo/gmaps/gmaps.js
@@ -226,7 +226,11 @@ if(typeof(google) != "undefined" && typeof(google.maps) != "undefined") {
     },
 
     pixelToLatLon: function(pos) {
-      return this.projector.fromContainerPixelToLatLng(new google.maps.Point(pos[0], pos[1]));
+      var latLng = this.projector.pixelToLatLng(new google.maps.Point(pos[0], pos[1]));
+      return {
+        lat: latLng.k,
+        lng: latLng.D
+      }
     },
 
     latLonToPixel: function(latlon) {

--- a/src/geo/gmaps/gmaps.js
+++ b/src/geo/gmaps/gmaps.js
@@ -228,8 +228,8 @@ if(typeof(google) != "undefined" && typeof(google.maps) != "undefined") {
     pixelToLatLon: function(pos) {
       var latLng = this.projector.pixelToLatLng(new google.maps.Point(pos[0], pos[1]));
       return {
-        lat: latLng.k,
-        lng: latLng.D
+        lat: latLng.lat(),
+        lng: latLng.lng()
       }
     },
 


### PR DESCRIPTION
Fixes cartodb/cartodb-management#4001.

Basically, `this.projector` didn't respond to `fromContainerPixelToLatLng` and this was causing a JS error when moving an annotation through the editor, when the map had a Google Maps basemap.

@javierarce would you mind taking a look at this?

cc/ @iriberri @javisantana 