### PR TITLE
image.getUrl documentation typo

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -1182,16 +1182,16 @@ cartodb.Image(vizjson_url)
 An _Image_ object
 
 
-#### Image.getURL(_callback(err, url)_)
+#### Image.getUrl(_callback(err, url)_)
 
 Gets the URL for the image requested.
 
-<div class="image-geturl">Image.getURL</div>
+<div class="image-geturl">Image.getUrl</div>
 ```javascript
 <script>
 cartodb.Image(vizjson_url)
   .size(600, 400)
-  .getURL(function(err, url) {
+  .getUrl(function(err, url) {
       console.log('image url',url);
   })
 </script>


### PR DESCRIPTION
maybe I'm wrong but I'm pretty sure image url method is lower case [getUrl](https://github.com/CartoDB/cartodb.js/blob/develop/src/vis/image.js#L399) not `getURL`. On the other hand it's not consistent with the subLayer [getURL](https://github.com/CartoDB/cartodb.js/blob/develop/doc/API.md#sublayergeturltemplate) method.