### PR TITLE
Add histogram selection + time info for torque time-series widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "semver": "~4.1.0",
     "source-map-support": "0.3.2",
     "time-grunt": "~0.3.1",
-    "torque.js": "2.11.4",
+    "torque.js": "2.14.0",
     "underscore": "1.8.3",
     "watchify": "3.4.0"
   },

--- a/src/geo/gmaps/gmaps-torque-layer-view.js
+++ b/src/geo/gmaps/gmaps-torque-layer-view.js
@@ -51,7 +51,7 @@ var GMapsTorqueLayerView = function(layerModel, gmapsMap) {
     this.play();
   }
 
-  layerModel.initBindsForTorqueLayerView(this);
+  layerModel.initForTorqueLayerView(this);
 };
 
 _.extend(

--- a/src/geo/leaflet/leaflet-torque-layer.js
+++ b/src/geo/leaflet/leaflet-torque-layer.js
@@ -74,7 +74,7 @@ var LeafletTorqueLayer = L.TorqueLayer.extend({
       this.trigger('loading');
     }, this);
 
-    layerModel.initBindsForTorqueLayerView(this);
+    layerModel.initForTorqueLayerView(this);
   },
 
   onAdd: function(map) {

--- a/src/geo/map/torque-layer.js
+++ b/src/geo/map/torque-layer.js
@@ -46,8 +46,9 @@ var TorqueLayer = MapLayer.extend({
     // Binds events from view to this moel
     torqueLayerView.bind('play', this._setWithoutReloadingTiles.bind(this, 'isRunning', true))
     torqueLayerView.bind('pause', this._setWithoutReloadingTiles.bind(this, 'isRunning', false))
-    torqueLayerView.bind('change:time', function() {
-      this._setWithoutReloadingTiles('step', torqueLayerView.getStep());
+    torqueLayerView.bind('change:time', function(changes) {
+      this._setWithoutReloadingTiles('time', changes.time);
+      this._setWithoutReloadingTiles('step', changes.step);
     }, this);
     torqueLayerView.bind('change:stepsRange', function() {
       this._setWithoutReloadingTiles('stepsRange', torqueLayerView.getStepsRange());
@@ -57,6 +58,7 @@ var TorqueLayer = MapLayer.extend({
     this.set({
       isRunning: torqueLayerView.isRunning(),
       timeBounds: torqueLayerView.getTimeBounds(),
+      time: torqueLayerView.getTime(),
       step: torqueLayerView.getStep(),
       steps: torqueLayerView.options.steps,
       stepsRange: torqueLayerView.getStepsRange()

--- a/src/geo/ui/widgets/histogram/content-view.js
+++ b/src/geo/ui/widgets/histogram/content-view.js
@@ -209,15 +209,11 @@ module.exports = WidgetContent.extend({
     this.histogramChartView.removeSelection();
 
     var data = this.originalData;
-    var start = data[loBarIndex].start;
-    var end = data[hiBarIndex - 1].end;
-
-    this._setRange(start, end);
+    this.filter.setRange(
+      data[loBarIndex].start,
+      data[hiBarIndex - 1].end
+    );
     this._updateStats();
-  },
-
-  _setRange: function(start, end) {
-    this.filter.setRange({ min: start, max: end });
   },
 
   _onBrushEnd: function(loBarIndex, hiBarIndex) {
@@ -228,17 +224,15 @@ module.exports = WidgetContent.extend({
     }
 
     var properties = { filter_enabled: true, lo_index: loBarIndex, hi_index: hiBarIndex };
-
     if (!this.viewModel.get('zoomed')) {
       properties.zoom_enabled = true;
     }
-
     this.viewModel.set(properties);
 
-    var start = data[loBarIndex].start;
-    var end = data[hiBarIndex - 1].end;
-
-    this._setRange(start, end);
+    this.filter.setRange(
+      data[loBarIndex].start,
+      data[hiBarIndex - 1].end
+    );
     this._updateStats();
   },
 
@@ -405,6 +399,7 @@ module.exports = WidgetContent.extend({
 
     this.dataModel.set({ own_filter: null });
     this.viewModel.set({ zoom_enabled: false, filter_enabled: false, lo_index: null, hi_index: null });
+
     this.filter.unsetRange();
 
     this.histogramChartView.contract(this.canvasHeight);

--- a/src/geo/ui/widgets/time-series/histogram-view.js
+++ b/src/geo/ui/widgets/time-series/histogram-view.js
@@ -34,6 +34,14 @@ module.exports = View.extend({
     });
     this.add_related_model(this.viewModel);
     this.viewModel.bind('change:width', this._onChangeWidth, this);
+
+    this.model.bind('change:data', this._onChangeData, this);
+  },
+
+  _onChangeData: function() {
+    if (this.chartView) {
+      this.chartView.replaceData(this.model.getData());
+    }
   },
 
   render: function() {

--- a/src/geo/ui/widgets/time-series/histogram-view.js
+++ b/src/geo/ui/widgets/time-series/histogram-view.js
@@ -74,14 +74,10 @@ module.exports = View.extend({
 
   _onBrushEnd: function(loBarIndex, hiBarIndex) {
     var data = this.model.getData();
-    this._setRange(
+    this.filter.setRange(
       data[loBarIndex].start,
       data[hiBarIndex - 1].end
     );
-  },
-
-  _setRange: function(start, end) {
-    this.filter.setRange({ min: start, max: end });
   },
 
   _onChangeWidth: function() {

--- a/src/geo/ui/widgets/time-series/torque-content-view.js
+++ b/src/geo/ui/widgets/time-series/torque-content-view.js
@@ -1,6 +1,7 @@
 var _ = require('underscore');
 var View = require('cdb/core/view');
 var TorqueControlsView = require('./torque-controls-view');
+var TorqueTimeInfoView = require('./torque-time-info-view');
 var placeholderTemplate = require('../histogram/placeholder.tpl');
 var TorqueHistogramView = require('./torque-histogram-view');
 
@@ -28,6 +29,9 @@ module.exports = View.extend({
 
   _renderContent: function() {
     this._appendView(new TorqueControlsView({
+      model: this.options.torqueLayerModel
+    }));
+    this._appendView(new TorqueTimeInfoView({
       model: this.options.torqueLayerModel
     }));
     this._appendView(new TorqueHistogramView(this.options));

--- a/src/geo/ui/widgets/time-series/torque-controls-view.js
+++ b/src/geo/ui/widgets/time-series/torque-controls-view.js
@@ -1,4 +1,3 @@
-var _ = require('underscore');
 var View = require('cdb/core/view');
 var template = require('./torque-controls.tpl');
 
@@ -16,18 +15,13 @@ module.exports = View.extend({
   },
 
   render: function() {
-    if (_.isNumber(this.model.get('step'))) {
-      this.$el.html(
-        template({
-          label: this.model.get('isRunning')
-            ? '❚❚'
-            : '▶'
-        })
-      );
-      this.show();
-    } else {
-      this.hide();
-    }
+    this.$el.html(
+      template({
+        label: this.model.get('isRunning')
+          ? '❚❚'
+          : '▶'
+      })
+    );
 
     return this;
   },

--- a/src/geo/ui/widgets/time-series/torque-histogram-view.js
+++ b/src/geo/ui/widgets/time-series/torque-histogram-view.js
@@ -50,6 +50,14 @@ module.exports = View.extend({
     this._viewModel.bind('change:width', this._onChangeWidth, this);
     this.add_related_model(this._viewModel);
     this._onChangeWidth();
+
+    this.model.bind('change:data', this._onChangeData, this);
+  },
+
+  _onChangeData: function() {
+    if (this._chartView) {
+      this._chartView.replaceData(this.model.getData());
+    }
   },
 
   render: function() {

--- a/src/geo/ui/widgets/time-series/torque-histogram-view.js
+++ b/src/geo/ui/widgets/time-series/torque-histogram-view.js
@@ -8,6 +8,7 @@ var TorqueTimeMarkerview = require('./torque-time-marker-view');
 /**
  * Torque time-series histogram view.
  * Extends the common histogram chart view with time-control
+ * this.model is a histogram model
  */
 module.exports = View.extend({
 
@@ -79,7 +80,8 @@ module.exports = View.extend({
     this._chartView.show();
 
     var timeMarkerView = new TorqueTimeMarkerview({
-      chartCanvas: this._chartView.canvas,
+      model: this.model, // a histogram model
+      chartView: this._chartView,
       viewModel: this._viewModel,
       torqueLayerModel: this._torqueLayerModel
     });
@@ -93,6 +95,7 @@ module.exports = View.extend({
       data[loBarIndex].start,
       data[hiBarIndex - 1].end
     );
+    this._torqueLayerModel.setStepsRange(loBarIndex, hiBarIndex);
   },
 
   _onChangeWidth: function() {

--- a/src/geo/ui/widgets/time-series/torque-histogram-view.js
+++ b/src/geo/ui/widgets/time-series/torque-histogram-view.js
@@ -24,9 +24,10 @@ module.exports = View.extend({
 
   initialize: function() {
     if (!this.options.torqueLayerModel) throw new Error('torqeLayerModel is required');
-    if (!this.options.filter) throw new Error('filter is required');
+    if (!this.options.rangeFilter) throw new Error('rangeFilter is required');
 
-    this._filter = this.options.filter;
+    this._rangeFilter = this.options.rangeFilter;
+    this._torqueLayerModel = this.options.torqueLayerModel;
 
     _.bindAll(this, '_onWindowResize');
     $(window).bind('resize', this._onWindowResize);
@@ -80,7 +81,7 @@ module.exports = View.extend({
     var timeMarkerView = new TorqueTimeMarkerview({
       chartCanvas: this._chartView.canvas,
       viewModel: this._viewModel,
-      torqueLayerModel: this.options.torqueLayerModel
+      torqueLayerModel: this._torqueLayerModel
     });
     this.addView(timeMarkerView);
     timeMarkerView.render();
@@ -88,14 +89,10 @@ module.exports = View.extend({
 
   _onBrushEnd: function(loBarIndex, hiBarIndex) {
     var data = this.model.getData();
-    this._setRange(
+    this._rangeFilter.setRange(
       data[loBarIndex].start,
       data[hiBarIndex - 1].end
     );
-  },
-
-  _setRange: function(start, end) {
-    this._filter.setRange({ min: start, max: end });
   },
 
   _onChangeWidth: function() {

--- a/src/geo/ui/widgets/time-series/torque-histogram-view.js
+++ b/src/geo/ui/widgets/time-series/torque-histogram-view.js
@@ -26,7 +26,7 @@ module.exports = View.extend({
     if (!this.options.torqueLayerModel) throw new Error('torqeLayerModel is required');
     if (!this.options.filter) throw new Error('filter is required');
 
-    this._filter = this.options._filter;
+    this._filter = this.options.filter;
 
     _.bindAll(this, '_onWindowResize');
     $(window).bind('resize', this._onWindowResize);

--- a/src/geo/ui/widgets/time-series/torque-time-info-view.js
+++ b/src/geo/ui/widgets/time-series/torque-time-info-view.js
@@ -1,0 +1,27 @@
+var d3 = require('d3');
+var View = require('cdb/core/view');
+
+/**
+ * View rendering the current step time
+ *
+ * Model is expected to be a torque layer model
+ */
+module.exports = View.extend({
+
+  initialize: function() {
+    this.model.bind('change:step', this.render, this);
+
+    // for format rules see https://github.com/mbostock/d3/wiki/Time-Formatting
+    this._formatter = d3.time.format('%H:%M %x');
+  },
+
+  render: function() {
+    this.$el.html(
+      this._formatter(
+        new Date(this.model.get('time'))
+      )
+    );
+
+    return this;
+  }
+});

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -119,7 +119,7 @@ var Vis = View.extend({
         createContentView: function(widget, layer) {
           return new TorqueTimeSeriesContentView({
             model: widget,
-            filter: widget.filter,
+            rangeFilter: widget.filter,
             torqueLayerModel: layer
           });
         },

--- a/src/windshaft/filters/range.js
+++ b/src/windshaft/filters/range.js
@@ -7,20 +7,23 @@ module.exports = WindshaftFilterBase.extend({
     return _.isUndefined(this.get('min')) && _.isUndefined(this.get('max'));
   },
 
-  setRange: function(range) {
-    this.set(range);
+  setRange: function(min, max) {
+    this.set({
+      min: min,
+      max: max
+    });
   },
 
-  unsetRange: function(range) {
-    this.unset('min', { silent: true });
-    this.unset('max', { silent: true });
-    this.trigger('change', this);
+  unsetRange: function() {
+    this.setRange(undefined, undefined);
   },
-
 
   toJSON: function() {
     var json = {};
-    json[this.get('widgetId')] = { min: this.get('min'), max: this.get('max') };
+    json[this.get('widgetId')] = {
+      min: this.get('min'),
+      max: this.get('max')
+    };
 
     return json;
   }

--- a/test/spec/geo/ui/widgets/time-series/torque-content-view.spec.js
+++ b/test/spec/geo/ui/widgets/time-series/torque-content-view.spec.js
@@ -10,7 +10,7 @@ describe('geo/ui/widgets/time-series/torque-content-view', function() {
       this.options = options;
     }.bind(this);
 
-    this.rangeFilter = new RangeFilter;
+    this.rangeFilter = new RangeFilter();
     this.torqueLayerModel = new TorqueLayerModel();
     this.view = new TimeContentView({
       model: this.model,

--- a/test/spec/geo/ui/widgets/time-series/torque-content-view.spec.js
+++ b/test/spec/geo/ui/widgets/time-series/torque-content-view.spec.js
@@ -1,4 +1,5 @@
 var HistogramModel = require('cdb/geo/ui/widgets/histogram/model');
+var RangeFilter = require('cdb/windshaft/filters/range');
 var TorqueLayerModel = require('cdb/geo/map/torque-layer');
 var TimeContentView = require('cdb/geo/ui/widgets/time-series/torque-content-view');
 
@@ -9,12 +10,12 @@ describe('geo/ui/widgets/time-series/torque-content-view', function() {
       this.options = options;
     }.bind(this);
 
-    this.filter = {};
+    this.rangeFilter = new RangeFilter;
     this.torqueLayerModel = new TorqueLayerModel();
     this.view = new TimeContentView({
       model: this.model,
       torqueLayerModel: this.torqueLayerModel,
-      filter: this.filter
+      rangeFilter: this.rangeFilter
     });
     this.renderResult = this.view.render();
   });

--- a/test/spec/geo/ui/widgets/time-series/torque-time-marker-view.spec.js
+++ b/test/spec/geo/ui/widgets/time-series/torque-time-marker-view.spec.js
@@ -1,0 +1,113 @@
+var HistogramModel = require('cdb/geo/ui/widgets/histogram/model');
+var HistogramChartView = require('cdb/geo/ui/widgets/histogram/chart');
+var Model = require('cdb/core/model');
+var TorqueLayerModel = require('cdb/geo/map/torque-layer');
+var TorqueTimeMarkerView = require('cdb/geo/ui/widgets/time-series/torque-time-marker-view');
+
+describe('geo/ui/widgets/time-series/torque-time-marker-view', function() {
+  beforeEach(function() {
+    this.model = new HistogramModel({
+      bins: 256
+    });
+    this.torqueLayerModel = new TorqueLayerModel({
+      isRunning: false,
+      step: 0,
+      steps: 256
+    });
+
+    this.histogramChartMargins = {
+      top: 1,
+      right: 2,
+      bottom: 3,
+      left: 4
+    };
+    this.viewModel = new Model({
+      histogramChartMargins: this.histogramChartMargins,
+      histogramChartWidth: 400,
+      histogramChartHeight: 200
+    });
+    this.chartView = new HistogramChartView({
+      margin: this.histogramChartMargins,
+      width: 400,
+      height: 200,
+      data: [{
+        start: 0,
+        end: 1
+      }]
+    });
+
+    this.view = new TorqueTimeMarkerView({
+      model: this.model,
+      viewModel: this.viewModel,
+      torqueLayerModel: this.torqueLayerModel,
+      chartView: this.chartView
+    });
+    this.renderResult = this.view.render();
+  });
+
+  it('should render ok', function() {
+    expect(this.renderResult).toBe(this.view);
+  });
+
+  describe('when step changes', function() {
+    describe('when is not dragging the marker', function() {
+      beforeEach(function() {
+        spyOn(this.view.timeMarker, 'data').and.callThrough();
+        this.torqueLayerModel.set('step', 40);
+      });
+
+      it('should move the time-marker', function() {
+        expect(this.view.timeMarker.data).toHaveBeenCalled();
+        expect(this.view.timeMarker.data.calls.argsFor(1)[0]).toEqual([{ x: 62.5, y: 0 }]);
+      });
+    });
+
+    describe('when is dragging the marker', function() {
+      beforeEach(function() {
+        spyOn(this.view.timeMarker, 'data').and.callThrough();
+        this.viewModel.set('isDragging', true);
+        this.torqueLayerModel.set('step', 40);
+      });
+
+      it('should not change anything', function() {
+        expect(this.view.timeMarker.data).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when stepsRange changes', function() {
+    beforeEach(function() {
+      spyOn(this.chartView, 'removeSelection');
+      spyOn(this.chartView, 'selectRange');
+    });
+
+    describe('when range matches data bins', function() {
+      beforeEach(function() {
+        this.torqueLayerModel.set('stepsRange', {
+          start: 0,
+          end: this.model.get('bins')
+        });
+      });
+
+      it('should remove selection if stepsRange matches the data bins', function() {
+        expect(this.chartView.removeSelection).toHaveBeenCalled();
+        expect(this.chartView.selectRange).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when range is custom', function() {
+      beforeEach(function() {
+        this.torqueLayerModel.set('stepsRange', {
+          start: 12,
+          end: 21
+        });
+      });
+
+      it('should set custom selection range', function() {
+        expect(this.chartView.selectRange).toHaveBeenCalled();
+        expect(this.chartView.selectRange.calls.argsFor(0)).toEqual([12, 21]);
+        expect(this.chartView.removeSelection).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/test/spec/windshaft/filters/range.spec.js
+++ b/test/spec/windshaft/filters/range.spec.js
@@ -1,0 +1,65 @@
+var RangeFilter = require('cdb/windshaft/filters/range');
+
+describe('windshaft/filters/range', function() {
+  beforeEach(function() {
+    var widgetId = 'range-filter-uuid';
+    this.filter = new RangeFilter({
+      widgetId: this.widgetId
+    });
+  });
+
+  it('should have a undefined range values by default', function() {
+    expect(this.filter.get('min')).toBeUndefined();
+    expect(this.filter.get('max')).toBeUndefined();
+  });
+
+  describe('.setRange', function() {
+    it('should set the range', function() {
+      this.filter.setRange(2, 4);
+      expect(this.filter.get('min')).toEqual(2);
+      expect(this.filter.get('max')).toEqual(4);
+    });
+  });
+
+  describe('.isEmpty', function() {
+    it('should return true if there are no range values set', function() {
+      expect(this.filter.isEmpty()).toBe(true);
+      this.filter.setRange(1, 2);
+      expect(this.filter.isEmpty()).toBe(false);
+    });
+  });
+
+  describe('.unsetRange', function() {
+    beforeEach(function() {
+      this.filter.setRange(2, 4);
+      this.changeSpy = jasmine.createSpy('change');
+      this.filter.bind('change', this.changeSpy);
+      this.filter.unsetRange();
+    });
+
+    it('should remove range', function() {
+      expect(this.filter.get('min')).toBeUndefined();
+      expect(this.filter.get('max')).toBeUndefined();
+    });
+
+    it('should only trigger change event once', function() {
+      expect(this.changeSpy).toHaveBeenCalled();
+      expect(this.changeSpy.calls.count()).toEqual(1);
+    });
+  });
+
+  describe('.toJSON', function() {
+    beforeEach(function() {
+      this.filter.setRange(2, 4);
+      this.res = this.filter.toJSON();
+    });
+
+    it('should return a JSON object', function() {
+      expect(this.res).toEqual(jasmine.any(Object));
+      var res = this.res[this.widgetId];
+      expect(res).toEqual(jasmine.any(Object));
+      expect(res.min).toEqual(2);
+      expect(res.max).toEqual(4);
+    });
+  });
+});


### PR DESCRIPTION
Waypoint for #786

![torque-range3](https://cloud.githubusercontent.com/assets/978461/11399826/0a7ef72a-938a-11e5-8f3d-b766adee10b2.gif)

This PR adds:
- Torque: animation for a selected time-series range
- Torque: format time-marker step info (time+date)

Basically just minor view changes, although had to modify the torque layer model slightly to handle events properly (for steps/range changes. 

Also notice that this PR depends on having a new minor version of torque.js, these changes are using https://github.com/CartoDB/torque/pull/243 for now I'm testing with a local checkout of that repo and using `npm link` to verify the changes working for this branch.

@javierarce can you review?
cc @javisantana for torque layer model changes