### PR TITLE
Feature 789 disable dragging

### DIFF
--- a/examples/map_dragging_disabled.html
+++ b/examples/map_dragging_disabled.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Map with dragging disabled | CartoDB.js</title>
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
+    <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
+    <style>
+      html, body, #map {
+        height: 100%;
+        padding: 0;
+        margin: 0;
+      }
+    </style>
+
+    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+  </head>
+  <body>
+    <div id="map"></div>
+
+    <!-- include cartodb.js library -->
+    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+
+    <script>
+      function main() {
+        cartodb.createVis('map', 'http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json', {
+            tiles_loader: true,
+            center_lat: 45,
+            center_lon: 30,
+            zoom: 4,
+            scrollwheel: false,
+            zoomControl: false
+        });
+      }
+
+      // window.onload = main;
+      var fn = function() { cartodb.load('../src/', main); }
+      window.onload = fn;
+    </script>
+  </body>
+</html>

--- a/src/geo/gmaps/gmaps.js
+++ b/src/geo/gmaps/gmaps.js
@@ -45,7 +45,11 @@ if(typeof(google) != "undefined" && typeof(google.maps) != "undefined") {
           minZoom: this.map.get('minZoom'),
           maxZoom: this.map.get('maxZoom'),
           disableDefaultUI: true,
+          // Set scrollwheel options
           scrollwheel: this.map.get("scrollwheel"),
+          // Allow dragging (and double click zoom)
+          draggable: this.map.get("drag"),
+          disableDoubleClickZoom: this.map.get("drag"),
           mapTypeControl:false,
           mapTypeId: google.maps.MapTypeId.ROADMAP,
           backgroundColor: 'white',

--- a/src/geo/leaflet/leaflet.js
+++ b/src/geo/leaflet/leaflet.js
@@ -42,8 +42,15 @@
         // remove the "powered by leaflet"
         this.map_leaflet.attributionControl.setPrefix('');
 
+        // Disable scrollwheel
         if (this.map.get("scrollwheel") == false) this.map_leaflet.scrollWheelZoom.disable();
+        // Disable keyboard
         if (this.map.get("keyboard") == false) this.map_leaflet.keyboard.disable();
+        // Disable dragging (also doubleClickZoom)
+        if (this.map.get("drag") == false) {
+          this.map_leaflet.dragging.disable();
+          this.map_leaflet.doubleClickZoom.disable();
+        }
 
       } else {
 

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -281,6 +281,7 @@ cdb.geo.Map = cdb.core.Model.extend({
     minZoom: 0,
     maxZoom: 40,
     scrollwheel: true,
+    drag: true,
     keyboard: true,
     provider: 'leaflet'
   },

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -336,6 +336,14 @@ var Vis = cdb.core.View.extend({
     var scrollwheel       = (options.scrollwheel === undefined)  ? data.scrollwheel : options.scrollwheel;
     var slides_controller = (options.slides_controller === undefined)  ? data.slides_controller : options.slides_controller;
 
+    // Do not allow pan map if zoom overlay and scrollwheel are disabled
+    // Check if zoom overlay is present.
+    var hasZoomOverlay = _.isObject(_.find(data.overlays, function(overlay) {
+      return overlay.type == "zoom"
+    }));
+
+    var allowDragging = hasZoomOverlay || scrollwheel;
+
     // map
     data.maxZoom || (data.maxZoom = 20);
     data.minZoom || (data.minZoom = 0);
@@ -372,6 +380,7 @@ var Vis = cdb.core.View.extend({
       minZoom: data.minZoom,
       legends: data.legends,
       scrollwheel: scrollwheel,
+      drag: allowDragging,
       provider: data.map_provider
     };
 

--- a/test/spec/geo/gmaps/gmaps.spec.js
+++ b/test/spec/geo/gmaps/gmaps.spec.js
@@ -133,7 +133,7 @@
         layer_definition: {
           version: '1.0.0',
           layers: [{
-             type: 'cartodb', 
+             type: 'cartodb',
              options: {
                sql: "select * from european_countries_export",
                cartocss: '#layer { polygon-fill: #000; polygon-opacity: 0.8;}',
@@ -234,4 +234,22 @@
         done();
       }, 2000);
     });
+
+    it("should disable gmaps dragging and double click zooming when the map has drag disabled", function() {
+      var container = $('<div>').css({
+          'height': '200px',
+          'width': '200px'
+      });
+      var map = new cdb.geo.Map({
+        drag: false
+      });
+      var mapView = new cdb.geo.GoogleMapsMapView({
+        el: container,
+        map: map
+      });
+
+      expect(mapView.map_googlemaps.get('draggable')).toBeFalsy();
+      expect(mapView.map_googlemaps.get('disableDoubleClickZoom')).toBeFalsy();
+    });
+
   });

--- a/test/spec/geo/leaflet/leaflet.spec.js
+++ b/test/spec/geo/leaflet/leaflet.spec.js
@@ -496,4 +496,21 @@ describe('LeafletMapView', function() {
     });
   });
 
+  it("should disable leaflet dragging and double click zooming when the map has drag disabled", function() {
+    var container = $('<div>').css({
+        'height': '200px',
+        'width': '200px'
+    });
+    var map = new cdb.geo.Map({
+      drag: false
+    });
+    var mapView = new cdb.geo.LeafletMapView({
+      el: container,
+      map: map
+    });
+
+    expect(mapView.map_leaflet.dragging.enabled()).toBeFalsy();
+    expect(mapView.map_leaflet.doubleClickZoom.enabled()).toBeFalsy();
+  });
+
 });

