### PR TITLE
Removed background-clip properties from legends

### DIFF
--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -23,15 +23,11 @@ describe("Image", function() {
   });
 
   it("should use the basemap defined in the vizjson", function(done) {
-
     var vizjson = "http://documentation.cartodb.com/api/v2/viz/318ab654-c989-11e4-97c6-0e9d821ea90d/viz.json"
-
     var image = cartodb.Image(vizjson).size(640, 480);
-
-    var basemap = { options: { visible: true, type: 'Tiled', urlTemplate: 'https://{s}.maps.nlp.nokia.com/maptile/2.1/maptile/newest/normal.day/{z}/{x}/{y}/256/png8?lg=eng&token=A7tBPacePg9Mj_zghvKt9Q&app_id=KuYppsdXZznpffJsKT24', subdomains: '1234', name: 'Nokia Day', className: 'nokia_day', attribution: "©2012 Nokia <a href='http://here.net/services/terms' target='_blank'>Terms of use</a>" }, infowindow: null, tooltip: null, id: '2c4a8c5e-2ba5-4068-8807-d916a01b48d5', order: 0, parent_id: null, children: [  ], type: 'tiled' }
-
+    var basemapURLTemplate = 'https://{s}.maps.nlp.nokia.com/maptile/2.1/maptile/newest/normal.day/{z}/{x}/{y}/256/png8?lg=eng&token=A7tBPacePg9Mj_zghvKt9Q&app_id=KuYppsdXZznpffJsKT24';
     image.getUrl(function() {
-      expect(image.imageOptions.basemap).toEqual(basemap);
+      expect(image.imageOptions.basemap.options.urlTemplate).toEqual(basemapURLTemplate);
       done();
     });
 
@@ -154,7 +150,7 @@ describe("Image", function() {
 
   });
 
-  it("shouldn't use hidden layers to generate the image", function(done) { 
+  it("shouldn't use hidden layers to generate the image", function(done) {
 
     var vizjson = "http://documentation.cartodb.com/api/v2/viz/42e98b9a-bcce-11e4-9d68-0e9d821ea90d/viz.json";
 

--- a/themes/css/map/cartodb-map-light.css
+++ b/themes/css/map/cartodb-map-light.css
@@ -1240,10 +1240,6 @@ div.cartodb-legend.choropleth li.graph {
   -o-border-radius: 3px;
   border-radius: 3px;
 
-  -moz-background-clip: padding;
-  -webkit-background-clip: padding;
-  background-clip: padding;
-
   /*box-shadow: inset 0px 0px 0px 1px rgba(0, 0, 0, 0.2);*/
   border: 1px solid #b3b3b3;
 }
@@ -1295,10 +1291,6 @@ div.cartodb-legend.density li.graph {
   -o-border-radius: 3px;
   border-radius: 3px;
 
-  -moz-background-clip: padding;
-  -webkit-background-clip: padding;
-  background-clip: padding;
-
   /*box-shadow: inset 0px 0px 0px 1px rgba(0, 0, 0, 0.2);*/
   border: 1px solid #b3b3b3;
 }
@@ -1335,10 +1327,6 @@ div.cartodb-legend.intensity li.graph {
   -ms-border-radius: 3px;
   -o-border-radius: 3px;
   border-radius: 3px;
-
-  -moz-background-clip: padding;
-  -webkit-background-clip: padding;
-  background-clip: padding;
 
   /*border: 1px solid #b3b3b3;*/
   -webkit-box-shadow: inset 0px 0px 0px 1px rgba(0, 0, 0, 0.2);
@@ -2344,7 +2332,7 @@ div.cartodb-timeslider p {
   padding: 10px;
 }
 
-.cartodb-slides-controller .slides-controller-content .prev, 
+.cartodb-slides-controller .slides-controller-content .prev,
 .cartodb-slides-controller .slides-controller-content .next { position:relative; }
 .cartodb-slides-controller .slides-controller-content .prev {
   display:inline-block; *display:inline; vertical-align:middle;
@@ -2365,10 +2353,10 @@ div.cartodb-timeslider p {
   opacity: .5;
 }
 
-.cartodb-slides-controller .slides-controller-content .prev:hover, 
+.cartodb-slides-controller .slides-controller-content .prev:hover,
 .cartodb-slides-controller .slides-controller-content .next:hover { opacity: .8; }
 
-.cartodb-slides-controller .slides-controller-content .prev:hover, 
+.cartodb-slides-controller .slides-controller-content .prev:hover,
 .cartodb-slides-controller .slides-controller-content .next:hover { opacity: .8; }
 
 .cartodb-slides-controller .slides-controller-content .prev:after { content: ''; position: absolute; top: -5px; left: 31px; height: 25px; width: 2px; background:#fff; opacity: .5; }


### PR DESCRIPTION
Working on https://github.com/CartoDB/cartodb/issues/5206, I've noticed that background-clip property is not well managed by html2canvas. Example: http://jsfiddle.net/njLnwrjd/.

Do you think @javierarce it is needed?

REVIEWER: @javierarce 