### PR TITLE
Handle map attributions a bit better

### DIFF
--- a/src/geo/gmaps/gmaps.js
+++ b/src/geo/gmaps/gmaps.js
@@ -113,6 +113,10 @@ if(typeof(google) != "undefined" && typeof(google.maps) != "undefined") {
       this.map.layers.bind('reset', this._addLayers, this);
       this.map.layers.bind('change:type', this._swicthLayerView, this);
 
+      // When layers are resetted/added/removed attribution is re-calculated and
+      // must updated in the UI
+      this.map.layers.bind('add remove reset', this.setAttribution, this);
+
       this.projector = new cdb.geo.CartoDBLayerGroupGMaps.Projector(this.map_googlemaps);
 
       this.projector.draw = this._ready;
@@ -252,10 +256,10 @@ if(typeof(google) != "undefined" && typeof(google.maps) != "undefined") {
       return [ [0,0], [0,0] ];
     },
 
-  setAttribution: function(m) {
+  setAttribution: function() {
     // Remove old one
     var old = document.getElementById("cartodb-gmaps-attribution")
-      , attribution = m.get("attribution").join(", ");
+      , attribution = this.map.get("attribution").join(", ");
 
       // If div already exists, remove it
       if (old) {

--- a/src/geo/gmaps/gmaps.js
+++ b/src/geo/gmaps/gmaps.js
@@ -208,21 +208,7 @@ if(typeof(google) != "undefined" && typeof(google.maps) != "undefined") {
         cdb.log.error("layer type not supported");
       }
 
-      var attribution = layer.get('attribution');
-
-      if (attribution && attribution !== '') {
-        // Setting attribution in map model
-        // it doesn't persist in the backend, so this is needed.
-        var attributions = _.clone(this.map.get('attribution')) || [];
-        if (!_.contains(attributions, attribution)) {
-          attributions.unshift(attribution);
-        }
-
-        this.map.set({ attribution: attributions });
-      }
-
       return layer_view;
-
     },
 
     pixelToLatLon: function(pos) {

--- a/src/geo/gmaps/gmaps.js
+++ b/src/geo/gmaps/gmaps.js
@@ -83,6 +83,7 @@ if(typeof(google) != "undefined" && typeof(google.maps) != "undefined") {
 
       this._bindModel();
       this._addLayers();
+      this.setAttribution();
 
       google.maps.event.addListener(this.map_googlemaps, 'center_changed', function() {
         var c = self.map_googlemaps.getCenter();
@@ -113,14 +114,9 @@ if(typeof(google) != "undefined" && typeof(google.maps) != "undefined") {
       this.map.layers.bind('reset', this._addLayers, this);
       this.map.layers.bind('change:type', this._swicthLayerView, this);
 
-      // When layers are resetted/added/removed attribution is re-calculated and
-      // must updated in the UI
-      this.map.layers.bind('add remove reset', this.setAttribution, this);
-
       this.projector = new cdb.geo.CartoDBLayerGroupGMaps.Projector(this.map_googlemaps);
 
       this.projector.draw = this._ready;
-
     },
 
     _ready: function() {

--- a/src/geo/leaflet/leaflet.js
+++ b/src/geo/leaflet/leaflet.js
@@ -66,16 +66,12 @@
       this.map.layers.bind('reset', this._addLayers, this);
       this.map.layers.bind('change:type', this._swicthLayerView, this);
 
-      // When layers are resetted/added/removed attribution is re-calculated and
-      // must updated in the UI
-      this.map.layers.bind('add remove reset', this.setAttribution, this);
-
       this.map.geometries.bind('add', this._addGeometry, this);
       this.map.geometries.bind('remove', this._removeGeometry, this);
 
       this._bindModel();
-
       this._addLayers();
+      this.setAttribution();
 
       this.map_leaflet.on('layeradd', function(lyr) {
         this.trigger('layeradd', lyr, self);

--- a/src/geo/leaflet/leaflet.js
+++ b/src/geo/leaflet/leaflet.js
@@ -66,6 +66,10 @@
       this.map.layers.bind('reset', this._addLayers, this);
       this.map.layers.bind('change:type', this._swicthLayerView, this);
 
+      // When layers are resetted/added/removed attribution is re-calculated and
+      // must updated in the UI
+      this.map.layers.bind('add remove reset', this.setAttribution, this);
+
       this.map.geometries.bind('add', this._addGeometry, this);
       this.map.geometries.bind('remove', this._removeGeometry, this);
 

--- a/src/geo/leaflet/leaflet.js
+++ b/src/geo/leaflet/leaflet.js
@@ -254,19 +254,6 @@
         lv.setZIndex(lv.model.get('order'));
       }
 
-      var attribution = layer.get('attribution');
-
-      if (attribution && attribution !== '') {
-        // Setting attribution in map model
-        // it doesn't persist in the backend, so this is needed.
-        var attributions = _.clone(this.map.get('attribution')) || [];
-        if (!_.contains(attributions, attribution)) {
-          attributions.unshift(attribution);
-        }
-
-        this.map.set({ attribution: attributions });
-      }
-
       if(opts === undefined || !opts.silent) {
         this.trigger('newLayerView', layer_view, layer_view.model, this);
       }

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -303,13 +303,15 @@ cdb.geo.Map = cdb.core.Model.extend({
   },
 
   _updateAttributions: function() {
+    var defaultCartoDBAttribution = this.defaults.attribution[0];
     var attributions = _.chain(this.layers.models)
       .map(function(layer) { return layer.get('attribution'); })
+      .reject(function(attribution) { return attribution == defaultCartoDBAttribution})
       .compact()
       .uniq()
       .value();
 
-    attributions.push(this.defaults.attribution[0]);
+    attributions.push(defaultCartoDBAttribution);
 
     this.set('attribution', attributions);
   },

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -662,7 +662,7 @@ cdb.geo.MapView = cdb.core.View.extend({
     this.map.bind('change:scrollwheel',     this._setScrollWheel, this);
     this.map.bind('change:keyboard',        this._setKeyboard, this);
     this.map.bind('change:center',          this._setCenter, this);
-    this.map.bind('change:attribution',     this._setAttribution, this);
+    this.map.bind('change:attribution',     this.setAttribution, this);
   },
 
   /** unbind model properties */
@@ -685,10 +685,6 @@ cdb.geo.MapView = cdb.core.View.extend({
 
   showBounds: function(bounds) {
     this.map.fitBounds(bounds, this.getSize())
-  },
-
-  _setAttribution: function(m,attr) {
-    this.setAttribution(m);
   },
 
   _addLayers: function() {

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -294,7 +294,24 @@ cdb.geo.Map = cdb.core.Model.extend({
       }
     }, this);
 
+    this.layers.bind('reset', this._updateAttributions, this);
+    this.layers.bind('add', this._updateAttributions, this);
+    this.layers.bind('remove', this._updateAttributions, this);
+    this.layers.bind('change:attribution', this._updateAttributions, this);
+
     this.geometries = new cdb.geo.Geometries();
+  },
+
+  _updateAttributions: function() {
+    var attributions = _.chain(this.layers.models)
+      .map(function(layer) { return layer.get('attribution'); })
+      .compact()
+      .uniq()
+      .value();
+
+    attributions.push(this.defaults.attribution[0]);
+
+    this.set('attribution', attributions);
   },
 
   setView: function(latlng, zoom) {
@@ -460,24 +477,6 @@ cdb.geo.Map = cdb.core.Model.extend({
     if(baseLayer && baseLayer.get('options'))  {
       return baseLayer.get('options').urlTemplate;
     }
-  },
-
-  updateAttribution: function(old, new_) {
-    var attributions = this.get("attribution") || [];
-
-    // Remove the old one
-    if (old) {
-      attributions = _.without(attributions, old);
-    }
-
-    // Save the new one
-    if (new_) {
-      if (!_.contains(attributions, new_)) {
-        attributions.push(new_);
-      }
-    }
-
-    this.set({ attribution: attributions });
   },
 
   addGeometry: function(geom) {

--- a/test/spec/geo/gmaps/gmaps.spec.js
+++ b/test/spec/geo/gmaps/gmaps.spec.js
@@ -234,20 +234,4 @@
         done();
       }, 2000);
     });
-
-    it("should set the attributions on the map when layers are added", function() {
-      var layer1 = new cdb.geo.CartoDBLayer({ type: 'cartodb', attribution: 'attribution1', table_name: "table1", tile_style: 'test', user_name: 'test' });
-      var layer2 = new cdb.geo.CartoDBLayer({ type: 'cartodb', attribution: 'attribution2', table_name: "table2", tile_style: 'test', user_name: 'test' });
-      var layer3 = new cdb.geo.CartoDBLayer({ type: 'cartodb', attribution: '', table_name: "table2", tile_style: 'test', user_name: 'test' });
-
-      map.layers.reset([layer1, layer2, layer3]);
-
-      expect(map.get('attribution')).toEqual([
-        'attribution2',
-        'attribution1',
-        'CartoDB <a href=\'http://cartodb.com/attributions\' target=\'_blank\'>attribution</a>'
-      ]);
-    });
-
   });
-

--- a/test/spec/geo/leaflet/leaflet.spec.js
+++ b/test/spec/geo/leaflet/leaflet.spec.js
@@ -293,20 +293,6 @@ describe('LeafletMapView', function() {
     expect(mapView.layers[newLayer.cid].check).toEqual('testing');
   });
 
-  it("should set the attributions on the map when layers are added", function() {
-    var layer1 = new cdb.geo.CartoDBLayer({ type: 'cartodb', attribution: 'attribution1', table_name: "table1", tile_style: 'test', user_name: 'test' });
-    var layer2 = new cdb.geo.CartoDBLayer({ type: 'cartodb', attribution: 'attribution2', table_name: "table2", tile_style: 'test', user_name: 'test' });
-    var layer3 = new cdb.geo.CartoDBLayer({ type: 'cartodb', attribution: '', table_name: "table2", tile_style: 'test', user_name: 'test' });
-
-    map.layers.reset([layer1, layer2, layer3]);
-
-    expect(map.get('attribution')).toEqual([
-      'attribution2',
-      'attribution1',
-      'CartoDB <a href=\'http://cartodb.com/attributions\' target=\'_blank\'>attribution</a>'
-    ]);
-  });
-
   // Test cases for gmaps substitutes since the support is deprecated.
   _({ // GMaps basemap base_type: expected substitute data
     //empty = defaults to gray_roadmap

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -275,7 +275,18 @@ describe("geo.map", function() {
 
       map.layers.remove(layer);
 
-      // The attribution has been removed after the layer has been removed
+      expect(map.get('attribution')).toEqual([
+        "attribution1",
+        "wadus",
+        "CartoDB <a href='http://cartodb.com/attributions' target='_blank'>attribution</a>",
+      ]);
+
+      // Addind a layer with the default attribution
+      var layer = new cdb.geo.CartoDBLayer();
+
+      map.layers.add(layer, { at: 0 });
+
+      // Default CartoDB only appears once and it's the last one
       expect(map.get('attribution')).toEqual([
         "attribution1",
         "wadus",

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -227,6 +227,61 @@ describe("geo.map", function() {
       expect(map.get('maxZoom')).toEqual(40);
       expect(map.get('minZoom')).toEqual(0);
     });
+
+    it('should update the attributions of the map when layers are reset/added/removed', function() {
+
+      map = new cdb.geo.Map();
+
+      // Map has the default CartoDB attribution
+      expect(map.get('attribution')).toEqual([
+        "CartoDB <a href='http://cartodb.com/attributions' target='_blank'>attribution</a>"
+      ]);
+
+      var layer1 = new cdb.geo.CartoDBLayer({ attribution: 'attribution1' });
+      var layer2 = new cdb.geo.CartoDBLayer({ attribution: 'attribution1' });
+      var layer3 = new cdb.geo.CartoDBLayer({ attribution: 'wadus' });
+      var layer4 = new cdb.geo.CartoDBLayer({ attribution: '' });
+
+      map.layers.reset([ layer1, layer2, layer3, layer4 ]);
+
+      // Attributions have been updated removing duplicated and empty attributions
+      expect(map.get('attribution')).toEqual([
+        "attribution1",
+        "wadus",
+        "CartoDB <a href='http://cartodb.com/attributions' target='_blank'>attribution</a>",
+      ]);
+
+      var layer = new cdb.geo.CartoDBLayer({ attribution: 'attribution2' });
+
+      map.layers.add(layer);
+
+      // The attribution of the new layer has been appended before the default CartoDB attribution
+      expect(map.get('attribution')).toEqual([
+        "attribution1",
+        "wadus",
+        "attribution2",
+        "CartoDB <a href='http://cartodb.com/attributions' target='_blank'>attribution</a>",
+      ]);
+
+      layer.set('attribution', 'new attribution');
+
+      // The attribution of the layer has been updated in the map
+      expect(map.get('attribution')).toEqual([
+        "attribution1",
+        "wadus",
+        "new attribution",
+        "CartoDB <a href='http://cartodb.com/attributions' target='_blank'>attribution</a>",
+      ]);
+
+      map.layers.remove(layer);
+
+      // The attribution has been removed after the layer has been removed
+      expect(map.get('attribution')).toEqual([
+        "attribution1",
+        "wadus",
+        "CartoDB <a href='http://cartodb.com/attributions' target='_blank'>attribution</a>",
+      ]);
+    })
   });
 
   describe('MapView', function() {

--- a/test/spec/geo/ui/mobile.spec.js
+++ b/test/spec/geo/ui/mobile.spec.js
@@ -61,7 +61,7 @@ describe("cdb.geo.ui.Mobile", function() {
       }
     });
 
-    map.layers = new cdb.geo.Layers([l1, layerGroup]);
+    map.layers.reset([l1, layerGroup]);
 
     template = cdb.core.Template.compile('\<div class="backdrop"></div>\
           <div class="cartodb-header">\
@@ -650,7 +650,7 @@ describe("cdb.geo.ui.Mobile", function() {
       }
     });
 
-    map.layers = new cdb.geo.Layers([l1, layerGroup]);
+    map.layers.reset([l1, layerGroup]);
 
 
     mapView = new cdb.geo.GoogleMapsMapView({


### PR DESCRIPTION
This PR tries to improve/simplify the way we handle attributions for maps. Now the Map model listens to changes on its layers and updates the `attribution` attribute and updates its attribution accordingly (removing empty attributions, duplicates, adding the default CartoDB attribution, etc.).

Also, when a MapView is instantiated, attributions are "refreshed", so the map renders the right attributions if the map model already have some layers loaded (this is what happens in the editor).

@javierarce could you please take a look? thanks!