--- a/test/spec/geo/leaflet/leaflet.spec.js
+++ b/test/spec/geo/leaflet/leaflet.spec.js
@@ -139,7 +139,7 @@ describe('LeafletMapView', function() {
   });
 
   it("should create the cartodb logo", function(done) {
-    layer = new cdb.geo.CartoDBLayer({ 
+    layer = new cdb.geo.CartoDBLayer({
       table_name: "INVENTADO",
       user_name: 'test',
       tile_style: 'test'
@@ -154,7 +154,7 @@ describe('LeafletMapView', function() {
   });
 
   it("should not add the cartodb logo when cartodb_logo = false", function(done) {
-    layer = new cdb.geo.CartoDBLayer({ 
+    layer = new cdb.geo.CartoDBLayer({
       table_name: "INVENTADO",
       user_name: 'test',
       tile_style: 'test',
@@ -495,5 +495,5 @@ describe('LeafletMapView', function() {
       expect(attributions).toEqual('Stamen, custom attribution, CartoDB attribution');
     });
   });
-});
 
+});

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -444,7 +444,7 @@ describe("Vis", function() {
 
   describe("dragging option", function() {
 
-    it("should be enabled with zoom overlay and scrollwheel enabled", function(done) {
+    it("should be enabled with zoom overlay and scrollwheel enabled", function() {
       var container = $('<div>').css('height', '200px');
       var vis = new cdb.vis.Vis({el: container});
 
@@ -472,15 +472,11 @@ describe("Vis", function() {
         ],
       };
 
-      vis.load(mapConfig)
-        .done(function() {
-          expect(vis.map.get('drag')).toBeTruthy();
-          done();
-        });
-
+      vis.load(mapConfig);
+      expect(vis.map.get('drag')).toBeTruthy();
     });
 
-    it("should be enabled with zoom overlay and scrollwheel disabled", function(done) {
+    it("should be enabled with zoom overlay and scrollwheel disabled", function() {
       var container = $('<div>').css('height', '200px');
       var vis = new cdb.vis.Vis({el: container});
 
@@ -508,15 +504,11 @@ describe("Vis", function() {
         ],
       };
 
-      vis.load(mapConfig)
-        .done(function() {
-          expect(vis.map.get('drag')).toBeTruthy();
-          done();
-        });
-
+      vis.load(mapConfig);
+      expect(vis.map.get('drag')).toBeTruthy();
     });
 
-    it("should be enabled without zoom overlay and scrollwheel enabled", function(done) {
+    it("should be enabled without zoom overlay and scrollwheel enabled", function() {
       var container = $('<div>').css('height', '200px');
       var vis = new cdb.vis.Vis({el: container});
 
@@ -533,15 +525,11 @@ describe("Vis", function() {
         overlays: [],
       };
 
-      vis.load(mapConfig)
-        .done(function() {
-          expect(vis.map.get('drag')).toBeTruthy();
-          done();
-        });
-
+      vis.load(mapConfig);
+      expect(vis.map.get('drag')).toBeTruthy();
     });
 
-    it("should be disabled without zoom overlay and scrollwheel disabled", function(done) {
+    it("should be disabled without zoom overlay and scrollwheel disabled", function() {
       var container = $('<div>').css('height', '200px');
       var vis = new cdb.vis.Vis({el: container});
 
@@ -558,46 +546,8 @@ describe("Vis", function() {
         overlays: [],
       };
 
-      vis.load(mapConfig)
-        .done(function() {
-          expect(vis.map.get('drag')).toBeFalsy();
-          done();
-        });
-
-    });
-
-    it("should disable leaflet dragging and double click zooming when the map has drag disabled", function() {
-      var container = $('<div>').css({
-          'height': '200px',
-          'width': '200px'
-      });
-      var map = new cdb.geo.Map({
-        drag: false
-      });
-      var mapView = new cdb.geo.LeafletMapView({
-        el: container,
-        map: map
-      });
-
-      expect(mapView.map_leaflet.dragging.enabled()).toBeFalsy();
-      expect(mapView.map_leaflet.doubleClickZoom.enabled()).toBeFalsy();
-    });
-
-    it("should disable gmaps dragging and double click zooming when the map has drag disabled", function() {
-      var container = $('<div>').css({
-          'height': '200px',
-          'width': '200px'
-      });
-      var map = new cdb.geo.Map({
-        drag: false
-      });
-      var mapView = new cdb.geo.GoogleMapsMapView({
-        el: container,
-        map: map
-      });
-
-      expect(mapView.map_googlemaps.get('draggable')).toBeFalsy();
-      expect(mapView.map_googlemaps.get('disableDoubleClickZoom')).toBeFalsy();
+      vis.load(mapConfig);
+      expect(vis.map.get('drag')).toBeFalsy();
     });
 
   });

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -1,7 +1,6 @@
 
 describe("Overlay", function() {
 
-
   it("should register and create a type", function() {
     var _data;
     cdb.vis.Overlay.register('test', function(data) {
@@ -89,7 +88,7 @@ describe("Vis", function() {
     expect(this.mapConfig.center[0]).not.toEqual(43.3);
     expect(this.mapConfig.center[1]).not.toEqual("ham");
   })
-  
+
   it("should parse bounds values if they are correct", function() {
     this.container = $('<div>').css('height', '200px');
     var opts = {
@@ -410,7 +409,7 @@ describe("Vis", function() {
     ];
 
     this.vis.load(this.mapConfig);
-    
+
     setTimeout(function() {
       var scripts = document.getElementsByTagName('script'),
           torqueRe = /\/cartodb\.mod\.torque\.js/;
@@ -438,9 +437,139 @@ describe("Vis", function() {
     };
 
     layers = null;
-    
+
     this.vis.load(this.mapConfig, opts);
     expect(this.vis.map.layers.at(0).get('type')).toEqual('GMapsBase');
+  });
+
+  describe("dragging option", function() {
+
+    it("should be enabled with zoom overlay and scrollwheel enabled", function(done) {
+      var container = $('<div>').css('height', '200px');
+      var vis = new cdb.vis.Vis({el: container});
+
+      var mapConfig = {
+        updated_at: 'cachebuster',
+        title: "irrelevant",
+        url: "http://cartodb.com",
+        center: [40.044, -101.95],
+        bounding_box_sw: [20, -140],
+        bounding_box_ne: [ 55, -50],
+        zoom: 4,
+        bounds: [[1, 2],[3, 4]],
+        scrollwheel: true,
+        overlays: [
+          {
+            type: "zoom",
+            order: 6,
+            options: {
+              x: 20,
+              y: 20,
+              display: true
+            },
+            template: ""
+          }
+        ],
+      };
+
+      vis.load(mapConfig);
+
+      setTimeout(function () {
+        expect(vis.map.get('drag')).toEqual(true);
+        done();
+      }, 500);
+
+    });
+
+    it("should be enabled with zoom overlay and scrollwheel disabled", function(done) {
+      var container = $('<div>').css('height', '200px');
+      var vis = new cdb.vis.Vis({el: container});
+
+      var mapConfig = {
+        updated_at: 'cachebuster',
+        title: "irrelevant",
+        url: "http://cartodb.com",
+        center: [40.044, -101.95],
+        bounding_box_sw: [20, -140],
+        bounding_box_ne: [ 55, -50],
+        zoom: 4,
+        bounds: [[1, 2],[3, 4]],
+        scrollwheel: false,
+        overlays: [
+          {
+            type: "zoom",
+            order: 6,
+            options: {
+              x: 20,
+              y: 20,
+              display: true
+            },
+            template: ""
+          }
+        ],
+      };
+
+      vis.load(mapConfig);
+
+      setTimeout(function () {
+        expect(vis.map.get('drag')).toEqual(true);
+        done();
+      }, 500);
+
+    });
+
+    it("should be enabled without zoom overlay and scrollwheel enabled", function(done) {
+      var container = $('<div>').css('height', '200px');
+      var vis = new cdb.vis.Vis({el: container});
+
+      var mapConfig = {
+        updated_at: 'cachebuster',
+        title: "irrelevant",
+        url: "http://cartodb.com",
+        center: [40.044, -101.95],
+        bounding_box_sw: [20, -140],
+        bounding_box_ne: [ 55, -50],
+        zoom: 4,
+        bounds: [[1, 2],[3, 4]],
+        scrollwheel: true,
+        overlays: [],
+      };
+
+      vis.load(mapConfig);
+
+      setTimeout(function () {
+        expect(vis.map.get('drag')).toEqual(true);
+        done();
+      }, 500);
+
+    });
+
+    it("should be disabled without zoom overlay and scrollwheel disabled", function(done) {
+      var container = $('<div>').css('height', '200px');
+      var vis = new cdb.vis.Vis({el: container});
+
+      var mapConfig = {
+        updated_at: 'cachebuster',
+        title: "irrelevant",
+        url: "http://cartodb.com",
+        center: [40.044, -101.95],
+        bounding_box_sw: [20, -140],
+        bounding_box_ne: [ 55, -50],
+        zoom: 4,
+        bounds: [[1, 2],[3, 4]],
+        scrollwheel: false,
+        overlays: [],
+      };
+
+      vis.load(mapConfig);
+
+      setTimeout(function () {
+        expect(vis.map.get('drag')).toEqual(false);
+        done();
+      }, 500);
+
+    });
+
   });
 
   describe("Legends", function() {

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -472,12 +472,11 @@ describe("Vis", function() {
         ],
       };
 
-      vis.load(mapConfig);
-
-      setTimeout(function () {
-        expect(vis.map.get('drag')).toEqual(true);
-        done();
-      }, 500);
+      vis.load(mapConfig)
+        .done(function() {
+          expect(vis.map.get('drag')).toBeTruthy();
+          done();
+        });
 
     });
 
@@ -509,12 +508,11 @@ describe("Vis", function() {
         ],
       };
 
-      vis.load(mapConfig);
-
-      setTimeout(function () {
-        expect(vis.map.get('drag')).toEqual(true);
-        done();
-      }, 500);
+      vis.load(mapConfig)
+        .done(function() {
+          expect(vis.map.get('drag')).toBeTruthy();
+          done();
+        });
 
     });
 
@@ -535,12 +533,11 @@ describe("Vis", function() {
         overlays: [],
       };
 
-      vis.load(mapConfig);
-
-      setTimeout(function () {
-        expect(vis.map.get('drag')).toEqual(true);
-        done();
-      }, 500);
+      vis.load(mapConfig)
+        .done(function() {
+          expect(vis.map.get('drag')).toBeTruthy();
+          done();
+        });
 
     });
 
@@ -561,13 +558,46 @@ describe("Vis", function() {
         overlays: [],
       };
 
-      vis.load(mapConfig);
+      vis.load(mapConfig)
+        .done(function() {
+          expect(vis.map.get('drag')).toBeFalsy();
+          done();
+        });
 
-      setTimeout(function () {
-        expect(vis.map.get('drag')).toEqual(false);
-        done();
-      }, 500);
+    });
 
+    it("should disable leaflet dragging and double click zooming when the map has drag disabled", function() {
+      var container = $('<div>').css({
+          'height': '200px',
+          'width': '200px'
+      });
+      var map = new cdb.geo.Map({
+        drag: false
+      });
+      var mapView = new cdb.geo.LeafletMapView({
+        el: container,
+        map: map
+      });
+
+      expect(mapView.map_leaflet.dragging.enabled()).toBeFalsy();
+      expect(mapView.map_leaflet.doubleClickZoom.enabled()).toBeFalsy();
+    });
+
+    it("should disable gmaps dragging and double click zooming when the map has drag disabled", function() {
+      var container = $('<div>').css({
+          'height': '200px',
+          'width': '200px'
+      });
+      var map = new cdb.geo.Map({
+        drag: false
+      });
+      var mapView = new cdb.geo.GoogleMapsMapView({
+        el: container,
+        map: map
+      });
+
+      expect(mapView.map_googlemaps.get('draggable')).toBeFalsy();
+      expect(mapView.map_googlemaps.get('disableDoubleClickZoom')).toBeFalsy();
     });
 
   });


### PR DESCRIPTION
Reviewer @alonsogarciapablo 

Close #789, close https://github.com/CartoDB/cartodb/issues/5995 

This PR allows to disable the map dragging when no zoomControl (overlay) is specified and the `scrollwheel` option is disabled.

**Note with this implementation you can only set dragging at construction time, for the moment is not possible to change the property later.**

Modifications:

- new `drag` property on `cdb.geo.Map` model class.
- Both `cdb.geo.GoogleMapsMapView` and `cdb.geo.LeafletMapView` uses the model `drag` attribute to initialize the map.

> Notes:
> - Can’t test `cdb.geo.LeafletMapView`. Although you disable dragging map continues moving using `panTo` or `setView`. The alternative is emulate a mouse dragging effect.