### PR TITLE
Bump the z-index value

### DIFF
--- a/themes/css/tooltip/cartodb-tooltip-default.css
+++ b/themes/css/tooltip/cartodb-tooltip-default.css
@@ -9,7 +9,7 @@
     min-width:120px;
     max-width:180px;
     overflow-y:hidden;
-    z-index: 5;
+    z-index: 50;
   }
 
   div.cartodb-tooltip-content-wrapper {


### PR DESCRIPTION
From the issue description: 

> Sometimes the z-index of the annotations is greater than the z-index of the tooltip (which by default is 5).

> The solution I propose consists in increasing the z-index value of the tooltips to a number that guarantees that a map with a normal amount of annotations won't produce overlapping.

Original issue: CartoDB/cartodb#4872