### PR TITLE
Fixed two issues with attributions in Leaflet maps

### DIFF
--- a/src/geo/leaflet/leaflet.js
+++ b/src/geo/leaflet/leaflet.js
@@ -282,14 +282,35 @@
     },
 
     setAttribution: function() {
+      var attributionControl = this._getAttributionControl();
 
-      // Attributions have already been set but we override them with
-      // the ones in the map object that are in the right order and include
-      // the default CartoDB attribution
-      this.map_leaflet.attributionControl._attributions = {};
-      _.each(this.map.get('attribution'), function(attribution){
-        this.map_leaflet.attributionControl.addAttribution(attribution);
-      }.bind(this));
+      // Save the attributions that were in the map the first time a new layer
+      // is added and the attributions of the map have changed
+      if (!this._originalAttributions) {
+        this._originalAttributions = Object.keys(attributionControl._attributions);
+      }
+
+      // Clear the attributions and re-add the original and custom attributions in
+      // the order we want
+      attributionControl._attributions = {};
+      var newAttributions = this._originalAttributions.concat(this.map.get('attribution'));
+      _.each(newAttributions, function(attribution) {
+        attributionControl.addAttribution(attribution);
+      });
+    },
+
+    _getAttributionControl: function() {
+      if (this._attributionControl) {
+        return this._attributionControl;
+      }
+
+      this._attributionControl = this.map_leaflet.attributionControl;
+      if (!this._attributionControl) {
+        this._attributionControl = L.control.attribution({ prefix: '' });
+        this.map_leaflet.addControl(this._attributionControl);
+      }
+
+      return this._attributionControl;
     },
 
     getSize: function() {

--- a/test/spec/geo/leaflet/leaflet.spec.js
+++ b/test/spec/geo/leaflet/leaflet.spec.js
@@ -8,7 +8,6 @@ describe('LeafletMapView', function() {
         'height': '200px',
         'width': '200px'
     });
-    //$('body').append(container);
     map = new cdb.geo.Map();
     mapView = new cdb.geo.LeafletMapView({
       el: container,
@@ -188,7 +187,6 @@ describe('LeafletMapView', function() {
     spyOn(mapView.map_leaflet,'addLayer');
     var b = new cdb.geo.TileLayer({urlTemplate: 'test' });
     map.addLayer(b, {at: 0});
-    
 
     expect(mapView.getLayerByCid(layer.cid).options.zIndex).toEqual(1);
     expect(mapView.getLayerByCid(b.cid).options.zIndex).toEqual(0);
@@ -418,5 +416,84 @@ describe('LeafletMapView', function() {
     });
   });
 
+  describe('attributions', function() {
+
+    var container;
+
+    beforeEach(function() {
+      container = $('<div>').css({
+        'height': '200px',
+        'width': '200px'
+      });
+    });
+
+    it('should render the right attributions', function() {
+      var attributions = mapView.$el.find('.leaflet-control-attribution').text();
+      expect(attributions).toEqual('CartoDB attribution');
+
+      layer = new cdb.geo.CartoDBLayer({
+        attribution: 'custom attribution'
+      });
+      map.addLayer(layer);
+
+      var attributions = mapView.$el.find('.leaflet-control-attribution').text();
+      expect(attributions).toEqual('custom attribution, CartoDB attribution');
+    });
+
+    it('should respect the attribution of existing Leaflet layers', function() {
+      var leafletMap = new L.Map(container[0], {
+        center: [43, 0],
+        zoom: 3
+      });
+
+      // Add a tile layer with some attribution
+      L.tileLayer('http://tile.stamen.com/toner/{z}/{x}/{y}.png', {
+        attribution: 'Stamen'
+      }).addTo(leafletMap);
+
+      mapView = new cdb.geo.LeafletMapView({
+        el: container,
+        map: map,
+        map_object: leafletMap
+      });
+
+      // Add a CartoDB layer with some custom attribution
+      layer = new cdb.geo.CartoDBLayer({
+        attribution: 'custom attribution'
+      });
+      map.addLayer(layer);
+
+      var attributions = mapView.$el.find('.leaflet-control-attribution').text();
+      expect(attributions).toEqual('Leaflet | Stamen, custom attribution, CartoDB attribution');
+    });
+
+    it('should render attributions when the Leaflet map has attributionControl disabled', function() {
+      var leafletMap = new L.Map(container[0], {
+        center: [43, 0],
+        zoom: 3,
+        attributionControl: false
+      });
+
+      // Add a tile layer with some attribution
+      L.tileLayer('http://tile.stamen.com/toner/{z}/{x}/{y}.png', {
+        attribution: 'Stamen'
+      }).addTo(leafletMap);
+
+      mapView = new cdb.geo.LeafletMapView({
+        el: container,
+        map: map,
+        map_object: leafletMap
+      });
+
+      // Add a CartoDB layer with some custom attribution
+      layer = new cdb.geo.CartoDBLayer({
+        attribution: 'custom attribution'
+      });
+      map.addLayer(layer);
+
+      var attributions = mapView.$el.find('.leaflet-control-attribution').text();
+      expect(attributions).toEqual('Stamen, custom attribution, CartoDB attribution');
+    });
+  });
 });
 


### PR DESCRIPTION
Fixes #681.

1. Leaflet maps might have `attributionControl` set to false and CartoDB.js should still handle attributions correctly.
2. Leaflet maps might have some other layers with attributions, and these shouldn't be removed.

@fdansv can you please take a look?

cc: @iriberri 