### PR TITLE
Select torque layers if no "cartodb" layers are present

### DIFF
--- a/src/api/layers.js
+++ b/src/api/layers.js
@@ -104,7 +104,7 @@
           }
           layerData = visData.layers[index];
         } else {
-          var DATA_LAYER_TYPES = ['namedmap', 'layergroup'];
+          var DATA_LAYER_TYPES = ['namedmap', 'layergroup', 'torque'];
 
           // Select the first data layer (namedmap or layergroup)
           layerData = _.find(visData.layers, function(layer){

--- a/test/spec/api/layers.spec.js
+++ b/test/spec/api/layers.spec.js
@@ -254,12 +254,13 @@ describe('api.layers', function() {
         });
 
         setTimeout(function() {
+          expect(layer).toBeDefined();
           expect(layer.options.type).toEqual('namedmap');
           done();
-        }, 100);
+        }, 0);
       });
 
-      it("should load the `layergroup` by default", function(done) {
+      it("should load the `layergroup` layer by default", function(done) {
         var layer;
 
         cartodb.createLayer(map, {
@@ -281,9 +282,36 @@ describe('api.layers', function() {
         });
 
         setTimeout(function() {
+          expect(layer).toBeDefined();
           expect(layer.options.type).toEqual('layergroup');
           done();
-        }, 100);
+        }, 0);
+      });
+
+      it("should load the `torque` layer by default", function(done) {
+        var layer;
+
+        cartodb.createLayer(map, {
+          updated_at: 'jaja',
+          layers: [
+            { type: 'tiled', options: {} },
+            { type: 'tiled', options: {} },
+            {
+              type: 'torque',
+              options: {
+                'torque-steps': 3
+              }
+            }
+          ]
+        }).done(function(lyr) {
+          layer = lyr;
+        });
+
+        setTimeout(function() {
+          expect(layer).toBeDefined();
+          expect(layer.type).toEqual('torque');
+          done();
+        }, 0);
       });
 
       it("should add a torque layer", function(done) {


### PR DESCRIPTION
Fixes #678. [This commit](https://github.com/CartoDB/cartodb.js/commit/30dca98e51defe0c171a92c24f4d400d4bf87eb3) changed how we select the layer that must be used when `createLayer` doesn't specify an index, and torque layers were not taken into account.

@xavijam easy one...

cc: @iriberri 