### PR TITLE
Allow pure custom Legends

### DIFF
--- a/src/geo/ui/legend.js
+++ b/src/geo/ui/legend.js
@@ -1099,7 +1099,8 @@ cdb.geo.ui.Legend.Custom = cdb.geo.ui.CustomLegend.extend({
       type: this.type,
       title: this.options.title,
       show_title: this.options.title ? true : false,
-      items: this.items.models
+      items: this.items.models,
+      template: this.options.template
     });
 
     this._bindModel();


### PR DESCRIPTION
This allows for legends that are purely custom (no data, just a template) to be rendered, otherwise
you get a "The legend is empty".

This check happens here: https://github.com/CartoDB/cartodb.js/blob/master/src/geo/ui/legend.js#L1062