### PR TITLE
If fullscreen is not possible, open the map in a new tab

### DIFF
--- a/src/geo/ui/fullscreen.js
+++ b/src/geo/ui/fullscreen.js
@@ -78,14 +78,13 @@ cdb.ui.common.FullScreen = cdb.core.View.extend({
   },
 
   render: function() {
-    var $el = this.$el;
     var options = _.extend(
       this.options,
       {
         mapUrl: location.href || ''
       }
     );
-    $el.html(this.options.template(options));
+    this.$el.html(this.options.template(options));
 
     if (!this._canFullScreenBeEnabled()) {
       this.undelegateEvents();

--- a/src/geo/ui/fullscreen.js
+++ b/src/geo/ui/fullscreen.js
@@ -67,10 +67,8 @@ cdb.ui.common.FullScreen = cdb.core.View.extend({
         }
       }
 
-      if (mapView) {
-        if (this.model.get("allowWheelOnFullscreen")) {
-          mapView.options.map.set("scrollwheel", true);
-        }
+      if (mapView && this.model.get("allowWheelOnFullscreen")) {
+        mapView.map.set("scrollwheel", true);
       }
     } else {
       cancelFullScreen.call(doc);

--- a/src/geo/ui/fullscreen.js
+++ b/src/geo/ui/fullscreen.js
@@ -14,47 +14,33 @@ cdb.ui.common.FullScreen = cdb.core.View.extend({
   className: 'cartodb-fullscreen',
 
   events: {
-
     "click a": "_toggleFullScreen"
-
   },
 
   initialize: function() {
-
     _.bindAll(this, 'render');
     _.defaults(this.options, this.default_options);
-
-    //this.model = new cdb.core.Model({
-      //allowWheelOnFullscreen: false
-    //});
-
     this._addWheelEvent();
-
   },
 
   _addWheelEvent: function() {
+    var self    = this;
+    var mapView = this.options.mapView;
 
-      var self    = this;
-      var mapView = this.options.mapView;
-
-      $(document).on('webkitfullscreenchange mozfullscreenchange fullscreenchange', function() {
-
-        if ( !document.fullscreenElement && !document.webkitFullscreenElement && !document.mozFullScreenElement && !document.msFullscreenElement) {
-          if (self.model.get("allowWheelOnFullscreen")) {
-            mapView.options.map.set("scrollwheel", false);
-          }
+    $(document).on('webkitfullscreenchange mozfullscreenchange fullscreenchange', function() {
+      if (!document.fullscreenElement && !document.webkitFullscreenElement && !document.mozFullScreenElement && !document.msFullscreenElement) {
+        if (self.model.get("allowWheelOnFullscreen")) {
+          mapView.options.map.set("scrollwheel", false);
         }
-
-        mapView.invalidateSize();
-
-      });
-
+      }
+      mapView.invalidateSize();
+    });
   },
 
   _toggleFullScreen: function(ev) {
-
-    ev.stopPropagation();
-    ev.preventDefault();
+    if (ev) {
+      this.killEvent(ev);
+    }
 
     var doc   = window.document;
     var docEl = doc.documentElement;
@@ -65,11 +51,9 @@ cdb.ui.common.FullScreen = cdb.core.View.extend({
 
     var requestFullScreen = docEl.requestFullscreen || docEl.mozRequestFullScreen || docEl.webkitRequestFullScreen || docEl.msRequestFullscreen;
     var cancelFullScreen = doc.exitFullscreen || doc.mozCancelFullScreen || doc.webkitExitFullscreen || doc.msExitFullscreen;
-
     var mapView = this.options.mapView;
 
     if (!doc.fullscreenElement && !doc.mozFullScreenElement && !doc.webkitFullscreenElement && !doc.msFullscreenElement) {
-
       if (docEl.webkitRequestFullScreen) {
         // Cartodb.js #361 :: Full screen button not working on Safari 8.0.3 #361
         // Safari has a bug that fullScreen doestn't work with Element.ALLOW_KEYBOARD_INPUT);
@@ -84,57 +68,49 @@ cdb.ui.common.FullScreen = cdb.core.View.extend({
       }
 
       if (mapView) {
-
         if (this.model.get("allowWheelOnFullscreen")) {
           mapView.options.map.set("scrollwheel", true);
         }
-
       }
-
     } else {
-
       cancelFullScreen.call(doc);
-
     }
   },
 
   render: function() {
-    if (this._canFullScreenBeEnabled()) {
-      var $el = this.$el;
-      var options = _.extend(this.options);
-      $el.html(this.options.template(options));
-    } else {
-      cdb.log.info('FullScreen is deprecated on insecure origins. See https://goo.gl/rStTGz for more details.');
+    var $el = this.$el;
+    var options = _.extend(
+      this.options,
+      {
+        mapUrl: location.href || ''
+      }
+    );
+    $el.html(this.options.template(options));
+
+    if (!this._canFullScreenBeEnabled()) {
+      this.undelegateEvents();
+      cdb.log.info('FullScreen API is deprecated on insecure origins. See https://goo.gl/rStTGz for more details.');
     }
 
     return this;
   },
 
   _canFullScreenBeEnabled: function() {
-    // If frameElement exists, it means that the map
-    // is embebed as an iframe so we need to check if
-    // the parent has a secure protocol
-    var frameElement = window && window.frameElement;
-    if (frameElement) {
-      var parentWindow = this._getFramedWindow(frameElement);
-      var parentProtocol = parentWindow.location.protocol;
-      if (parentProtocol.search('https:') !== 0) {
+    if (this._isInIframe()) {
+      var parentUrl = document.referrer;
+      if (parentUrl.search('https:') !== 0) {
         return false;
       }
     }
-
     return true;
   },
 
-  _getFramedWindow: function(f) {
-    if (f.parentNode == null) {
-      f = document.body.appendChild(f);
+  _isInIframe: function() {
+    try {
+      return window.self !== window.top;
+    } catch (e) {
+      return true;
     }
-    var w = (f.contentWindow || f.contentDocument);
-    if (w && w.nodeType && w.nodeType==9) {
-      w = (w.defaultView || w.parentWindow);
-    }
-    return w;
   }
 
 });

--- a/src/vis/overlays.js
+++ b/src/vis/overlays.js
@@ -358,7 +358,7 @@ cdb.vis.Overlay.register('fullscreen', function(data, vis) {
   options.allowWheelOnFullscreen = false;
 
   var template = cdb.core.Template.compile(
-    data.template || '<a href="#"></a>',
+    data.template || '<a href="{{ mapUrl }}" target="_blank"></a>',
     data.templateType || 'mustache'
   );
 


### PR DESCRIPTION
Apart from I introduced a bug last time I changed the fullscreen functionality (god), after talking with @iriberri and @oriolbx, if the fullscreen behaviour is not possible, we provide the possibility to open the map in a new tab, how does it sound? This could only happen when the map is added as an iframe.

REVIEWER: @alonsogarciapablo 