### PR TITLE
Fixing double click over google maps when drag is enabled

### DIFF
--- a/src/geo/gmaps/gmaps.js
+++ b/src/geo/gmaps/gmaps.js
@@ -49,7 +49,7 @@ if(typeof(google) != "undefined" && typeof(google.maps) != "undefined") {
           scrollwheel: this.map.get("scrollwheel"),
           // Allow dragging (and double click zoom)
           draggable: this.map.get("drag"),
-          disableDoubleClickZoom: this.map.get("drag"),
+          disableDoubleClickZoom: !this.map.get("drag"),
           mapTypeControl:false,
           mapTypeId: google.maps.MapTypeId.ROADMAP,
           backgroundColor: 'white',

--- a/test/spec/geo/gmaps/gmaps.spec.js
+++ b/test/spec/geo/gmaps/gmaps.spec.js
@@ -249,7 +249,7 @@
       });
 
       expect(mapView.map_googlemaps.get('draggable')).toBeFalsy();
-      expect(mapView.map_googlemaps.get('disableDoubleClickZoom')).toBeFalsy();
+      expect(mapView.map_googlemaps.get('disableDoubleClickZoom')).toBeTruthy();
     });
 
   });


### PR DESCRIPTION
We were mixing up the value of the allowDragging. So when drag was enabled, disableDoubleClick should false.

Fixes cartodb/cartodb#6216.

cc @acanimal 