### PR TITLE
Added support for retina displays

### DIFF
--- a/grunt/tasks/concat.js
+++ b/grunt/tasks/concat.js
@@ -155,7 +155,7 @@ module.exports = {
             'vendor/mod/jquery-ui/jquery.ui.mouse.js',
             'vendor/mod/jquery-ui/jquery.ui.slider.js'
           ]
-        }  
+        }
       },
 
       odyssey: {
@@ -168,7 +168,7 @@ module.exports = {
           '<%= config.dist %>/cartodb.mod.odyssey.uncompressed.js': [
             'vendor/mod/odyssey.js'
           ]
-        }  
+        }
       },
 
       themes: {
@@ -176,6 +176,7 @@ module.exports = {
         files: {
           // CartoDB.js CSSs (themes?)
           '<%= config.dist %>/themes/css/cartodb.css': [
+            'themes/css/cartodb.retina.css',
             'themes/css/infowindow/*.css',
             'themes/css/map/*.css',
             'themes/css/tooltip/*.css',
@@ -185,7 +186,7 @@ module.exports = {
             'themes/css/ie/*.css',
             '!themes/css/cartodb.ie.css'
           ]
-        }  
+        }
       }
     }
   }

--- a/src/cartodb.js
+++ b/src/cartodb.js
@@ -15,6 +15,15 @@
 
     cdb.CARTOCSS_DEFAULT_VERSION = '2.1.1';
 
+    /**
+     * Determines if device supports high resolution.
+     *
+     * @returns {Boolean} True if device is high resolution, false otherwise. 
+     */
+    cdb.isRetinaBrowser = function() {
+      return 	window.devicePixelRatio > 1 || (window.matchMedia && window.matchMedia("(-webkit-min-device-pixel-ratio: 1.5),(-moz-min-device-pixel-ratio: 1.5),(min-device-pixel-ratio: 1.5)").matches);
+    }
+
     root.cdb.config = {};
     root.cdb.core = {};
     root.cdb.image = {};

--- a/src/geo/leaflet/leaflet_cartodb_layergroup.js
+++ b/src/geo/leaflet/leaflet_cartodb_layergroup.js
@@ -27,7 +27,7 @@ L.CartoDBGroupLayerBase = L.TileLayer.extend({
     sql_api_domain:     "cartodb.com",
     sql_api_port:       "80",
     sql_api_protocol:   "http",
-    maxZoom: 30, // default leaflet zoom level for a layers is 18, raise it 
+    maxZoom: 30, // default leaflet zoom level for a layers is 18, raise it
     extra_params:   {
     },
     cdn_url:        null,
@@ -89,10 +89,15 @@ L.CartoDBGroupLayerBase = L.TileLayer.extend({
 
     var index = (tilePoint.x + tilePoint.y) % tiles.length;
 
-    return L.Util.template(tiles[index], L.Util.extend({
+    // Add the high resolution images suffix
+    // FIXME - I think it would be better to change the layer tiles configuration !!!
+    var tile = tiles[index].replace(".png", "{r}.png");
+
+    return L.Util.template(tile, L.Util.extend({
       z: this._getZoomForUrl(),
       x: tilePoint.x,
-      y: tilePoint.y
+      y: tilePoint.y,
+      r: cdb.isRetinaBrowser() ? "@2x" : ""
     }, this.options));
   },
 
@@ -123,7 +128,7 @@ L.CartoDBGroupLayerBase = L.TileLayer.extend({
   onAdd: function(map) {
     var self = this;
     this.options.map = map;
-    
+
     // Add cartodb logo
     if (this.options.cartodb_logo != false)
       cdb.geo.common.CartoDBLogo.addWadus({ left:8, bottom:8 }, 0, map._container);
@@ -132,8 +137,8 @@ L.CartoDBGroupLayerBase = L.TileLayer.extend({
       // if while the layer was processed in the server is removed
       // it should not be added to the map
       var id = L.stamp(self);
-      if (!map._layers[id]) { 
-        return; 
+      if (!map._layers[id]) {
+        return;
       }
 
       L.TileLayer.prototype.onAdd.call(self, map);

--- a/themes/css/cartodb.retina.css
+++ b/themes/css/cartodb.retina.css
@@ -1,0 +1,8 @@
+
+/**
+ * CSS for high-resolution devices
+ */
+@media only screen and (-Webkit-min-device-pixel-ratio: 1.5),
+  only screen and (-moz-min-device-pixel-ratio: 1.5),
+  only screen and (-o-min-device-pixel-ratio: 3/2),
+  only screen and (min-device-pixel-ratio: 1.5) {}


### PR DESCRIPTION
This PR tries to bring support to high res devices. (Related with https://github.com/CartoDB/cartodb.js/issues/276)

The idea is to concat a new `cartodb.retina.css` file that defines device resolution media query for retina devices. To allow this I have modified the `grunt/tasks/concat.js` too.

Within the `cartodb.js` file I have defined a global `cdb.isRetinaBrowser()` function that checks if device is retina ready, inspecting the CSS `devicePixelRatio` value on the previous media query.
I saw in the `src/geo/commons.js` there is a logo class which implements a similar `isRetina()` method. I do not change the code here, but if the global function is accepted, the logo code would be to be updated to use it.

Finally, I have modified the `src/geo/leaflet/leaflet_cartodb_layergroup.js` file so the inherited `getTile()` takes into account if the device is retina ready. Note, I attach to the tiles URL a final `{r}.png` template variable. I think it would be better to set a different configuration in the `tilejson`.

It lacks support for GMaps (I'm not very experienced with it) but from what I can see it is required to update the `src/geo/gmaps/gmaps_tiledlayer.js` (the `getTileUrl()` function) and probably `src/geo/gmaps/gmaps_tlayergroup.js` (the `CartoDBLayerGroupBase.prototype.getTile()` method) to take into account the `{r}.png` variable too. I need more time to research on it.
