### PR TITLE
Remove capitalize in !important statements

### DIFF
--- a/themes/css/map/cartodb-map-light.css
+++ b/themes/css/map/cartodb-map-light.css
@@ -299,8 +299,8 @@ only screen and (                min-resolution: 2dppx) {
     width:80%;
   }
   div.cartodb-zoom a {
-    background:url('../img/other@2x.png') no-repeat 0 0!Important;
-    background-size: 113px 34px!Important;
+    background:url('../img/other@2x.png') no-repeat 0 0!important;
+    background-size: 113px 34px!important;
   }
   div.cartodb-zoom a.zoom_in {
     background-position: -68px 9px!important
@@ -309,31 +309,31 @@ only screen and (                min-resolution: 2dppx) {
     background-position:-94px 10px!important;
   }
   div.cartodb-header div.social a.facebook {
-    background:url('../img/other@2x.png') no-repeat 0 0!Important;
-    background-size: 113px 34px!Important;
+    background:url('../img/other@2x.png') no-repeat 0 0!important;
+    background-size: 113px 34px!important;
   }
   div.cartodb-header div.social a.twitter {
-    background:url('../img/other@2x.png') no-repeat -26px 0!Important;
-    background-size: 113px 34px!Important;
+    background:url('../img/other@2x.png') no-repeat -26px 0!important;
+    background-size: 113px 34px!important;
   }
   div.cartodb-searchbox span.loader {
-    background: url('../img/loader@2x.gif') no-repeat center center white!Important;
-    background-size: 16px 16px!Important;
+    background: url('../img/loader@2x.gif') no-repeat center center white!important;
+    background-size: 16px 16px!important;
   }
   div.cartodb-mobile .aside div.cartodb-searchbox span.loader {
-    background: url('../img/dark_loader@2x.gif') no-repeat center center #292929!Important;
-    background-size: 16px 16px!Important;
+    background: url('../img/dark_loader@2x.gif') no-repeat center center #292929!important;
+    background-size: 16px 16px!important;
   }
   div.cartodb-tiles-loader div.loader {
-    background: url('../img/loader@2x.gif') no-repeat center center white!Important;
-    background-size: 16px 16px!Important;
+    background: url('../img/loader@2x.gif') no-repeat center center white!important;
+    background-size: 16px 16px!important;
   }
   div.cartodb-searchbox input.submit {
-    background:url('../img/other@2x.png') no-repeat -56px 0!Important;
-    background-size: 113px 34px!Important;
+    background:url('../img/other@2x.png') no-repeat -56px 0!important;
+    background-size: 113px 34px!important;
   }
   .cartodb-mobile .aside .cartodb-searchbox input.submit {
-    background:url('../img/mobile_zoom.png') no-repeat 0 0!Important;
+    background:url('../img/mobile_zoom.png') no-repeat 0 0!important;
   }
   .cartodb-mobile div.cartodb-slides-controller div.slides-controller-content a.prev {
     background: url('../img/slide_left@2x.png') no-repeat;


### PR DESCRIPTION
PR initially posted here : https://github.com/CartoDB/cartodb/pull/6112  cc @xavijam

It seems that grunt-sass (node-sass) cannot compile styles from cartodb.css because some !important statements are capitalized (!Important). 

![image](https://cloud.githubusercontent.com/assets/5102622/11070183/8df1fd02-87da-11e5-8dc0-43c388c7d260.png)

I switched all the !Important to !important in cartodb.css 