### PR TITLE
Stack legend visible by default

### DIFF
--- a/themes/css/map/cartodb-map-light.css
+++ b/themes/css/map/cartodb-map-light.css
@@ -984,7 +984,6 @@ div.cartodb-legend-stack {
   position:absolute;
   bottom: 35px;
   right: 20px;
-  display:none;
 
   webkit-box-shadow: rgba(0, 0, 0, 0.2) 0 0 4px 2px;
   -moz-box-shadow: rgba(0, 0, 0, 0.2) 0 0 4px 2px;


### PR DESCRIPTION
reviewer @xavijam 

close #752 

CSS style for stacked legen was using `display: none;` that makes the stack legend hidden by default. I have remove that so by default it was visible like any other legend.