### PR TITLE
Only display legends if layer is visible

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 3.X ()
 * Take `visible` attribute into account when determining visibility of layers and serializing maps (#546)
+* Only show legends if the layer is visible (#651)
 
 3.15 (24//06//2015)
 * cartodb.js knows how to work with multiple types of sublayers (#508):

--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,7 @@
 * Remove check for http-beginng vizjson addresses
 * Use local time in timeslider instead of UTC
 * New sublayer.isVisible() function
+* `cartodb.createLayer` selects the first data layer instead of assuming that it's in position 1
 
 3.14.6 (16//06//2015)
 * Use the right indexes when fetching grids and attributes (#518)

--- a/src/geo/ui/legend.js
+++ b/src/geo/ui/legend.js
@@ -899,12 +899,11 @@ cdb.geo.ui.StackedLegend = cdb.core.View.extend({
     }
 
     _.each(this.options.legends, function(item) {
-      var type = item.model.get("type");
-
-      if (type && type != "none") {
-        item.show();
-      } else {
+      var legendModel = item.model;
+      if (legendModel.get("type") === "none" || legendModel.get("visible") === false) {
         item.hide();
+      } else {
+        item.show();
       }
     }, this);
   },

--- a/src/geo/ui/legend.js
+++ b/src/geo/ui/legend.js
@@ -1,8 +1,10 @@
+
+// MODELS & COLLECTIONS
+
 /*
  * Model for the legend item
  *
  * */
-
 cdb.geo.ui.LegendItemModel = cdb.core.Model.extend({
 
   defaults: {
@@ -17,16 +19,65 @@ cdb.geo.ui.LegendItemModel = cdb.core.Model.extend({
  * Collection of items for a legend
  *
  * */
-
 cdb.geo.ui.LegendItems = Backbone.Collection.extend({
   model: cdb.geo.ui.LegendItemModel
 });
+
+
+/*
+ * Legend Model
+ *
+ **/
+cdb.geo.ui.LegendModel = cdb.core.Model.extend({
+
+  defaults: {
+    type: null,
+    show_title: false,
+    title: "",
+    template: "",
+    visible: true
+  },
+
+  initialize: function() {
+
+    this.items = new cdb.geo.ui.LegendItems(this.get("items"));
+
+    this.items.bind("add remove reset change", function() {
+      this.set({ items: this.items.toJSON() });
+    }, this);
+
+    this.bind("change:items", this._onUpdateItems, this);
+    this.bind("change:title change:show_title", this._onUpdateTitle, this);
+    this.bind("change:template", this._onUpdateTemplate, this);
+
+  },
+
+  _onUpdateTemplate: function() {
+    this.template = this.get("template");
+  },
+
+  _onUpdateTitle: function() {
+    this.title = this.get("title");
+    this.show_title = this.get("show_title");
+  },
+
+  _onUpdateItems: function() {
+    var items = this.get("items");
+    this.items.reset(items);
+  }
+
+});
+
+cdb.geo.ui.Legends = Backbone.Collection.extend({
+  model: cdb.geo.ui.LegendModel
+});
+
+// VIEWS
 
 /*
  * Legend item
  *
  * */
-
 cdb.geo.ui.LegendItem = cdb.core.View.extend({
 
   tagName: "li",
@@ -54,7 +105,6 @@ cdb.geo.ui.LegendItem = cdb.core.View.extend({
     this.$el.html(this.template(options));
 
     return this.$el;
-
   }
 
 });
@@ -63,13 +113,11 @@ cdb.geo.ui.LegendItem = cdb.core.View.extend({
  * Legend View: wrapper for the different types of lengeds
  *
  * */
-
 cdb.geo.ui.Legend = cdb.core.View.extend({
 
   className: "cartodb-legend",
 
   events: {
-
     "dragstart":            "_stopPropagation",
     "mousedown":            "_stopPropagation",
     "touchstart":           "_stopPropagation",
@@ -79,11 +127,9 @@ cdb.geo.ui.Legend = cdb.core.View.extend({
     "DOMMouseScroll":       "_stopPropagation",
     "dbclick":              "_stopPropagation",
     "click":                "_stopPropagation"
-
   },
 
   initialize: function() {
-
     _.bindAll(this, "render", "show", "hide");
 
     _.defaults(this.options, this.default_options);
@@ -94,17 +140,13 @@ cdb.geo.ui.Legend = cdb.core.View.extend({
     this._setupItems();
 
     this._updateLegendType();
-
   },
 
   _stopPropagation: function(ev) {
-
     ev.stopPropagation();
-
   },
 
   _setupModel: function() {
-
     if (!this.model) {
 
       this.model = new cdb.geo.ui.LegendModel({
@@ -113,42 +155,39 @@ cdb.geo.ui.Legend = cdb.core.View.extend({
         show_title: this.options.show_title || cdb.geo.ui.LegendModel.prototype.defaults.show_title,
         template: this.options.template || cdb.geo.ui.LegendModel.prototype.defaults.template
       });
-
     }
 
     this.add_related_model(this.model);
 
     //this.model.bind("change:template change:type change:items change:title change:show_title",  this._updateLegendType, this);
     this.model.bind("change",  this._updateLegendType, this);
-
   },
 
   _updateLegendType: function() {
-
     var type = this.model.get("type");
-
     this.legend_name = this._capitalize(type) + "Legend";
 
     if (type == 'none' || type == null) {
-
       this.legend_name = null;
       this.model.set({ type: "none" }, { silent: true });
-
     } else if (!cdb.geo.ui[this.legend_name]) {
 
       // set the previous type
       this.legend_name = null;
       this.model.set({ type: this.model.previous("type") }, { silent: true });
       return;
-
     }
 
     this._refresh();
+  },
 
+  _capitalize: function(string) {
+    if (string && _.isString(string)) {
+      return string.charAt(0).toUpperCase() + string.slice(1);
+    }
   },
 
   _refresh: function() {
-
     var self = this;
 
     if (this.view) this.view.clean();
@@ -159,7 +198,6 @@ cdb.geo.ui.Legend = cdb.core.View.extend({
     var template = this.model.get("template");
 
     if (type && this.legend_name) {
-
       this.view = new cdb.geo.ui[this.legend_name]({
         model: this.model
       });
@@ -167,24 +205,17 @@ cdb.geo.ui.Legend = cdb.core.View.extend({
       // Set the type as the element class for styling
       this.$el.removeClass();
       this.$el.addClass(this.className + " " + this.model.get("type"));
-
-      this.show();
-
     } else {
-
       this.hide();
 
       this.$el.removeClass();
       this.$el.addClass(this.className + " none");
-
     }
 
     this.render();
-
   },
 
   _setupItems: function() {
-
     var self = this;
 
     this.items = this.model.items;
@@ -194,26 +225,9 @@ cdb.geo.ui.Legend = cdb.core.View.extend({
     }
 
     this.items.bind("add remove change:value change:name", this.render, this);
-
-  },
-
-  show: function(callback) {
-    var type = this.model.get("type");
-    if (type && type != "none") this.$el.show();
-  },
-
-  hide: function(callback) {
-    if (this.model.get("type")) this.$el.hide();
-  },
-
-  _capitalize: function(string) {
-    if (string && _.isString(string)) {
-      return string.charAt(0).toUpperCase() + string.slice(1);
-    }
   },
 
   render: function() {
-
     if (this.view) {
 
       if (this.model.get("template")) {
@@ -232,8 +246,16 @@ cdb.geo.ui.Legend = cdb.core.View.extend({
     }
 
     return this;
-  }
+  },
 
+  show: function(callback) {
+    var type = this.model.get("type");
+    if (type && type != "none") this.$el.show();
+  },
+
+  hide: function(callback) {
+    if (this.model.get("type")) this.$el.hide();
+  }
 });
 
 /*
@@ -814,7 +836,6 @@ cdb.geo.ui.Legend.Color = cdb.geo.ui.Legend.Category.extend({ });
 cdb.geo.ui.StackedLegend = cdb.core.View.extend({
 
   events: {
-
     "dragstart":            "_stopPropagation",
     "mousedown":            "_stopPropagation",
     "touchstart":           "_stopPropagation",
@@ -824,25 +845,18 @@ cdb.geo.ui.StackedLegend = cdb.core.View.extend({
     "DOMMouseScroll":       "_stopPropagation",
     "dbclick":              "_stopPropagation",
     "click":                "_stopPropagation"
-
   },
 
   className: "cartodb-legend-stack",
 
   initialize: function() {
-
     _.each(this.options.legends, this._setupBinding, this);
-
   },
 
   _stopPropagation: function(ev) {
-
     ev.stopPropagation();
-
   },
 
-  //TODO: change this method to
-  // getLegendByIndex
   getLegendByIndex: function(index) {
     if (!this._layerByIndex) {
       this._layerByIndex = {};
@@ -856,14 +870,24 @@ cdb.geo.ui.StackedLegend = cdb.core.View.extend({
   },
 
   _setupBinding: function(legend) {
-
     legend.model.bind("change:type", this._checkVisibility, this);
     this.add_related_model(legend.model);
+  },
 
+  render: function() {
+    this._renderItems();
+    this._checkVisibility();
+
+    return this;
+  },
+
+  _renderItems: function() {
+    _.each(this.options.legends, function(item) {
+      this.$el.append(item.render().$el);
+    }, this);
   },
 
   _checkVisibility: function() {
-
     var visible = _.some(this.options.legends, function(legend) {
       return legend.model.get("type") && (legend.model.get("type") != "none"  || legend.model.get("template"))
     }, this);
@@ -875,7 +899,6 @@ cdb.geo.ui.StackedLegend = cdb.core.View.extend({
     }
 
     _.each(this.options.legends, function(item) {
-
       var type = item.model.get("type");
 
       if (type && type != "none") {
@@ -883,18 +906,7 @@ cdb.geo.ui.StackedLegend = cdb.core.View.extend({
       } else {
         item.hide();
       }
-
     }, this);
-
-
-  },
-
-  _renderItems: function() {
-
-    _.each(this.options.legends, function(item) {
-      this.$el.append(item.render().$el);
-    }, this);
-
   },
 
   show: function() {
@@ -907,22 +919,9 @@ cdb.geo.ui.StackedLegend = cdb.core.View.extend({
 
   addTo: function(element) {
     $(element).html(this.render().$el);
-  },
-
-  render: function() {
-
-    this._renderItems();
-    this._checkVisibility();
-
-    return this;
-
   }
-
 });
 
-cdb.geo.ui.Legends = Backbone.Collection.extend({
-  model: cdb.geo.ui.LegendModel
-});
 
 /*
  * Stacked Legend public interface
@@ -1012,51 +1011,6 @@ cdb.geo.ui.Legend.Stacked = cdb.geo.ui.StackedLegend.extend({
     var legend = this.legendItems.at(n);
     this.legendItems.remove(legend);
 
-  }
-
-});
-
-
-/*
- * Legend Model
- *
- * */
-cdb.geo.ui.LegendModel = cdb.core.Model.extend({
-
-  defaults: {
-    type: null,
-    show_title: false,
-    title: "",
-    template: "",
-    visible: true
-  },
-
-  initialize: function() {
-
-    this.items = new cdb.geo.ui.LegendItems(this.get("items"));
-
-    this.items.bind("add remove reset change", function() {
-      this.set({ items: this.items.toJSON() });
-    }, this);
-
-    this.bind("change:items", this._onUpdateItems, this);
-    this.bind("change:title change:show_title", this._onUpdateTitle, this);
-    this.bind("change:template", this._onUpdateTemplate, this);
-
-  },
-
-  _onUpdateTemplate: function() {
-    this.template = this.get("template");
-  },
-
-  _onUpdateTitle: function() {
-    this.title = this.get("title");
-    this.show_title = this.get("show_title");
-  },
-
-  _onUpdateItems: function() {
-    var items = this.get("items");
-    this.items.reset(items);
   }
 
 });

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -802,9 +802,7 @@ var Vis = cdb.core.View.extend({
         options: options,
         torqueLayer: this.torqueLayer
       });
-
     }
-
   },
 
   _createLegendView: function(layer, layerView) {
@@ -813,12 +811,16 @@ var Vis = cdb.core.View.extend({
       var legend = layer.legend;
 
       if ((legend.items && legend.items.length) || legend.template) {
-        var view = new cdb.geo.ui.Legend(layer.legend);
-        layerView.legend = view.model; // cdb.geo.ui.LegendModel
-        layerView.bind('change:visibility', function(layer, hidden) {
-          view[hidden? 'hide': 'show']();
+        var legendAttrs = _.extend(layer.legend, {
+          visible: layer.visible
         });
-        return view;
+        var legendModel = new cdb.geo.ui.LegendModel(legendAttrs);
+        var legendView = new cdb.geo.ui.Legend({ model: legendModel });
+        layerView.bind('change:visibility', function(layer, hidden) {
+          legendView[hidden ? 'hide': 'show']();
+        });
+        layerView.legend = legendModel;
+        return legendView;
       }
     }
     return null;

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -192,9 +192,13 @@
   
   <script src="../src/api/sql.js"></script>
   
+  <script src="../src/api/cartocss.js"></script>
+  
   <script src="../src/api/vis.js"></script>
   
   <script src="spec/SpecHelper.js"></script>
+  
+  <script src="spec/api/cartocss.spec.js"></script>
   
   <script src="spec/api/layers.spec.js"></script>
   

--- a/test/spec/api/layers/cartodb.spec.js
+++ b/test/spec/api/layers/cartodb.spec.js
@@ -99,7 +99,6 @@ describe('api.layers.cartodb', function() {
     });
 
     it("should expose the legend", function(done) {
-
       var legend = {
         type: "custom",
         show_title: true,
@@ -132,7 +131,8 @@ describe('api.layers.cartodb', function() {
           template: '<div></div>',
           fields: [{name: 'test', title: true, order: 0}]
         },
-        legend: legend
+        legend: legend,
+        visible: true
       }, function(l) {
         addFn(map, l);
         layer = l;
@@ -140,6 +140,7 @@ describe('api.layers.cartodb', function() {
 
       setTimeout(function() {
         expect(layer.legend instanceof cdb.geo.ui.LegendModel).toBeTruthy();
+        expect(layer.legend.get('visible')).toBeTruthy();
         expect(layer.legend.get('items')).toEqual(legend.items);
         done();
       }, 100);


### PR DESCRIPTION
Fixes #609.

There's some noise in this PR due to some reordering of classes inside a file. Sorry about that. The actual fix is implemented in these two commits: [1](https://github.com/CartoDB/cartodb.js/commit/153656c5e2eb036f1df4364f8fc2a203c0fed7b5) and [2](https://github.com/CartoDB/cartodb.js/commit/b174863f424ac73ac6e8d220069cfdd1af04c446).

@viddo PTAL. Thanks!