### PR TITLE
Changed default CartoDB attribution for layers

### DIFF
--- a/src/geo/gmaps/gmaps_cartodb_layer.js
+++ b/src/geo/gmaps/gmaps_cartodb_layer.js
@@ -28,7 +28,7 @@ var CartoDBLayer = function(options) {
   var default_options = {
     query:          "SELECT * FROM {{table_name}}",
     opacity:        0.99,
-    attribution:    "CartoDB",
+    attribution:    cdb.config.get('cartodb_attributions'),
     opacity:        1,
     debug:          false,
     visible:        true,

--- a/src/geo/gmaps/gmaps_cartodb_layergroup.js
+++ b/src/geo/gmaps/gmaps_cartodb_layergroup.js
@@ -26,7 +26,7 @@ Projector.prototype.pixelToLatLng = function(point) {
 
 var default_options = {
   opacity:        0.99,
-  attribution:    "CartoDB",
+  attribution:    cdb.config.get('cartodb_attributions'),
   debug:          false,
   visible:        true,
   added:          false,

--- a/src/geo/leaflet/leaflet_cartodb_layer.js
+++ b/src/geo/leaflet/leaflet_cartodb_layer.js
@@ -9,7 +9,7 @@ L.CartoDBLayer = L.CartoDBGroupLayer.extend({
   options: {
     query:          "SELECT * FROM {{table_name}}",
     opacity:        0.99,
-    attribution:    "CartoDB",
+    attribution:    cdb.config.get('cartodb_attributions'),
     debug:          false,
     visible:        true,
     added:          false,

--- a/src/geo/leaflet/leaflet_cartodb_layergroup.js
+++ b/src/geo/leaflet/leaflet_cartodb_layergroup.js
@@ -17,7 +17,7 @@ L.CartoDBGroupLayerBase = L.TileLayer.extend({
 
   options: {
     opacity:        0.99,
-    attribution:    "CartoDB",
+    attribution:    cdb.config.get('cartodb_attributions'),
     debug:          false,
     visible:        true,
     added:          false,

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -135,7 +135,7 @@ cdb.geo.TorqueLayer = cdb.geo.MapLayer.extend({
 cdb.geo.CartoDBLayer = cdb.geo.MapLayer.extend({
 
   defaults: {
-    attribution: 'CartoDB',
+    attribution: cdb.config.get('cartodb_attributions'),
     type: 'CartoDB',
     active: true,
     query: null,


### PR DESCRIPTION
To prevent this in the editor:

<img width="415" alt="screen shot 2015-09-04 at 13 23 45" src="https://cloud.githubusercontent.com/assets/390398/9682672/368d09c2-5309-11e5-95c7-a2386c04ba11.png">

@javierarce PTAL! Thanks!


