### PR TITLE
Display custom attributions

### DIFF
--- a/src/geo/gmaps/gmaps.js
+++ b/src/geo/gmaps/gmaps.js
@@ -215,7 +215,7 @@ if(typeof(google) != "undefined" && typeof(google.maps) != "undefined") {
         // it doesn't persist in the backend, so this is needed.
         var attributions = _.clone(this.map.get('attribution')) || [];
         if (!_.contains(attributions, attribution)) {
-          attributions.push(attribution);
+          attributions.unshift(attribution);
         }
 
         this.map.set({ attribution: attributions });

--- a/src/geo/gmaps/gmaps.js
+++ b/src/geo/gmaps/gmaps.js
@@ -210,7 +210,7 @@ if(typeof(google) != "undefined" && typeof(google.maps) != "undefined") {
 
       var attribution = layer.get('attribution');
 
-      if (attribution) {
+      if (attribution && attribution !== '') {
         // Setting attribution in map model
         // it doesn't persist in the backend, so this is needed.
         var attributions = _.clone(this.map.get('attribution')) || [];

--- a/src/geo/gmaps/gmaps.js
+++ b/src/geo/gmaps/gmaps.js
@@ -213,7 +213,7 @@ if(typeof(google) != "undefined" && typeof(google.maps) != "undefined") {
       if (attribution) {
         // Setting attribution in map model
         // it doesn't persist in the backend, so this is needed.
-        var attributions = this.map.get('attribution') || [];
+        var attributions = _.clone(this.map.get('attribution')) || [];
         if (!_.contains(attributions, attribution)) {
           attributions.push(attribution);
         }

--- a/src/geo/gmaps/gmaps_cartodb_layer.js
+++ b/src/geo/gmaps/gmaps_cartodb_layer.js
@@ -80,10 +80,6 @@ var GMapsCartoDBLayerView = function(layerModel, gmapsMap) {
 
   _.bindAll(this, 'featureOut', 'featureOver', 'featureClick');
 
-  // CartoDB new attribution,
-  // also we have the logo
-  layerModel.attributes.attribution = cdb.config.get('cartodb_attributions');
-
   var opts = _.clone(layerModel.attributes);
 
   opts.map =  gmapsMap;

--- a/src/geo/gmaps/gmaps_cartodb_layergroup.js
+++ b/src/geo/gmaps/gmaps_cartodb_layergroup.js
@@ -318,10 +318,6 @@ function LayerGroupView(base) {
 
     _.bindAll(this, 'featureOut', 'featureOver', 'featureClick');
 
-    // CartoDB new attribution,z
-    // also we have the logo
-    layerModel.attributes.attribution = cdb.config.get('cartodb_attributions');
-
     var opts = _.clone(layerModel.attributes);
 
     opts.map =  gmapsMap;

--- a/src/geo/gmaps/torque.js
+++ b/src/geo/gmaps/torque.js
@@ -7,7 +7,6 @@ if(typeof(google) == "undefined" || typeof(google.maps) == "undefined")
 var GMapsTorqueLayerView = function(layerModel, gmapsMap) {
 
   var extra = layerModel.get('extra_params');
-  layerModel.attributes.attribution = cdb.config.get('cartodb_attributions');
   cdb.geo.GMapsLayerView.call(this, layerModel, this, gmapsMap);
 
   var query = this._getQuery(layerModel);

--- a/src/geo/leaflet/leaflet.js
+++ b/src/geo/leaflet/leaflet.js
@@ -258,6 +258,19 @@
         lv.setZIndex(lv.model.get('order'));
       }
 
+      var attribution = layer.get('attribution');
+
+      if (attribution) {
+        // Setting attribution in map model
+        // it doesn't persist in the backend, so this is needed.
+        var attributions = _.clone(this.map.get('attribution')) || [];
+        if (!_.contains(attributions, attribution)) {
+          attributions.unshift(attribution);
+        }
+
+        this.map.set({ attribution: attributions });
+      }
+
       if(opts === undefined || !opts.silent) {
         this.trigger('newLayerView', layer_view, layer_view.model, this);
       }
@@ -285,8 +298,15 @@
       ];
     },
 
-    setAttribution: function(m) {
-      // Leaflet takes care of attribution by its own.
+    setAttribution: function() {
+
+      // Attributions have already been set but we override them with
+      // the ones in the map object that are in the right order and include
+      // the default CartoDB attribution
+      this.map_leaflet.attributionControl._attributions = {};
+      _.each(this.map.get('attribution'), function(attribution){
+        this.map_leaflet.attributionControl.addAttribution(attribution);
+      }.bind(this));
     },
 
     getSize: function() {

--- a/src/geo/leaflet/leaflet.js
+++ b/src/geo/leaflet/leaflet.js
@@ -58,8 +58,11 @@
         // unset bounds to not change mapbounds
         self.map.unset('view_bounds_sw', { silent: true });
         self.map.unset('view_bounds_ne', { silent: true });
-
       }
+
+      // TODO: Try to add the attribution after the rest of attribution (after all layers)
+      // have been added.
+      this.map_leaflet.attributionControl.addAttribution(this.map.get("attribution"));
 
       this.map.bind('set_view', this._setView, this);
       this.map.layers.bind('add', this._addLayer, this);
@@ -253,18 +256,6 @@
       for(var i in this.layers) {
         var lv = this.layers[i];
         lv.setZIndex(lv.model.get('order'));
-      }
-
-      var attribution = layer.get('attribution');
-
-      if (attribution) {
-        // Setting attribution in map model
-        var attributions = this.map.get('attribution') || [];
-        if (!_.contains(attributions, attribution)) {
-          attributions.push(attribution);
-        }
-
-        this.map.set({ attribution: attributions });
       }
 
       if(opts === undefined || !opts.silent) {

--- a/src/geo/leaflet/leaflet.js
+++ b/src/geo/leaflet/leaflet.js
@@ -60,10 +60,6 @@
         self.map.unset('view_bounds_ne', { silent: true });
       }
 
-      // TODO: Try to add the attribution after the rest of attribution (after all layers)
-      // have been added.
-      this.map_leaflet.attributionControl.addAttribution(this.map.get("attribution"));
-
       this.map.bind('set_view', this._setView, this);
       this.map.layers.bind('add', this._addLayer, this);
       this.map.layers.bind('remove', this._removeLayer, this);

--- a/src/geo/leaflet/leaflet.js
+++ b/src/geo/leaflet/leaflet.js
@@ -256,7 +256,7 @@
 
       var attribution = layer.get('attribution');
 
-      if (attribution) {
+      if (attribution && attribution !== '') {
         // Setting attribution in map model
         // it doesn't persist in the backend, so this is needed.
         var attributions = _.clone(this.map.get('attribution')) || [];

--- a/src/geo/leaflet/leaflet_cartodb_layer.js
+++ b/src/geo/leaflet/leaflet_cartodb_layer.js
@@ -76,10 +76,6 @@ var LeafLetLayerCartoDBView = L.CartoDBLayer.extend({
 
     _.bindAll(this, 'featureOut', 'featureOver', 'featureClick');
 
-    // CartoDB new attribution,
-    // also we have the logo
-    layerModel.attributes.attribution = cdb.config.get('cartodb_attributions');
-
     var opts = _.clone(layerModel.attributes);
 
     opts.map =  leafletMap;

--- a/src/geo/leaflet/leaflet_cartodb_layergroup.js
+++ b/src/geo/leaflet/leaflet_cartodb_layergroup.js
@@ -317,10 +317,6 @@ function layerView(base) {
       var self = this;
       var hovers = [];
 
-      // CartoDB new attribution,
-      // also we have the logo
-      layerModel.attributes.attribution = cdb.config.get('cartodb_attributions');
-
       var opts = _.clone(layerModel.attributes);
 
       opts.map =  leafletMap;

--- a/src/geo/leaflet/torque.js
+++ b/src/geo/leaflet/torque.js
@@ -11,7 +11,6 @@ var LeafLetTorqueLayer = L.TorqueLayer.extend({
 
   initialize: function(layerModel, leafletMap) {
     var extra = layerModel.get('extra_params');
-    layerModel.attributes.attribution = cdb.config.get('cartodb_attributions');
 
     var query = this._getQuery(layerModel);
 

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -275,6 +275,7 @@ cdb.geo.Layers = Backbone.Collection.extend({
 cdb.geo.Map = cdb.core.Model.extend({
 
   defaults: {
+    attribution: [cdb.config.get('cartodb_attributions')],
     center: [0, 0],
     zoom: 3,
     minZoom: 0,

--- a/test/spec/geo/gmaps/gmaps.spec.js
+++ b/test/spec/geo/gmaps/gmaps.spec.js
@@ -235,23 +235,19 @@
       }, 2000);
     });
 
-/*
+    it("should set the attributions on the map when layers are added", function() {
+      var layer1 = new cdb.geo.CartoDBLayer({ type: 'cartodb', attribution: 'attribution1', table_name: "table1", tile_style: 'test', user_name: 'test' });
+      var layer2 = new cdb.geo.CartoDBLayer({ type: 'cartodb', attribution: 'attribution2', table_name: "table2", tile_style: 'test', user_name: 'test' });
+      var layer3 = new cdb.geo.CartoDBLayer({ type: 'cartodb', attribution: '', table_name: "table2", tile_style: 'test', user_name: 'test' });
 
-    it("should inser layer in specified order", function() {
-      var layer    = new cdb.geo.CartoDBLayer({});
-      map.addLayer(layer);
+      map.layers.reset([layer1, layer2, layer3]);
 
-      spyOn(mapView.map_leaflet,'addLayer');
-      layer    = new cdb.geo.PlainLayer({});
-      map.addLayer(layer, {at: 0});
-
-      expect(mapView.map_leaflet.addLayer.mostRecentCall.args[1]).toEqual(true);
-      //expect(mapView.map_leaflet.addLayer).toHaveBeenCalledWith(mapView.layers[layer.cid].leafletLayer, true);
-
-
+      expect(map.get('attribution')).toEqual([
+        'attribution2',
+        'attribution1',
+        'CartoDB <a href=\'http://cartodb.com/attributions\' target=\'_blank\'>attribution</a>'
+      ]);
     });
-
-*/
 
   });
 

--- a/test/spec/geo/leaflet/leaflet.spec.js
+++ b/test/spec/geo/leaflet/leaflet.spec.js
@@ -293,6 +293,20 @@ describe('LeafletMapView', function() {
     expect(mapView.layers[newLayer.cid].check).toEqual('testing');
   });
 
+  it("should set the attributions on the map when layers are added", function() {
+    var layer1 = new cdb.geo.CartoDBLayer({ type: 'cartodb', attribution: 'attribution1', table_name: "table1", tile_style: 'test', user_name: 'test' });
+    var layer2 = new cdb.geo.CartoDBLayer({ type: 'cartodb', attribution: 'attribution2', table_name: "table2", tile_style: 'test', user_name: 'test' });
+    var layer3 = new cdb.geo.CartoDBLayer({ type: 'cartodb', attribution: '', table_name: "table2", tile_style: 'test', user_name: 'test' });
+
+    map.layers.reset([layer1, layer2, layer3]);
+
+    expect(map.get('attribution')).toEqual([
+      'attribution2',
+      'attribution1',
+      'CartoDB <a href=\'http://cartodb.com/attributions\' target=\'_blank\'>attribution</a>'
+    ]);
+  });
+
   // Test cases for gmaps substitutes since the support is deprecated.
   _({ // GMaps basemap base_type: expected substitute data
     //empty = defaults to gray_roadmap


### PR DESCRIPTION
These are the changes required to display the custom attributions that were added to the viz.json in cartodb/cartodb#5270.

@javier what do you think? [this](https://github.com/CartoDB/cartodb.js/compare/display-custom-attributions?expand=1#diff-c99f1bfa0704edaea17491896ed25ab7R302) is a bit hacky but it was the only way I found to set the attributions in the order I wanted (CartoDB attribution first and then the rest...). Thanks!