### PR TITLE
Add checker to fullscreen button when it is rendered in an iframe

### DIFF
--- a/src/geo/ui/fullscreen.js
+++ b/src/geo/ui/fullscreen.js
@@ -112,7 +112,8 @@ cdb.ui.common.FullScreen = cdb.core.View.extend({
 
   _isFullScreenEnabled: function() {
     // If frameElement exists, it means that the map
-    // is embebed as an iframe so we need
+    // is embebed as an iframe so we need to check if
+    // the parent has a secure protocol
     var frameElement = window && window.frameElement;
     if (frameElement) {
       var parentWindow = this._getFramedWindow(frameElement);

--- a/src/geo/ui/fullscreen.js
+++ b/src/geo/ui/fullscreen.js
@@ -99,7 +99,7 @@ cdb.ui.common.FullScreen = cdb.core.View.extend({
   },
 
   render: function() {
-    if (this._isFullScreenEnabled()) {
+    if (this._canFullScreenBeEnabled()) {
       var $el = this.$el;
       var options = _.extend(this.options);
       $el.html(this.options.template(options));
@@ -110,7 +110,7 @@ cdb.ui.common.FullScreen = cdb.core.View.extend({
     return this;
   },
 
-  _isFullScreenEnabled: function() {
+  _canFullScreenBeEnabled: function() {
     // If frameElement exists, it means that the map
     // is embebed as an iframe so we need to check if
     // the parent has a secure protocol

--- a/src/geo/ui/fullscreen.js
+++ b/src/geo/ui/fullscreen.js
@@ -99,14 +99,41 @@ cdb.ui.common.FullScreen = cdb.core.View.extend({
   },
 
   render: function() {
-
-    var $el = this.$el;
-
-    var options = _.extend(this.options);
-
-    $el.html(this.options.template(options));
+    if (this._isFullScreenEnabled()) {
+      var $el = this.$el;
+      var options = _.extend(this.options);
+      $el.html(this.options.template(options));
+    } else {
+      cdb.log.info('FullScreen is deprecated on insecure origins. See https://goo.gl/rStTGz for more details.');
+    }
 
     return this;
+  },
+
+  _isFullScreenEnabled: function() {
+    // If frameElement exists, it means that the map
+    // is embebed as an iframe so we need
+    var frameElement = window && window.frameElement;
+    if (frameElement) {
+      var parentWindow = this._getFramedWindow(frameElement);
+      var parentProtocol = parentWindow.location.protocol;
+      if (parentProtocol.search('https:') !== 0) {
+        return false;
+      }
+    }
+
+    return true;
+  },
+
+  _getFramedWindow: function(f) {
+    if (f.parentNode == null) {
+      f = document.body.appendChild(f);
+    }
+    var w = (f.contentWindow || f.contentDocument);
+    if (w && w.nodeType && w.nodeType==9) {
+      w = (w.defaultView || w.parentWindow);
+    }
+    return w;
   }
 
 });


### PR DESCRIPTION
The problem is iframe content can't be "fullscreen-ed" if the origin/parent url doesn't have a https protocol. And this possible solution would be:

- Check if the map is iframed.
- If so, checks if the parent of the iframe has http protocol.
- If it doesn't have https protocol, fullscreen button is not rendered.

Related:

- Bug in CartoDB: https://github.com/CartoDB/cartodb/issues/4543 
- Happening here: http://mashable.com/2015/07/17/schumer-thrones-google-emmys/#vVL1wykkAZk9
- Explanation: https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-powerful-features-on-insecure-origins 

Using some keys from [here](http://stackoverflow.com/questions/935127/how-to-access-parent-iframe-from-javascript).

Sorry but I'd like to warn all @CartoDB/frontend team.