### PR TITLE
Fix torque time-series control icons

### DIFF
--- a/src/geo/ui/widgets/time-series/torque-controls-view.js
+++ b/src/geo/ui/widgets/time-series/torque-controls-view.js
@@ -7,7 +7,7 @@ var template = require('./torque-controls.tpl');
 module.exports = View.extend({
 
   tagName: 'button',
-  className: 'CDB-Widget-buttonIcon CDB-Widget-buttonIcon--circleBig is-selected',
+  className: 'CDB-Widget-controlButton',
 
   events: {
     'click': '_onClick'
@@ -20,9 +20,10 @@ module.exports = View.extend({
   render: function() {
     this.$el.html(
       template({
-        iconClass: this.model.get('isRunning')
-          ? 'CDB-Widget-timeSeriesPauseIcon'
-          : 'CDB-Widget-timeSeriesPlayIcon'
+        iconClass: 'CDB-Widget-controlButton-icon CDB-Widget-controlButton-icon--' + (
+          this.model.get('isRunning')
+            ? 'pause'
+            : 'play')
       })
     );
 

--- a/src/geo/ui/widgets/time-series/torque-controls.tpl
+++ b/src/geo/ui/widgets/time-series/torque-controls.tpl
@@ -1,1 +1,3 @@
-<i class="<%- iconClass %>"></i>
+<div class="CDB-Widget-controlButton-content">
+  <i class="<%- iconClass %>"></i>
+</div>

--- a/themes/scss/widgets/buttons.scss
+++ b/themes/scss/widgets/buttons.scss
@@ -23,18 +23,9 @@
 .CDB-Widget-buttonIcon--circle {
   width: 16px;
   height: 16px;
-  border: 1px solid transparent;
+  border: 1px solid transparent; // border used for :hover, color set in theme
   border-radius: 14px;
   text-align: center;
-}
-.CDB-Widget-buttonIcon--circleBig {
-  @include display-flex();
-  @include justify-content(center);
-  @include align-items(center);
-  width: 24px;
-  height: 24px;
-  border: 1px solid transparent;
-  border-radius: 14px;
 }
 
 .CDB-Widget-link,

--- a/themes/scss/widgets/control-button.scss
+++ b/themes/scss/widgets/control-button.scss
@@ -1,0 +1,52 @@
+// Control button
+// ----------------------------------------------
+@import '../variables/sizes';
+@import '../variables/mixins';
+
+$size: 24px;
+
+.CDB-Widget-controlButton {
+  width: $size;
+  min-width: $size; // to avoid the element to be "squashed" due to limited space in container
+  height: $size;
+  border: 1px solid transparent; // border used for :hover, color set in theme
+  border-radius: 50%;
+  &:hover {
+    cursor: pointer;
+  }
+}
+// The flex layout requires a separate element, because a <button> tag don't support flex in all browsers
+// see https://github.com/philipwalton/flexbugs#9-some-html-elements-cant-be-flex-containers for details
+.CDB-Widget-controlButton-content {
+  @include display-flex();
+  @include justify-content(center);
+  @include align-items(center);
+}
+.CDB-Widget-controlButton-icon {
+  display: block;
+  width: 8px;
+  height: 8px;
+}
+.CDB-Widget-controlButton-icon--play {
+  width: 6px;
+  box-sizing: border-box; // for border to appear within the box (to appear as a triangle)
+  margin-left: 1px; // avoid optical illusion; make it appear horizontal center
+  border-top: 4px dotted transparent; // use dotted type for lines to not be jagged in FF
+  border-bottom: 4px dotted transparent;
+  border-left-width: 6px;
+  border-left-style: solid;
+}
+.CDB-Widget-controlButton-icon--pause {
+  margin-top: -6px; // to make the :before/:after appear in vertical center
+  &:before,
+  &:after {
+    display: inline-block;
+    width: 2px;
+    height: 8px;
+    border-radius: 3px;
+    content: '';
+  }
+  &:after {
+    margin-left: 2px; // creates the space between :before and :after
+  }
+}

--- a/themes/scss/widgets/themes/light.scss
+++ b/themes/scss/widgets/themes/light.scss
@@ -52,8 +52,7 @@ $commonBkg: rgba(#FFF, 1);
       color: $linkHover;
     }
   }
-  .CDB-Widget-buttonIcon--circle.is-selected,
-  .CDB-Widget-buttonIcon--circleBig.is-selected {
+  .CDB-Widget-buttonIcon--circle.is-selected {
     background-color: $link;
     color: #FFF;
     &:hover {
@@ -61,6 +60,24 @@ $commonBkg: rgba(#FFF, 1);
       background: $linkHover;
     }
   }
+
+  .CDB-Widget-controlButton {
+    background-color: $link;
+    &:hover {
+      border-color: $linkHover;
+      background: $linkHover;
+    }
+  }
+  .CDB-Widget-controlButton-icon--play {
+    border-left-color: $elementBkg;
+  }
+  .CDB-Widget-controlButton-icon--pause {
+    &:before,
+    &:after {
+      background-color: $elementBkg;
+    }
+  }
+
   .CDB-Widget-searchLens {
     color: $link;
   }
@@ -132,15 +149,6 @@ $commonBkg: rgba(#FFF, 1);
   .CDB-Widget-timeSeriesFakeControl,
   .CDB-Widget-timeSeriesFakeChartItem {
     background-color: $loadingBkg;
-  }
-  .CDB-Widget-timeSeriesPlayIcon {
-    border-left-color: $elementBkg;
-  }
-  .CDB-Widget-timeSeriesPauseIcon {
-    &:before,
-    &:after {
-      background-color: $elementBkg;
-    }
   }
 
   .CDB-Widget-loader {

--- a/themes/scss/widgets/time-series.scss
+++ b/themes/scss/widgets/time-series.scss
@@ -21,31 +21,6 @@
   width: 16px;
   height: 16px;
 }
-.CDB-Widget-timeSeriesPlayIcon {
-  display: inline-block;
-  width: 0;
-  height: 0;
-  margin-left: 2px; // make the icon to appear more centric
-  border-top: 4px solid transparent;
-  border-bottom: 4px solid transparent;
-  border-left-width: 6px;
-  border-left-style: solid;
-}
-.CDB-Widget-timeSeriesPauseIcon {
-  margin-top: -2px;
-  &:before,
-  &:after {
-    display: inline-block;
-    width: 2px;
-    height: 8px;
-    border-radius: 3px;
-    content: '';
-  }
-  &:after {
-    margin-left: 2px;
-  }
-}
-
 .CDB-Widget-timeSeriesTimeInfo {
   margin-left: 16px;
   white-space: nowrap;

--- a/themes/styleguide/elements.html
+++ b/themes/styleguide/elements.html
@@ -31,11 +31,16 @@
               <div class="CDB-Widget CDB-Widget--light CDB-Widget--timeSeries">
                 <div class="CDB-Widget-body CDB-Widget-body--timeSeries">
                   <div class="CDB-Widget-header CDB-Widget-header--timeSeries">
-                    <div>
-                      <button class="CDB-Widget-buttonIcon CDB-Widget-buttonIcon--circleBig is-selected">
-                        <i class="CDB-Widget-timeSeriesPlayIcon"></i>
-                      </button>
-                    </div>
+                    <button class="CDB-Widget-controlButton">
+                      <div class="CDB-Widget-controlButton-content">
+                        <i class="CDB-Widget-controlButton-icon CDB-Widget-controlButton-icon--play"></i>
+                      </div>
+                    </button>
+                    <button class="CDB-Widget-controlButton">
+                      <div class="CDB-Widget-controlButton-content">
+                        <i class="CDB-Widget-controlButton-icon CDB-Widget-controlButton-icon--pause"></i>
+                      </div>
+                    </button>
                     <div class="CDB-Widget-timeSeriesTimeInfo">
                       <p class="CDB-Widget-textBig">10:19</p>
                       <p class="CDB-Widget-textBig CDB-Widget-text--secondary">02/26/2015</p>

--- a/themes/styleguide/layout-loading.html
+++ b/themes/styleguide/layout-loading.html
@@ -20,17 +20,17 @@
 
 <body>
 
-  <div class="Dashboard-canvas">
-    <div class="Dashboard-mapWrapper">
-      <div class="Map-canvas">
-        <div class="Map" id="map">
+  <div class="CDB-Dashboard-canvas">
+    <div class="CDB-Dashboard-mapWrapper">
+      <div class="CDB-Map-canvas">
+        <div class="CDB-Map" id="map">
           <div style="position: relative; width: 100%; height: 100%;">
             <div class="cartodb-map-wrapper leaflet-container leaflet-fade-anim" tabindex="0" style="position: absolute; top: 0px; left: 0px; right: 0px; bottom: 0px; width: 100%; cursor: pointer;">
             </div>
           </div>
         </div>
       </div>
-      <div class="Dashboard-belowMap js-dashboard-belowMap">
+      <div class="CDB-Dashboard-belowMap js-dashboard-belowMap">
         <div class="CDB-Widget CDB-Widget--light CDB-Widget--timeSeries">
           <div class="CDB-Widget-loader"></div>
           <div class="CDB-Widget-error is-hidden">

--- a/themes/styleguide/styleguide.css
+++ b/themes/styleguide/styleguide.css
@@ -1,7 +1,3 @@
-body {
-  font-family: 'Lato';
-}
-
 .start {
   padding: 80px 0;
 }
@@ -33,9 +29,6 @@ body {
   padding-bottom: 10px;
   background: #e5e5e5;
 }
-hr {
-  margin: 80px 0;
-}
 .copy-box {
   cursor: pointer;
 }
@@ -58,17 +51,7 @@ hr {
   margin-bottom: 40px;
 }
 
-pre.zeroclipboard-is-hover {
-  background: #f8f8f8;
-}
-section > div > h2 {
-  font-weight: bold;
-  font-size: 20px;
-}
-
-
 /** BUTTONS **/
-
 .button {
   text-transform: uppercase;
   font: 700 12px 'Lato';
@@ -215,117 +198,6 @@ section > div > h2 {
   right: 0;
   top: 0;
   z-index: 100;
-}
-/** FORMS **/
-
-*:focus {
-  outline: none;
-}
-
-input[type=radio],
-select {
-  cursor: pointer;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-input[type="radio"] {
-  width: 20px;
-  height: 20px;
-  border: 2px solid #ddd;
-  border-radius: 50%;
-  position: relative;
-}
-
-input[type="radio"]:checked:before {
-  content: "";
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  margin-top: -5px;
-  margin-left: -5px;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: #189BDB;
-}
-
-input[type=checkbox] {
-  cursor: pointer;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-input[type="checkbox"].checkbox {
-  width: 20px;
-  height: 20px;
-  border: 2px solid #ddd;
-  border-radius: 3px;
-  position: relative;
-}
-
-input[type=checkbox]:checked.checkbox:after {
-  content: '\2713';
-  position: absolute;
-  color: #0090D7;
-  text-align: center;
-  line-height: 18px;
-  font-size: 14px;
-  left: 0;
-  right: 0;
-}
-
-input[type=checkbox].toogle {
-  border: 0;
-  box-shadow: inset 0 1px 0 rgba(0, 0, 0, .1);
-  background: #ddd;
-  border-radius: 50px;
-  width: 36px;
-  height: 20px;
-  position: relative;
-}
-
-input[type=checkbox].toogle:before {
-  content: "";
-  top: 4px;
-  left: 4px;
-  position: absolute;
-  width: 12px;
-  height: 12px;
-  background: #fff;
-  border-radius: 50%;
-  position: absolute;
-  box-shadow: 0 1px 0 rgba(0, 0, 0, .1);
-}
-
-input[type=checkbox]:checked.toogle {
-  background: #8FB83F;
-}
-
-input[type=checkbox]:checked.toogle:before {
-  left: auto;
-  right: 4px;
-}
-
-input[type=text] {
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  font: 300 13px 'Lato';
-  color: #666;
-  padding: 11px 13px;
-  display: block;
-  width: 100%;
-}
-
-input[type=text]:placeholder {
-  color: #ccc;
-}
-
-label {
-  font: 300 13px 'Lato';
-  color: #666;
 }
 
 .InputDecoration input[type=text] {
@@ -1277,152 +1149,7 @@ label {
   background: #000;
   height: 1px;
 }
-link {
-  display: block;
-}
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
-}
-
-/* HTML5 display-role reset for older browsers */
-
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
-}
-
-body {
-  line-height: 1;
-}
-
-ol,
-ul {
-  list-style: none;
-}
-
-blockquote,
-q {
-  quotes: none;
-}
-
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: '';
-  content: none;
-}
-
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-
-* {
-  box-sizing: border-box;
-}
-
-a {
-  color: #0090D7;
-  text-decoration: none;
-}
-
-a:hover {
-  text-decoration: underline;
-}
 .u-vspace-xxl {
   margin-bottom: 40px;
 }
@@ -1672,31 +1399,6 @@ a:hover {
 .Dropdown-item:last-child {
   margin-bottom: 0;
 }
-h1 {
-  font: 400 18px/27px 'Lato';
-}
-
-h2 {
-  font: 400 16px/24px 'Lato';
-}
-
-h3 {
-  font: 400 15px/22px 'Lato';
-}
-
-h4,
-h5,
-h6 {
-  font: 400 13px/20px 'Lato';
-}
-
-p {
-  font: 300 15px/22px 'Lato';
-}
-
-strong {
-  font-weight: 700;
-}
 .clearfix:after {
   content: "";
   display: block;
@@ -1798,28 +1500,6 @@ strong {
   -webkit-line-clamp: 1;
 }
 /* Code blocks */
-pre[class*="language-"] {
-  padding: 0 1em;
-  margin: .5em 0;
-  overflow: auto;
-  line-height: 1.5;
-}
-
-code {
-  font-size: 1.1em;
-}
-
-:not(pre) > code[class*="language-"],
-pre[class*="language-"] {
-  background: #f5f2f0;
-}
-
-/* Inline code */
-:not(pre) > code[class*="language-"] {
-  padding: .1em;
-  border-radius: .3em;
-}
-
 .token.comment,
 .token.prolog,
 .token.doctype,


### PR DESCRIPTION
Resolves #894

Makes the icons appear consistent in all evergreen browsers. Perhaps we should consider applying the same approach for the other (round-kind) icons too, and consolidate the components a little?

Anyway, the code changes should speak for themselves, added inlined comments for non-obvious props though. Also fixed the styleguide to be coherent with the cartodb.css (removing default resets), so things actually will look the same in both styleguide and examples.

@xavijam can you review plz? cc @piensaenpixel @javierarce 

