### PR TITLE
Fix setBounds/fitBounds for map w/o suitable zoom

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -1022,7 +1022,8 @@ You can use the results from `getBounds` to center data on your maps using Leafl
 <div class="code-title">sql.getBounds</div>
 ```javascript
 sql.getBounds('select * from table').done(function(bounds) {
-  map.fitBounds(bounds);
+  map.setBounds(bounds);
+  // or map.fitBounds(bounds, mapView.getSize());
 });
 ```
 

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -504,6 +504,9 @@ cdb.geo.Map = cdb.core.Model.extend({
   // set center and zoom according to fit bounds
   fitBounds: function(bounds, mapSize) {
     var z = this.getBoundsZoom(bounds, mapSize);
+    if(z === null) {
+      return;
+    }
 
     // project -> calculate center -> unproject
     var swPoint = cdb.geo.Map.latlngToMercator(bounds[0], z);
@@ -520,7 +523,8 @@ cdb.geo.Map = cdb.core.Model.extend({
   },
 
   // adapted from leaflat src
-  // @return {Number} Calculated zoom from given bounds, or the maxZoom if no appropriate zoom level could be found
+  // @return {Number, null} Calculated zoom from given bounds or the maxZoom if no appropriate zoom level could be found
+  //   or null if given mapSize has no size.
   getBoundsZoom: function(boundsSWNE, mapSize) {
     // sometimes the map reports size = 0 so return null
     if(mapSize.x === 0 || mapSize.y === 0) return null;

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -504,9 +504,7 @@ cdb.geo.Map = cdb.core.Model.extend({
   // set center and zoom according to fit bounds
   fitBounds: function(bounds, mapSize) {
     var z = this.getBoundsZoom(bounds, mapSize);
-    if(z === null) {
-      return;
-    }
+
     // project -> calculate center -> unproject
     var swPoint = cdb.geo.Map.latlngToMercator(bounds[0], z);
     var nePoint = cdb.geo.Map.latlngToMercator(bounds[1], z);
@@ -522,6 +520,7 @@ cdb.geo.Map = cdb.core.Model.extend({
   },
 
   // adapted from leaflat src
+  // @return {Number} Calculated zoom from given bounds, or the maxZoom if no appropriate zoom level could be found
   getBoundsZoom: function(boundsSWNE, mapSize) {
     // sometimes the map reports size = 0 so return null
     if(mapSize.x === 0 || mapSize.y === 0) return null;
@@ -545,7 +544,7 @@ cdb.geo.Map = cdb.core.Model.extend({
     } while (zoomNotFound && zoom <= maxZoom);
 
     if (zoomNotFound) {
-      return null;
+      return maxZoom;
     }
 
     return zoom - 1;


### PR DESCRIPTION
While working on https://github.com/CartoDB/cartodb/issues/4552 I found that setBounds wasn't working, because the internal code silently aborted, due to zoom level not being returned.

As with http://leafletjs.com/reference.html, `getBoundsZoom` now always returns a number (fallbacks on max zoom if could not found a suitable one), and enabled. fitBounds to also work since it do not have to check for the `null` value anymore.

Also updated docs to use `setBounds` instead since there's no clear reason for why fitBounds should be used.