### PR TITLE
Changes the default basemap ramp to blue to avoid problems with positron

### DIFF
--- a/src/api/cartocss.js
+++ b/src/api/cartocss.js
@@ -246,8 +246,8 @@ function getWeightFromShape(dist_type){
 function getMethodProperties(stats) { // TODO: only require the necessary params
 
   var method;
-  var ramp = ramps.pink;
-  var name = "pink";
+  var ramp = ramps.blue;
+  var name = "blue";
 
   if (['A','U'].indexOf(stats.dist_type) != -1) { // apply divergent scheme
     method = stats.jenks;


### PR DESCRIPTION
Fixes this issue: https://github.com/CartoDB/cartodb/issues/4493