### PR TITLE
Removes line default style from the point generator

### DIFF
--- a/src/api/cartocss.js
+++ b/src/api/cartocss.js
@@ -40,8 +40,6 @@ function getDefaultCSSForGeometryType(geometryType) {
     ];
   }
   return [
-    "line-color: #0C2C84;",
-    "line-opacity: 1;",
     "marker-fill-opacity: 0.9;",
     "marker-line-color: #FFF;",
     "marker-line-width: 1;",


### PR DESCRIPTION
The `getDefaultCSSForGeometryType` method shouldn't give line styles to the points. This should fix CartoDB/cartodb#4748.

Fixes: https://github.com/CartoDB/cartodb.js/issues/627