### PR TITLE
Refactor the chart hide/show methods

### DIFF
--- a/src/geo/ui/widgets/histogram/chart.js
+++ b/src/geo/ui/widgets/histogram/chart.js
@@ -512,11 +512,11 @@ module.exports = View.extend({
   },
 
   hide: function() {
-    this.model.set({ display: false });
+    this.model.set('display', false);
   },
 
   show: function() {
-    this.model.set({ display: true });
+    this.model.set('display', true);
   },
 
   _hide: function() {

--- a/src/geo/ui/widgets/histogram/chart.js
+++ b/src/geo/ui/widgets/histogram/chart.js
@@ -43,7 +43,6 @@ module.exports = View.extend({
     // using tagName: 'svg' doesn't work,
     // and w/o class="" d3 won't instantiate properly
     this.setElement($('<svg class=""></svg>')[0]);
-    this.$el.hide(); // will be toggled on width change
 
     this.canvas = d3.select(this.el)
     .attr('width', 0)
@@ -57,11 +56,13 @@ module.exports = View.extend({
       showLabels: true,
       data: this.options.data,
       height: this.options.height,
+      display: true,
       margin: _.clone(this.options.margin),
       width: 0, // will be set on resize listener
       pos: { x: 0, y: 0 }
     });
 
+    this.model.bind('change:display', this._onChangeDisplay, this);
     this.model.bind('change:width', this._onChangeWidth, this);
     this.model.bind('change:height', this._onChangeHeight, this);
     this.model.bind('change:pos', this._onChangePos, this);
@@ -74,6 +75,8 @@ module.exports = View.extend({
 
     this._setupDimensions();
     this._setupD3Bindings();
+
+    this.hide(); // will be toggled on width change
   },
 
   render: function() {
@@ -111,12 +114,20 @@ module.exports = View.extend({
   },
 
   _resizeToParentElement: function() {
+
     if (this.$el.parent()) {
       // Hide this view temporarily to get actual size of the parent container
-      var wasVisible = this.isHidden();
-      this.$el.hide();
+      var wasHidden = this.isHidden();
+
+      this.hide();
+
       var width = this.$el.parent().width() || 0;
-      this.$el.toggle(wasVisible);
+
+      if (wasHidden) {
+        this.hide();
+      } else {
+        this.show();
+      }
 
       this.model.set('width', width);
     }
@@ -181,7 +192,7 @@ module.exports = View.extend({
     this.$el.width(width);
     this.chart.attr('width', width);
     if (this.options.showOnWidthChange && width > 0) {
-      this.$el.show();
+      this.show();
     }
     this.reset();
 
@@ -492,16 +503,32 @@ module.exports = View.extend({
     this.chart.classed(this.options.className || '', true);
   },
 
+  _onChangeDisplay: function() {
+    if (this.model.get('display')) {
+      this._show();
+    } else {
+      this._hide();
+    }
+  },
+
   hide: function() {
-    this.$el.hide();
+    this.model.set({ display: false });
   },
 
   show: function() {
+    this.model.set({ display: true });
+  },
+
+  _hide: function() {
+    this.$el.hide();
+  },
+
+  _show: function() {
     this.$el.show();
   },
 
   isHidden: function() {
-    return this.$el.is(':visible');
+    return !this.model.get('display');
   },
 
   _selectBars: function() {

--- a/src/geo/ui/widgets/histogram/content-view.js
+++ b/src/geo/ui/widgets/histogram/content-view.js
@@ -178,7 +178,7 @@ module.exports = WidgetContent.extend({
     this.addView(this.miniHistogramChartView);
     this.$('.js-content').append(this.miniHistogramChartView.el);
     this.miniHistogramChartView.bind('on_brush_end', this._onMiniRangeUpdated, this);
-    this.miniHistogramChartView.render().hide();
+    this.miniHistogramChartView.render();
   },
 
   _setupBindings: function() {

--- a/test/spec/geo/ui/widgets/histogram/chart.spec.js
+++ b/test/spec/geo/ui/widgets/histogram/chart.spec.js
@@ -100,6 +100,41 @@ describe('geo/ui/widgets/histogram/chart', function() {
       expect(this.view.$el.find('.CDB-Chart-handle').size()).toBe(2);
     });
 
+    it('should hide the chart', function() {
+      expect(this.view.$el.css('display')).toBe('inline');
+
+      this.view.hide();
+
+      expect(this.view.isHidden()).toBe(true);
+      expect(this.view.model.get('display')).toBe(false);
+      expect(this.view.$el.css('display')).toBe('none');
+    });
+
+    it('should show the chart', function() {
+      this.view.hide();
+      this.view.show();
+      expect(this.view.$el.css('display')).toBe('inline');
+    });
+
+    it('should set the parent width', function() {
+      this.view.show();
+      this.view._resizeToParentElement();
+      expect(this.view.model.get('width')).toBe(this.width);
+    });
+
+    it('should maintain the visibility after calling _resizeToParentElement', function() {
+      this.view.show();
+      var width = this.view.$el.parent().width() ;
+      this.view._resizeToParentElement();
+      expect(this.view.$el.css('display')).toBe('inline');
+      expect(this.view.model.get('display')).toBe(true);
+
+      this.view.hide();
+      this.view._resizeToParentElement();
+      expect(this.view.$el.css('display')).toBe('none');
+      expect(this.view.model.get('display')).toBe(false);
+    });
+
     it('should calculate the scales', function() {
       var max = _.max(this.view.model.get('data'), function(d) { return d.freq; });
 


### PR DESCRIPTION
This PR moves the hide/show logic to a model-based one. It also fixes a Firefox bug that prevented hiding an histogram right after was appended to the dom.