### PR TITLE
Change linter to semistandard

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -195,14 +195,14 @@ module.exports = function(grunt) {
 
   grunt.registerTask('standard:lint', 'lint source files', function() {
     var done = this.async();
-    require("child_process").exec('PATH=$(npm bin):$PATH standard', function (error, stdout, stderr) {
+    require("child_process").exec('PATH=$(npm bin):$PATH semistandard', function (error, stdout, stderr) {
       if (error) {
         grunt.log.fail(error);
 
         // Filter out lines that are ignored,
         // e.g. "src/foobar.js:0:0: File ignored because of your .eslintignore file. Use --no-ignore to override."
         grunt.log.fail(stdout.replace(/.+--no-ignore.+(\r?\n|\r)/g, ''));
-        grunt.fail.warn('try `node_modules/.bin/standard --format src/filename.js` to auto-format code (you might still need to fix some things manually).')
+        grunt.fail.warn('try `node_modules/.bin/semistandard --format src/filename.js` to auto-format code (you might still need to fix some things manually).')
       } else {
         grunt.log.ok('All linted files OK!');
         grunt.log.writeln('Note that files listed in .eslintignore are not linted');

--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
     "gulp-sketch": "0.0.7",
     "jshint-stylish": "~0.1.3",
     "load-grunt-tasks": "~0.6.0",
+    "semistandard": "^7.0.4",
     "semver": "~4.1.0",
     "source-map-support": "0.3.2",
-    "standard": "5.4.1",
     "time-grunt": "~0.3.1",
     "watchify": "3.4.0"
   },
@@ -125,7 +125,7 @@
     "vendor"
   ],
   "main": "src/index.js",
-  "standard": {
+  "semistandard": {
     "globals": [
       "cartodb",
       "cdb",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "gulp-sketch": "0.0.7",
     "jshint-stylish": "~0.1.3",
     "load-grunt-tasks": "~0.6.0",
-    "semistandard": "^7.0.4",
+    "semistandard": "7.0.4",
     "semver": "~4.1.0",
     "source-map-support": "0.3.2",
     "time-grunt": "~0.3.1",

--- a/src/api/module-load.js
+++ b/src/api/module-load.js
@@ -1,10 +1,10 @@
-var cdb = require('cdb')
-var config = require('cdb.config')
+var cdb = require('cdb');
+var config = require('cdb.config');
 
 module.exports = function (name, mod) {
-  cdb[name] = mod
+  cdb[name] = mod;
   config.modules.add({
     name: name,
     mod: mod
-  })
-}
+  });
+};

--- a/src/cartodb.js
+++ b/src/cartodb.js
@@ -1,117 +1,117 @@
-var isLeafletAlreadyLoaded = !!window.L
+var isLeafletAlreadyLoaded = !!window.L;
 
-var _ = require('underscore')
-var L = require('leaflet')
-require('mousewheel') // registers itself to $.event; TODO what's this required for? still relevant for supported browsers?
-require('mwheelIntent') // registers itself to $.event; TODO what's this required for? still relevant for supported browsers?
+var _ = require('underscore');
+var L = require('leaflet');
+require('mousewheel'); // registers itself to $.event; TODO what's this required for? still relevant for supported browsers?
+require('mwheelIntent'); // registers itself to $.event; TODO what's this required for? still relevant for supported browsers?
 
-var cdb = require('cdb')
+var cdb = require('cdb');
 
 if (window) {
-  window.cartodb = window.cdb = cdb
+  window.cartodb = window.cdb = cdb;
 }
 
-cdb.Backbone = require('backbone')
-cdb.Mustache = require('mustache')
-cdb.$ = require('jquery')
-cdb._ = _
-cdb.L = L
+cdb.Backbone = require('backbone');
+cdb.Mustache = require('mustache');
+cdb.$ = require('jquery');
+cdb._ = _;
+cdb.L = L;
 
-if (isLeafletAlreadyLoaded) L.noConflict()
-_.extend(cdb.geo, require('./geo/leaflet'))
+if (isLeafletAlreadyLoaded) L.noConflict();
+_.extend(cdb.geo, require('./geo/leaflet'));
 
-cdb.SQL = require('./api/sql')
+cdb.SQL = require('./api/sql');
 
-cdb.config = require('cdb.config')
-cdb.log = require('cdb.log')
-cdb.errors = require('cdb.errors')
-cdb.templates = require('cdb.templates')
-cdb.decorators = require('./core/decorators')
-cdb.createVis = require('./api/create-vis')
-cdb.createLayer = require('./api/create-layer')
-cdb.LZMA = require('lzma')
+cdb.config = require('cdb.config');
+cdb.log = require('cdb.log');
+cdb.errors = require('cdb.errors');
+cdb.templates = require('cdb.templates');
+cdb.decorators = require('./core/decorators');
+cdb.createVis = require('./api/create-vis');
+cdb.createLayer = require('./api/create-layer');
+cdb.LZMA = require('lzma');
 
 // used in libs like torque to add themselves here (or so it seems)
-cdb.moduleLoad = require('./api/module-load')
+cdb.moduleLoad = require('./api/module-load');
 
-cdb.core.Profiler = require('cdb.core.Profiler')
-cdb.core.util = require('cdb.core.util')
-cdb.core.Loader = cdb.vis.Loader = require('./core/loader')
-cdb.core.sanitize = require('./core/sanitize')
-cdb.core.Template = require('./core/template')
-cdb.core.TemplateList = require('./core/template-list')
-cdb.core.Model = require('./core/model')
-cdb.core.View = require('./core/view')
+cdb.core.Profiler = require('cdb.core.Profiler');
+cdb.core.util = require('cdb.core.util');
+cdb.core.Loader = cdb.vis.Loader = require('./core/loader');
+cdb.core.sanitize = require('./core/sanitize');
+cdb.core.Template = require('./core/template');
+cdb.core.TemplateList = require('./core/template-list');
+cdb.core.Model = require('./core/model');
+cdb.core.View = require('./core/view');
 
-cdb.ui.common.Dialog = require('./ui/common/dialog')
-cdb.ui.common.ShareDialog = require('./ui/common/share')
-cdb.ui.common.Dropdown = require('./ui/common/dropdown')
-cdb.ui.common.FullScreen = require('./ui/common/fullscreen')
-cdb.ui.common.Notification = require('./ui/common/notification')
-cdb.ui.common.Row = require('./ui/common/table/row')
-cdb.ui.common.TableData = require('./ui/common/table/table-data')
-cdb.ui.common.TableProperties = require('./ui/common/table/table-properties')
-cdb.ui.common.RowView = require('./ui/common/table/row-view')
-cdb.ui.common.Table = require('./ui/common/table')
+cdb.ui.common.Dialog = require('./ui/common/dialog');
+cdb.ui.common.ShareDialog = require('./ui/common/share');
+cdb.ui.common.Dropdown = require('./ui/common/dropdown');
+cdb.ui.common.FullScreen = require('./ui/common/fullscreen');
+cdb.ui.common.Notification = require('./ui/common/notification');
+cdb.ui.common.Row = require('./ui/common/table/row');
+cdb.ui.common.TableData = require('./ui/common/table/table-data');
+cdb.ui.common.TableProperties = require('./ui/common/table/table-properties');
+cdb.ui.common.RowView = require('./ui/common/table/row-view');
+cdb.ui.common.Table = require('./ui/common/table');
 
-cdb.geo.common.CartoDBLogo = require('./geo/cartodb-logo')
+cdb.geo.common.CartoDBLogo = require('./geo/cartodb-logo');
 
-cdb.geo.geocoder.NOKIA = require('./geo/geocoder/nokia-geocoder')
-cdb.geo.geocoder.YAHOO = require('./geo/geocoder/yahoo-geocoder')
-cdb.geo.Geometry = require('./geo/geometry')
+cdb.geo.geocoder.NOKIA = require('./geo/geocoder/nokia-geocoder');
+cdb.geo.geocoder.YAHOO = require('./geo/geocoder/yahoo-geocoder');
+cdb.geo.Geometry = require('./geo/geometry');
 
-cdb.geo.MapLayer = require('./geo/map/map-layer')
-cdb.geo.TileLayer = require('./geo/map/tile-layer')
-cdb.geo.GMapsBaseLayer = require('./geo/map/gmaps-base-layer')
-cdb.geo.WMSLayer = require('./geo/map/wms-layer')
-cdb.geo.PlainLayer = require('./geo/map/plain-layer')
-cdb.geo.TorqueLayer = require('./geo/map/torque-layer')
-cdb.geo.CartoDBLayer = require('./geo/map/cartodb-layer')
-cdb.geo.CartoDBLayerGroupNamed = require('./geo/map/cartodb-layer-group-named')
-cdb.geo.CartoDBLayerGroupAnonymous = require('./geo/map/cartodb-layer-group-anonymous')
-cdb.geo.Layers = require('./geo/map/layers')
-cdb.geo.Map = require('./geo/map')
-cdb.geo.MapView = require('./geo/map-view')
+cdb.geo.MapLayer = require('./geo/map/map-layer');
+cdb.geo.TileLayer = require('./geo/map/tile-layer');
+cdb.geo.GMapsBaseLayer = require('./geo/map/gmaps-base-layer');
+cdb.geo.WMSLayer = require('./geo/map/wms-layer');
+cdb.geo.PlainLayer = require('./geo/map/plain-layer');
+cdb.geo.TorqueLayer = require('./geo/map/torque-layer');
+cdb.geo.CartoDBLayer = require('./geo/map/cartodb-layer');
+cdb.geo.CartoDBLayerGroupNamed = require('./geo/map/cartodb-layer-group-named');
+cdb.geo.CartoDBLayerGroupAnonymous = require('./geo/map/cartodb-layer-group-anonymous');
+cdb.geo.Layers = require('./geo/map/layers');
+cdb.geo.Map = require('./geo/map');
+cdb.geo.MapView = require('./geo/map-view');
 
-_.extend(cdb.geo, require('./geo/gmaps'))
+_.extend(cdb.geo, require('./geo/gmaps'));
 
 // overwrites the Promise defined from the core bundle
-cdb.Promise = require('./api/promise')
+cdb.Promise = require('./api/promise');
 
-cdb.geo.ui.Text = require('./geo/ui/text')
-cdb.geo.ui.Annotation = require('./geo/ui/annotation')
-cdb.geo.ui.Image = require('./geo/ui/image')
-cdb.geo.ui.Share = require('./geo/ui/share')
-cdb.geo.ui.Zoom = require('./geo/ui/zoom')
-cdb.geo.ui.ZoomInfo = require('./geo/ui/zoom-info')
+cdb.geo.ui.Text = require('./geo/ui/text');
+cdb.geo.ui.Annotation = require('./geo/ui/annotation');
+cdb.geo.ui.Image = require('./geo/ui/image');
+cdb.geo.ui.Share = require('./geo/ui/share');
+cdb.geo.ui.Zoom = require('./geo/ui/zoom');
+cdb.geo.ui.ZoomInfo = require('./geo/ui/zoom-info');
 
 // setup expected object structure here, to avoid circular references
-_.extend(cdb.geo.ui, require('./geo/ui/legend-exports'))
-cdb.geo.ui.Legend = require('./geo/ui/legend')
-_.extend(cdb.geo.ui.Legend, require('./geo/ui/legend/legend-view-exports'))
+_.extend(cdb.geo.ui, require('./geo/ui/legend-exports'));
+cdb.geo.ui.Legend = require('./geo/ui/legend');
+_.extend(cdb.geo.ui.Legend, require('./geo/ui/legend/legend-view-exports'));
 
-cdb.geo.ui.InfowindowModel = require('./geo/ui/infowindow-model')
-cdb.geo.ui.Infowindow = require('./geo/ui/infowindow')
+cdb.geo.ui.InfowindowModel = require('./geo/ui/infowindow-model');
+cdb.geo.ui.Infowindow = require('./geo/ui/infowindow');
 
-cdb.geo.ui.Header = require('./geo/ui/header')
+cdb.geo.ui.Header = require('./geo/ui/header');
 
-cdb.geo.ui.Search = require('./geo/ui/search')
+cdb.geo.ui.Search = require('./geo/ui/search');
 
-cdb.geo.ui.LayerSelector = require('./geo/ui/layer-selector')
-cdb.geo.ui.LayerView = require('./geo/ui/layer-view')
+cdb.geo.ui.LayerSelector = require('./geo/ui/layer-selector');
+cdb.geo.ui.LayerView = require('./geo/ui/layer-view');
 
-cdb.geo.ui.MobileLayer = require('./geo/ui/mobile-layer')
-cdb.geo.ui.Mobile = require('./geo/ui/mobile')
-cdb.geo.ui.TilesLoader = require('./geo/ui/tiles-loader')
-cdb.geo.ui.InfoBox = require('./geo/ui/infobox')
-cdb.geo.ui.Tooltip = require('./geo/ui/tooltip')
+cdb.geo.ui.MobileLayer = require('./geo/ui/mobile-layer');
+cdb.geo.ui.Mobile = require('./geo/ui/mobile');
+cdb.geo.ui.TilesLoader = require('./geo/ui/tiles-loader');
+cdb.geo.ui.InfoBox = require('./geo/ui/infobox');
+cdb.geo.ui.Tooltip = require('./geo/ui/tooltip');
 
-cdb.vis.INFOWINDOW_TEMPLATE = require('./vis/vis/infowindow-template')
-cdb.vis.Overlay = require('./vis/vis/overlay')
-cdb.vis.Overlays = require('./vis/vis/overlays')
-cdb.vis.Layers = require('./vis/vis/layers')
-cdb.vis.Vis = require('./vis/vis')
-require('./vis/overlays') // Overlay.register calls
-require('./vis/layers') // Layers.register calls
+cdb.vis.INFOWINDOW_TEMPLATE = require('./vis/vis/infowindow-template');
+cdb.vis.Overlay = require('./vis/vis/overlay');
+cdb.vis.Overlays = require('./vis/vis/overlays');
+cdb.vis.Layers = require('./vis/vis/layers');
+cdb.vis.Vis = require('./vis/vis');
+require('./vis/overlays'); // Overlay.register calls
+require('./vis/layers'); // Layers.register calls
 
-module.exports = cdb
+module.exports = cdb;

--- a/src/cartodb.mod.torque.js
+++ b/src/cartodb.mod.torque.js
@@ -1,13 +1,13 @@
 /* global google */
-var cdb = require('cdb')
-var moduleLoad = require('./api/module-load')
-var torque = window.torque = require('torque.js') // standalone torque lib, required for gmaps/leaflet layer view
+var cdb = require('cdb');
+var moduleLoad = require('./api/module-load');
+var torque = window.torque = require('torque.js'); // standalone torque lib, required for gmaps/leaflet layer view
 
 if (typeof google !== 'undefined' && typeof google.maps !== 'undefined') {
-  cdb.geo.GMapsTorqueLayerView = require('./geo/gmaps/gmaps-torque-layer-view')
+  cdb.geo.GMapsTorqueLayerView = require('./geo/gmaps/gmaps-torque-layer-view');
 }
 
-cdb.geo.LeafletTorqueLayer = require('./geo/leaflet/leaflet-torque-layer')
+cdb.geo.LeafletTorqueLayer = require('./geo/leaflet/leaflet-torque-layer');
 
-moduleLoad('torque', torque)
-module.exports = torque
+moduleLoad('torque', torque);
+module.exports = torque;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
-var cdb = require('./cartodb.js')
+var cdb = require('./cartodb.js');
 
 // Eager-load cartodb.mod.torque stuff for the default case
-require('./cartodb.mod.torque.js')
+require('./cartodb.mod.torque.js');
 
-module.exports = cdb
+module.exports = cdb;

--- a/test/spec/cartodb.mod.torque.spec.js
+++ b/test/spec/cartodb.mod.torque.spec.js
@@ -1,21 +1,21 @@
-var torque = require('cdb/cartodb.mod.torque')
-require('leaflet').noConflict()
+var torque = require('cdb/cartodb.mod.torque');
+require('leaflet').noConflict();
 
 describe('torque', function () {
   it('should set a window.torque object', function () {
-    expect(torque).toBeDefined()
-    expect(window.torque).toBe(torque)
-  })
+    expect(torque).toBeDefined();
+    expect(window.torque).toBe(torque);
+  });
 
   it('should modify the window.cartodb object', function () {
-    expect(window.cartodb).toEqual(jasmine.any(Object))
+    expect(window.cartodb).toEqual(jasmine.any(Object));
 
-    var cdb = window.cartodb
-    expect(cdb.geo).toEqual(jasmine.any(Object))
+    var cdb = window.cartodb;
+    expect(cdb.geo).toEqual(jasmine.any(Object));
 
-    expect(cdb.geo.GMapsTorqueLayerView).toEqual(jasmine.any(Function))
-    expect(cdb.geo.LeafletTorqueLayer).toEqual(jasmine.any(Function))
+    expect(cdb.geo.GMapsTorqueLayerView).toEqual(jasmine.any(Function));
+    expect(cdb.geo.LeafletTorqueLayer).toEqual(jasmine.any(Function));
 
-    expect(cdb.geo.ui).toEqual(jasmine.any(Object))
-  })
-})
+    expect(cdb.geo.ui).toEqual(jasmine.any(Object));
+  });
+});


### PR DESCRIPTION
Same as [standard but with semicolons](https://github.com/Flet/semistandard#rules), as requested offline and https://github.com/CartoDB/cartodb.js/pull/928#issuecomment-165036919

@javisantana @alonsogarciapablo OK with you? This PR was a 5-min change so no biggie. 
cc @CartoDB/frontend FYI