### PR TITLE
Do not rely on object.offsetParent when the map is fixed to the top.

### DIFF
--- a/examples/infowindow-with-different-positioning.html
+++ b/examples/infowindow-with-different-positioning.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Infowindow working with different positionings | CartoDB.js</title>
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
+    <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
+    <style>
+      html, body {
+        padding: 0;
+        margin: 0;
+      }
+
+      #map1 {
+        position: fixed;
+        left: 0px;
+        top: 0px;
+        width: 500px;
+        height: 300px;
+      }
+
+      #map2 {
+        height: 400px;
+        padding: 0;
+        margin: 800px 50px 0 550px;
+      }
+
+      .scrollSign {
+        margin-left: 550px;
+        background: yellow;
+        position: absolute;
+        bottom: 0;
+        text-align: center;
+        padding: 10px 0;
+      }
+    </style>
+
+    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+  </head>
+  <body>
+    <div id="map1"></div>
+    <div class="scrollSign">&#11015; &#11015; &#11015; Scroll down &#11015; &#11015; &#11015;</div>
+    <div id="map2"></div>
+
+    <!-- include cartodb.js library -->
+    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+
+    <script>
+      function main() {
+        cartodb.createVis('map1', 'http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json', {
+        })
+        cartodb.createVis('map2', 'http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json', {
+        })
+      }
+
+      window.onload = main;
+    </script>
+  </body>
+</html>

--- a/src/geo/leaflet/leaflet_cartodb_layergroup.js
+++ b/src/geo/leaflet/leaflet_cartodb_layergroup.js
@@ -277,18 +277,21 @@ L.CartoDBGroupLayerBase = L.TileLayer.extend({
       y = o.e.clientY;
     }
 
-    if (obj.offsetParent) {
-      // Modern browsers
+    // If the map is fixed at the top of the window, we can't use offsetParent
+    // cause there might be some scrolling that we need to take into account.
+    if (obj.offsetParent && obj.offsetTop > 0) {
       do {
         curleft += obj.offsetLeft;
         curtop += obj.offsetTop;
       } while (obj = obj.offsetParent);
-      return map.containerPointToLayerPoint(new L.Point(x - curleft, y - curtop));
+      var p = new L.Point(
+        x - curleft, y - curtop);
+      return map.containerPointToLayerPoint(p);
     } else {
       var rect = obj.getBoundingClientRect();
       var p = new L.Point(
-            (o.e.clientX? o.e.clientX: x) - rect.left - obj.clientLeft - window.scrollX,
-            (o.e.clientY? o.e.clientY: y) - rect.top - obj.clientTop - window.scrollY);
+        (o.e.clientX? o.e.clientX: x) - rect.left - obj.clientLeft - window.scrollX,
+        (o.e.clientY? o.e.clientY: y) - rect.top - obj.clientTop - window.scrollY);
       return map.containerPointToLayerPoint(p);
     }
   }

--- a/src/geo/leaflet/leaflet_cartodb_layergroup.js
+++ b/src/geo/leaflet/leaflet_cartodb_layergroup.js
@@ -264,8 +264,9 @@ L.CartoDBGroupLayerBase = L.TileLayer.extend({
    * @params {Object} Map object
    * @params {Object} Wax event object
    */
-  _findPos: function (map,o) {
-    var curleft = 0, curtop = 0;
+  _findPos: function (map, o) {
+    var curleft = 0;
+    var curtop = 0;
     var obj = map.getContainer();
 
     var x, y;
@@ -284,20 +285,25 @@ L.CartoDBGroupLayerBase = L.TileLayer.extend({
         curleft += obj.offsetLeft;
         curtop += obj.offsetTop;
       } while (obj = obj.offsetParent);
-      var p = new L.Point(
+      var point = this._newPoint(
         x - curleft, y - curtop);
-      return map.containerPointToLayerPoint(p);
     } else {
       var rect = obj.getBoundingClientRect();
       var scrollX = (window.scrollX || window.pageXOffset);
       var scrollY = (window.scrollY || window.pageYOffset);
-      var p = new L.Point(
+      var point = this._newPoint(
         (o.e.clientX? o.e.clientX: x) - rect.left - obj.clientLeft - scrollX,
         (o.e.clientY? o.e.clientY: y) - rect.top - obj.clientTop - scrollY);
-      return map.containerPointToLayerPoint(p);
     }
-  }
+    return map.containerPointToLayerPoint(point);
+  },
 
+  /**
+   * Creates an instance of a Leaflet Point
+   */
+  _newPoint: function(x, y) {
+    return new L.Point(x, y);
+  }
 });
 
 L.CartoDBGroupLayer = L.CartoDBGroupLayerBase.extend({

--- a/src/geo/leaflet/leaflet_cartodb_layergroup.js
+++ b/src/geo/leaflet/leaflet_cartodb_layergroup.js
@@ -289,9 +289,11 @@ L.CartoDBGroupLayerBase = L.TileLayer.extend({
       return map.containerPointToLayerPoint(p);
     } else {
       var rect = obj.getBoundingClientRect();
+      var scrollX = (window.scrollX || window.pageXOffset);
+      var scrollY = (window.scrollY || window.pageYOffset);
       var p = new L.Point(
-        (o.e.clientX? o.e.clientX: x) - rect.left - obj.clientLeft - window.scrollX,
-        (o.e.clientY? o.e.clientY: y) - rect.top - obj.clientTop - window.scrollY);
+        (o.e.clientX? o.e.clientX: x) - rect.left - obj.clientLeft - scrollX,
+        (o.e.clientY? o.e.clientY: y) - rect.top - obj.clientTop - scrollY);
       return map.containerPointToLayerPoint(p);
     }
   }


### PR DESCRIPTION
Fixes #639.

In some circumstances, the map can be fixed to the top but the page might have some scroll that we need to take into account. In these cases it's better not to use the object.offsetParent approach.

@xavijam what do you think?