### PR TITLE
Adds loader and error message to the infowindow

### DIFF
--- a/src/geo/ui/infowindow.js
+++ b/src/geo/ui/infowindow.js
@@ -119,8 +119,10 @@ var Infowindow = View.extend({
         this.$('.js-content').css('max-height', this.model.get('maxHeight') + 'px');
       }
 
-      this._loadCover();
       this._renderLoader();
+      this._startLoader();
+
+      this._loadCover();
 
       if (!this.isLoadingData()) {
         this.model.trigger('domready', this, this.$el);
@@ -164,11 +166,18 @@ var Infowindow = View.extend({
   },
 
   _renderLoader: function () {
+    this.$('.js-inner').append('<div class="CDB-Loader js-loader"></div>');
+  },
+
+  _startLoader: function () {
     this.$('.js-inner').addClass('is-loading');
-    this.$('.js-inner').append('<div class="CDB-Loader js-loader is-visible"></div>');
+    this.$('.js-loader').addClass('is-visible');
   },
 
   _stopLoader: function () {
+    if (this._containsCover() && this._coverLoading) {
+      return;
+    }
     this.$('.js-inner').removeClass('is-loading');
     this.$('.js-loader').removeClass('is-visible');
   },
@@ -377,6 +386,9 @@ var Infowindow = View.extend({
       return;
     }
 
+    this._startLoader();
+    this._coverLoading = true;
+
     $img = $("<img class='CDB-infowindow-media-item' />").attr('src', url);
 
     $cover.append($img);
@@ -404,6 +416,9 @@ var Infowindow = View.extend({
       $img.css(styles);
       $cover.css({ height: h - self.options.hookHeight });
       $img.fadeIn(self.options.imageTransitionSpeed);
+
+      self._coverLoading = false;
+      self._stopLoader();
 
       self._loadImageHook($img.width(), $img.height(), h - self.options.hookHeight, url);
     }).error();
@@ -445,27 +460,6 @@ var Infowindow = View.extend({
    */
   _stopPropagation: function (ev) {
     ev.stopPropagation();
-  },
-
-  /**
-   *  Set loading state adding its content
-   */
-  setLoading: function () {
-    this.model.set({
-      content: {
-        fields: [{
-          title: null,
-          loading: true,
-          alternative_name: null,
-          value: 'Loading content...',
-          index: null,
-          type: 'loading'
-        }],
-        data: {}
-      }
-    });
-
-    return this;
   },
 
   /**

--- a/src/geo/ui/infowindow.js
+++ b/src/geo/ui/infowindow.js
@@ -377,11 +377,11 @@ var Infowindow = View.extend({
     var $img = $cover.find('img');
     var url = this._getCoverURL();
 
-    if (!this._isValidURL(url)) {
+    if (this._isValidURL(url)) {
+      this._clearInfowindowImageError();
+    } else {
       this._showInfowindowImageError();
       return;
-    } else {
-      this._clearInfowindowImageError();
     }
 
     if ($img.length > 0) {

--- a/src/geo/ui/infowindow.js
+++ b/src/geo/ui/infowindow.js
@@ -119,12 +119,13 @@ var Infowindow = View.extend({
         this.$('.js-content').css('max-height', this.model.get('maxHeight') + 'px');
       }
 
-      // If the template is 'cover-enabled', load the cover
       this._loadCover();
+      this._renderLoader();
 
       if (!this.isLoadingData()) {
         this.model.trigger('domready', this, this.$el);
         this.trigger('domready', this, this.$el);
+        this._stopLoader();
       }
 
       this._renderScroll();
@@ -160,6 +161,16 @@ var Infowindow = View.extend({
     if (e && e.keyCode === 27) {
       this._closeInfowindow();
     }
+  },
+
+  _renderLoader: function () {
+    this.$('.js-inner').addClass('is-loading');
+    this.$('.js-inner').append('<div class="CDB-Loader js-loader is-visible"></div>');
+  },
+
+  _stopLoader: function () {
+    this.$('.js-inner').removeClass('is-loading');
+    this.$('.js-loader').removeClass('is-visible');
   },
 
   _renderScroll: function () {

--- a/src/geo/ui/infowindow.js
+++ b/src/geo/ui/infowindow.js
@@ -182,6 +182,11 @@ var Infowindow = View.extend({
     this.$('.js-loader').removeClass('is-visible');
   },
 
+  _stopCoverLoader: function () {
+    this._coverLoading = false;
+    this._stopLoader();
+  },
+
   _renderScroll: function () {
     if (this.$('.has-scroll').length === 0) return;
 
@@ -417,8 +422,7 @@ var Infowindow = View.extend({
       $cover.css({ height: h - self.options.hookHeight });
       $img.fadeIn(self.options.imageTransitionSpeed);
 
-      self._coverLoading = false;
-      self._stopLoader();
+      self._stopCoverLoader();
 
       self._loadImageHook($img.width(), $img.height(), h - self.options.hookHeight, url);
     }).error();

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -967,7 +967,6 @@ var Vis = View.extend({
       // Show infowindow with loading state
       infowindow
         .setLatLng(latlng)
-        .setLoading()
         .showInfowindow();
 
       if (layerView.tooltip) {

--- a/styleguide/infowindows.html
+++ b/styleguide/infowindows.html
@@ -46,9 +46,9 @@
             <br>
 
 
-            <div class="CDB-infowindow CDB-infowindow--light js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--light is-loading js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
-                <div class="CDB-infowindow-inner is-loading">
+                <div class="CDB-infowindow-inner">
                   <div class="CDB-Loader is-visible"></div>
                 </div>
                 <div class="CDB-hook">
@@ -687,7 +687,8 @@
           <h2>Infowindows image</h2>
           <div class="block clearfix u-tspace-xl">
 
-            <div class="CDB-infowindow CDB-infowindow--light is-header-image js-infowindow" style="max-width: 200px;">
+
+            <div class="CDB-infowindow CDB-infowindow--light has-header-image js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover" style="height:116px;">
                   <div class="CDB-infowindow-mediaTitle">
@@ -695,7 +696,7 @@
                   </div>
                   <img src="image/white.png" alt="title" class="CDB-infowindow-media-item" />
                 </div>
-                <div class="CDB-hook-image">
+                <div class="CDB-hook-image has-image">
                   <div class="CDB-hook-image-inner js-hook">
                     <img src="image/white.png" alt="title" style="margin-top: -116px;" />
                   </div>
@@ -705,7 +706,7 @@
             <br/>
             <br/>
             <br/>
-            <div class="CDB-infowindow CDB-infowindow--light is-header-image js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--light has-header-image js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover" style="height:133px;">
                   <div class="CDB-infowindow-mediaTitle">
@@ -713,7 +714,7 @@
                   </div>
                   <img src="image/land.png" alt="title" class="CDB-infowindow-media-item" />
                 </div>
-                <div class="CDB-hook-image">
+                <div class="CDB-hook-image has-image">
                   <div class="CDB-hook-image-inner js-hook">
                     <img src="image/land.png" alt="title" style="margin-top: -133px;" />
                   </div>
@@ -725,7 +726,7 @@
             <br/>
             <br/>
 
-            <div class="CDB-infowindow CDB-infowindow--light is-header-image js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--light has-header-image js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover" style="height: 116px;">
                   <div class="CDB-infowindow-mediaTitle">
@@ -734,7 +735,7 @@
                   </div>
                   <img src="image/blue.png" alt="title" class="CDB-infowindow-media-item" />
                 </div>
-                <div class="CDB-hook-image">
+                <div class="CDB-hook-image has-image">
                   <div class="CDB-hook-image-inner js-hook">
                     <img src="image/blue.png" alt="title" style="margin-top: -116px;" />
                   </div>
@@ -819,9 +820,9 @@
             <br/>
             <br/>
             <br/>
-            <div class="CDB-infowindow CDB-infowindow--light is-header js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--light is-loading is-header js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
-                <div class="CDB-infowindow-inner is-loading">
+                <div class="CDB-infowindow-inner">
                   <div class="CDB-Loader is-visible"></div>
                 </div>
                 <div class="CDB-hook">
@@ -839,9 +840,9 @@
             <br/>
             <br/>
             <br/>
-            <div class="CDB-infowindow CDB-infowindow--light is-header js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--light is-header is-loading js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
-                <div class="CDB-infowindow-header CDB-infowindow-headerMedia is-loading js-cover">
+                <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover">
                   <div class="CDB-Loader is-visible"></div>
                 </div>
                 <div class="CDB-infowindow-inner">
@@ -871,9 +872,9 @@
             <br/>
             <br/>
             <br/>
-            <div class="CDB-infowindow CDB-infowindow--light is-header js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--light is-header is-loading js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
-                <div class="CDB-infowindow-header CDB-infowindow-headerMedia is-loading js-cover">
+                <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover">
                   <div class="CDB-infowindow-mediaTitle">
                     <h5 class="CDB-infowindow-subtitle"><span>FACILITY NAME</span></h5>
                     <h4 class="CDB-infowindow-title"><span>St. Gobain Performance Plastics</span></h4>
@@ -908,9 +909,9 @@
             <br/>
             <br/>
             <br/>
-            <div class="CDB-infowindow CDB-infowindow--light is-header js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--light is-header has-header-image has-fields has-title is-fail js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
-                <div class="CDB-infowindow-header CDB-infowindow-headerMedia is-fail js-cover">
+                <div class="CDB-infowindow-header CDB-infowindow-headerMedia has-title js-cover">
                   <div class="CDB-infowindow-mediaTitle">
                     <h5 class="CDB-infowindow-subtitle"><span>FACILITY NAME</span></h5>
                     <h4 class="CDB-infowindow-title"><span>St. Gobain Performance Plastics</span></h4>
@@ -944,9 +945,9 @@
             <br/>
             <br/>
             <br/>
-            <div class="CDB-infowindow CDB-infowindow--light is-header js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--light is-header is-fail js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
-                <div class="CDB-infowindow-header CDB-infowindow-headerMedia is-fail js-cover">
+                <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover">
                   <p class="CDB-infowindow-fail">Non-valid picture URL</p>
                 </div>
                 <div class="CDB-infowindow-inner">

--- a/styleguide/infowindows.html
+++ b/styleguide/infowindows.html
@@ -396,7 +396,7 @@
             <br>
             <br>
 
-            <div class="CDB-infowindow CDB-infowindow--custom is-header js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--custom has-header js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--dark" style="background: #98E0A8;">
                   <div class="CDB-infowindow-list">
@@ -439,7 +439,7 @@
             <br>
             <br>
 
-            <div class="CDB-infowindow CDB-infowindow--custom is-header js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--custom has-header js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--dark" style="background: #98E0A8;">
                   <div class="CDB-infowindow-tabs">
@@ -540,7 +540,7 @@
             <br>
             <br>
 
-            <div class="CDB-infowindow CDB-infowindow--custom is-header js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--custom has-header js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--light" style="background: #E68165;">
                   <div class="CDB-infowindow-list">
@@ -582,7 +582,7 @@
             <br>
             <br>
 
-            <div class="CDB-infowindow CDB-infowindow--custom is-header js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--custom has-header js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--light" style="background: #E68165;">
                   <div class="CDB-infowindow-list">
@@ -623,7 +623,7 @@
             <br>
             <br>
 
-            <div class="CDB-infowindow CDB-infowindow--custom is-header js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--custom has-header js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--light" style="background: #E68165;">
                   <div class="CDB-infowindow-tabs">
@@ -774,7 +774,7 @@
             <br/>
             <br/>
 
-            <div class="CDB-infowindow CDB-infowindow--light is-header js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--light has-header js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover">
                   <div class="CDB-infowindow-mediaTitle">
@@ -820,7 +820,7 @@
             <br/>
             <br/>
             <br/>
-            <div class="CDB-infowindow CDB-infowindow--light is-loading is-header js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--light is-loading has-header js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-inner">
                   <div class="CDB-Loader is-visible"></div>
@@ -840,7 +840,7 @@
             <br/>
             <br/>
             <br/>
-            <div class="CDB-infowindow CDB-infowindow--light is-header is-loading js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--light has-header is-loading js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover">
                   <div class="CDB-Loader is-visible"></div>
@@ -872,7 +872,7 @@
             <br/>
             <br/>
             <br/>
-            <div class="CDB-infowindow CDB-infowindow--light is-header is-loading js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--light has-header is-loading js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover">
                   <div class="CDB-infowindow-mediaTitle">
@@ -909,7 +909,7 @@
             <br/>
             <br/>
             <br/>
-            <div class="CDB-infowindow CDB-infowindow--light is-header has-header-image has-fields has-title is-fail js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--light has-header has-header-image has-fields has-title is-fail js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia has-title js-cover">
                   <div class="CDB-infowindow-mediaTitle">
@@ -945,7 +945,7 @@
             <br/>
             <br/>
             <br/>
-            <div class="CDB-infowindow CDB-infowindow--light is-header is-fail js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--light has-header is-fail js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover">
                   <p class="CDB-infowindow-fail">Non-valid picture URL</p>
@@ -973,7 +973,7 @@
             <br/>
             <br/>
 
-            <div class="CDB-infowindow CDB-infowindow--light is-header js-infowindow" style="max-width: 300px;">
+            <div class="CDB-infowindow CDB-infowindow--light has-header js-infowindow" style="max-width: 300px;">
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-tabs">
                   <div class="CDB-infowindow-tabsItem">

--- a/styleguide/infowindows.html
+++ b/styleguide/infowindows.html
@@ -862,7 +862,111 @@
                 </div>
               </div>
             </div>
+            <br/>
+            <br/>
+            <br/>
+            <br/>
+            Loading status
+            <br/>
+            <br/>
+            <br/>
+            <br/>
+            <div class="CDB-infowindow CDB-infowindow--light is-header js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-container">
+                <div class="CDB-infowindow-header CDB-infowindow-headerMedia is-loading js-cover">
+                  <div class="CDB-infowindow-mediaTitle">
+                    <h5 class="CDB-infowindow-subtitle"><span>FACILITY NAME</span></h5>
+                    <h4 class="CDB-infowindow-title"><span>St. Gobain Performance Plastics</span></h4>
+                  </div>
+                  <div class="CDB-Loader is-visible"></div>
+                </div>
+                <div class="CDB-infowindow-inner">
+                  <div class="CDB-infowindow-list">
+                    <div class="CDB-infowindow-listItem">
+                      <h5 class="CDB-infowindow-subtitle">ADDRESS</h5>
+                      <h4 class="CDB-infowindow-title">409 East Street</h4>
+                    </div>
+                    <div class="CDB-infowindow-listItem">
+                      <h5 class="CDB-infowindow-subtitle">HAP EMISSIONS TPY</h5>
+                      <h4 class="CDB-infowindow-title">33.53</h4>
+                    </div>
+                  </div>
+                </div>
+                <div class="CDB-hook">
+                  <div class="CDB-hook-inner">
+                  </div>
+                </div>
+              </div>
+            </div>
 
+            <br/>
+            <br/>
+            <br/>
+            <br/>
+            Loading status (fail)
+            <br/>
+            <br/>
+            <br/>
+            <br/>
+            <div class="CDB-infowindow CDB-infowindow--light is-header js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-container">
+                <div class="CDB-infowindow-header CDB-infowindow-headerMedia is-fail js-cover">
+                  <div class="CDB-infowindow-mediaTitle">
+                    <h5 class="CDB-infowindow-subtitle"><span>FACILITY NAME</span></h5>
+                    <h4 class="CDB-infowindow-title"><span>St. Gobain Performance Plastics</span></h4>
+                  </div>
+                  <p class="CDB-infowindow-fail">Non-valid picture URL</p>
+                </div>
+                <div class="CDB-infowindow-inner">
+                  <div class="CDB-infowindow-list">
+                    <div class="CDB-infowindow-listItem">
+                      <h5 class="CDB-infowindow-subtitle">ADDRESS</h5>
+                      <h4 class="CDB-infowindow-title">409 East Street</h4>
+                    </div>
+                    <div class="CDB-infowindow-listItem">
+                      <h5 class="CDB-infowindow-subtitle">HAP EMISSIONS TPY</h5>
+                      <h4 class="CDB-infowindow-title">33.53</h4>
+                    </div>
+                  </div>
+                </div>
+                <div class="CDB-hook">
+                  <div class="CDB-hook-inner">
+                  </div>
+                </div>
+              </div>
+            </div>
+<br/>
+            <br/>
+            <br/>
+            <br/>
+            Loading status (fail)
+            <br/>
+            <br/>
+            <br/>
+            <br/>
+            <div class="CDB-infowindow CDB-infowindow--light is-header js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-container">
+                <div class="CDB-infowindow-header CDB-infowindow-headerMedia is-fail js-cover">
+                  <p class="CDB-infowindow-fail">Non-valid picture URL</p>
+                </div>
+                <div class="CDB-infowindow-inner">
+                  <div class="CDB-infowindow-list">
+                    <div class="CDB-infowindow-listItem">
+                      <h5 class="CDB-infowindow-subtitle">ADDRESS</h5>
+                      <h4 class="CDB-infowindow-title">409 East Street</h4>
+                    </div>
+                    <div class="CDB-infowindow-listItem">
+                      <h5 class="CDB-infowindow-subtitle">HAP EMISSIONS TPY</h5>
+                      <h4 class="CDB-infowindow-title">33.53</h4>
+                    </div>
+                  </div>
+                </div>
+                <div class="CDB-hook">
+                  <div class="CDB-hook-inner">
+                  </div>
+                </div>
+              </div>
+            </div>
             <br/>
             <br/>
             <br/>

--- a/styleguide/infowindows.html
+++ b/styleguide/infowindows.html
@@ -48,15 +48,8 @@
 
             <div class="CDB-infowindow CDB-infowindow--light js-infowindow" style="max-width: 200px;">
               <div class="CDB-infowindow-container">
-                <div class="CDB-infowindow-inner">
-                  <div class="CDB-loading">
-                    <div class="CDB-loading-text CDB-loading-subtitle">
-                      <div class="CDB-loading-bg"></div>
-                    </div>
-                    <div class="CDB-loading-text CDB-loading-title">
-                      <div class="CDB-loading-bg"></div>
-                    </div>
-                  </div>
+                <div class="CDB-infowindow-inner is-loading">
+                  <div class="CDB-Loader is-visible"></div>
                 </div>
                 <div class="CDB-hook">
                   <div class="CDB-hook-inner">
@@ -806,6 +799,60 @@
                     <div class="CDB-infowindow-listItem">
                       <h5 class="CDB-infowindow-subtitle">PROCESS</h5>
                       <h4 class="CDB-infowindow-title">Surface Coating (Fabric Coating)</h4>
+                    </div>
+                  </div>
+                </div>
+                <div class="CDB-hook">
+                  <div class="CDB-hook-inner">
+                  </div>
+                </div>
+              </div>
+            </div>
+
+
+            <br/>
+            <br/>
+            <br/>
+            <br/>
+            Loading status
+            <br/>
+            <br/>
+            <br/>
+            <br/>
+            <div class="CDB-infowindow CDB-infowindow--light is-header js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-container">
+                <div class="CDB-infowindow-inner is-loading">
+                  <div class="CDB-Loader is-visible"></div>
+                </div>
+                <div class="CDB-hook">
+                  <div class="CDB-hook-inner">
+                  </div>
+                </div>
+              </div>
+            </div>
+            <br/>
+            <br/>
+            <br/>
+            <br/>
+            Loading status
+            <br/>
+            <br/>
+            <br/>
+            <br/>
+            <div class="CDB-infowindow CDB-infowindow--light is-header js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-container">
+                <div class="CDB-infowindow-header CDB-infowindow-headerMedia is-loading js-cover">
+                  <div class="CDB-Loader is-visible"></div>
+                </div>
+                <div class="CDB-infowindow-inner">
+                  <div class="CDB-infowindow-list">
+                    <div class="CDB-infowindow-listItem">
+                      <h5 class="CDB-infowindow-subtitle">ADDRESS</h5>
+                      <h4 class="CDB-infowindow-title">409 East Street</h4>
+                    </div>
+                    <div class="CDB-infowindow-listItem">
+                      <h5 class="CDB-infowindow-subtitle">HAP EMISSIONS TPY</h5>
+                      <h4 class="CDB-infowindow-title">33.53</h4>
                     </div>
                   </div>
                 </div>

--- a/test/spec/geo/ui/infowindow.spec.js
+++ b/test/spec/geo/ui/infowindow.spec.js
@@ -403,7 +403,7 @@ describe('geo/ui/infowindow', function() {
       expect(view._containsCover()).toEqual(true);
     });
 
-    it("should show the loader", function() {
+    it("should render the loader by default", function() {
       model.set('template', '<div class="js-infowindow"><div class="js-inner"></div></div>');
       expect(view.$el.find(".js-loader").length).toEqual(1);
     });

--- a/test/spec/geo/ui/infowindow.spec.js
+++ b/test/spec/geo/ui/infowindow.spec.js
@@ -386,10 +386,9 @@ describe('geo/ui/infowindow', function() {
     });
 
     it("should add the image cover class in the custom template", function() {
-      model.set('template', '<div class="js-infowindow" data-cover="true"><div class="js-cover" style="height: 123px"><img src="//fake" style="height: 100px"></div><div class="js-hook"></div></div>');
+      model.set('template', '<div class="js-infowindow has-title has-header-image is-header" data-cover="true"><div class="js-cover" style="height: 123px"><img src="//fake" style="height: 100px"></div><div class="js-hook"></div></div>');
       expect(view._containsCover()).toEqual(true);
       expect(view.$(".CDB-infowindow-media-item").length).toEqual(1);
-      expect(view.$(".js-cover").height()).toEqual(100 - view.options.hookHeight);
     });
 
     it("should setup the hook correctly", function() {

--- a/test/spec/geo/ui/infowindow.spec.js
+++ b/test/spec/geo/ui/infowindow.spec.js
@@ -403,6 +403,11 @@ describe('geo/ui/infowindow', function() {
       expect(view._containsCover()).toEqual(true);
     });
 
+    it("should show the loader", function() {
+      model.set('template', '<div class="js-infowindow"><div class="js-inner"></div></div>');
+      expect(view.$el.find(".js-loader").length).toEqual(1);
+    });
+
     it("should append the image", function() {
       model.set('template', '<div class="js-infowindow" data-cover="true"><div class="js-cover"></div></div>');
       expect(view.$el.find("img").length).toEqual(1);

--- a/test/spec/geo/ui/infowindow.spec.js
+++ b/test/spec/geo/ui/infowindow.spec.js
@@ -412,17 +412,22 @@ describe('geo/ui/infowindow', function() {
       expect(view.$el.find("img").length).toEqual(1);
     });
 
-    it("if the image is invalid it shouldn't append it", function() {
+    it("shouldn't append an image if it's not valid", function() {
       model.set("content", { fields: fieldsWithoutURL });
       model.set('template', '<div class="js-infowindow header" data-cover="true"><div class="js-cover"></div></div>');
       expect(view.$el.find("img").length).toEqual(0);
     });
 
-    it("if the theme doesn't have cover don't append the image", function() {
+    it("shouldn't append the image if the theme doesn't have cover", function() {
       model.set("content", { fields: fields });
       model.set('template', '<div class="js-cover"></div>');
       expect(view.$el.find("img").length).toEqual(0);
     });
 
+    it("shouldn append a non-valid error message if the image is not valid", function() {
+      model.set("content", { fields: fieldsWithoutURL });
+      model.set('template', '<div class="js-infowindow header" data-cover="true"><div class="js-cover"></div></div>');
+      expect(view.$el.find(".CDB-infowindow-fail").length).toEqual(1);
+    });
   });
 });

--- a/themes/scss/infowindow/cartodb-infowindow-default.scss
+++ b/themes/scss/infowindow/cartodb-infowindow-default.scss
@@ -101,14 +101,13 @@
 }
 
 .CDB-infowindow-fail {
+  display: block;
+  transform: translateY(50px);
   color: rgb(243, 86, 60);
   font-size: 9px;
-  text-transform: uppercase;
-  transform: translateY(50px);
-  display: block;
   text-align: center;
+  text-transform: uppercase;
 }
-
 
 .CDB-infowindow-mediaTitle {
   position: absolute;
@@ -117,8 +116,8 @@
   left: 24px;
   + .CDB-infowindow-fail {
     padding: 16px 0 0 20px;
-    text-align: left;
     transform: translateY(0);
+    text-align: left;
   }
 }
 .CDB-infowindow-headerMedia {

--- a/themes/scss/infowindow/cartodb-infowindow-default.scss
+++ b/themes/scss/infowindow/cartodb-infowindow-default.scss
@@ -1,42 +1,37 @@
 @import '../variables/sizes';
 @import '../variables/mixins';
 
-/* new infowindow */
 .CDB-infowindow-wrapper {
   position: absolute;
 }
 .CDB-infowindow {
-  position: relative;
-  /* remove when fix the position */
-  transform: translateY(-24px) translateX(4px);
-  border-radius: 4px;
   background: #FFF;
-  font-family: 'Open Sans';
+  border-radius: 4px;
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.24);
+  position: relative;
+  transform: translateY(-24px) translateX(4px); /* remove when fix the position */
+  font-family: 'Open Sans';
   cursor: default;
 }
 .CDB-infowindow-container {
   border-radius: 4px;
   overflow: hidden;
 }
+.CDB-infowindow.is-loading .CDB-infowindow-inner {
+  min-height: 104px;
+}
 .CDB-infowindow-inner,
 .CDB-infowindow-headerBg {
   padding: 20px 24px 18px;
 }
-.is-loading {
-  position: relative;
-  min-height: 50px;
-}
 .CDB-infowindow-inner.CDB-infowindow-inner--scroll .CDB-infowindow-list {
   max-height: 200px;
 }
-.is-header {
-  .CDB-infowindow-headerBg {
-    padding-bottom: 12px;
-  }
-  .CDB-infowindow-inner {
-    padding-top: 12px;
-  }
+.CDB-infowindow.is-header .CDB-infowindow-headerBg {
+  padding-bottom: 12px;
+}
+.CDB-infowindow.is-header .CDB-infowindow-inner {
+  padding-top: 12px;
 }
 .CDB-infowindow-header .CDB-infowindow-tabs {
   margin: -20px -24px 18px;
@@ -63,17 +58,22 @@
   padding-right: 12px;
 }
 
-.has-scroll .CDB-infowindow-list {
+.CDB-infowindow-inner.has-scroll .CDB-infowindow-list {
   position: relative;
   max-height: 200px;
   overflow: scroll;
 }
 
+.CDB-infowindow-inner.has-scroll .CDB-infowindow-list .CDB-infowindow-listItem {
+  margin-right: 20px;
+}
+
 .CDB-infowindow-listItem {
   margin-top: 8px;
-  &:first-child {
-    margin-top: 0;
-  }
+  word-break: break-all;
+}
+.CDB-infowindow-listItem:first-child {
+  margin-top: 0;
 }
 
 .CDB-infowindow-list .ps-scrollbar-y-rail {
@@ -96,17 +96,45 @@
   background: #888 !important;
 }
 
-.is-header .CDB-infowindow-mediaTitle {
+.CDB-infowindow.is-header .CDB-infowindow-mediaTitle {
   bottom: 12px;
+  display: block;
+}
+
+.CDB-infowindow.is-fail .CDB-infowindow-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.CDB-infowindow.has-items.has-title .CDB-infowindow-fail {
+  position: absolute;
+  left: 20px;
+  text-align: left;
+}
+
+.CDB-infowindow.has-title .CDB-infowindow-fail {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  text-align: left;
+}
+
+.CDB-infowindow.has-title .CDB-infowindow-fail {
+  position: absolute;
+  left: 0;
+  top: 20px;
+  width: 100%;
+  text-align: center;
 }
 
 .CDB-infowindow-fail {
-  display: block;
-  transform: translateY(50px);
-  color: rgb(243, 86, 60);
   font-size: 9px;
-  text-align: center;
   text-transform: uppercase;
+  color: rgb(243, 86, 60);
+  width: 100%;
+  text-align: center;
+  display: block;
 }
 
 .CDB-infowindow-mediaTitle {
@@ -114,23 +142,18 @@
   right: 24px;
   bottom: 24px;
   left: 24px;
-  + .CDB-infowindow-fail {
-    padding: 16px 0 0 20px;
-    transform: translateY(0);
-    text-align: left;
-  }
 }
+.CDB-infowindow-mediaTitle .CDB-infowindow-fail {
+  padding: 16px 0 0 20px;
+  text-align: left;
+  transform: translateY(0);
+}
+
 .CDB-infowindow-headerMedia {
   position: relative;
   min-height: 104px;
   overflow: hidden;
   z-index: 1;
-  &.is-loading {
-    background: #F5F5F5;
-  }
-  &.is-fail {
-    background: rgba(241, 87, 67, 0.04);
-  }
 
   .CDB-infowindow-title > span {
     display: inline;
@@ -148,6 +171,27 @@
     box-shadow: 4px 0 0 rgba(0, 0, 0, 0.64), -4px 0 0 rgba(0, 0, 0, 0.64);
   }
 }
+
+.CDB-infowindow-media-item {
+  transition: opacity 150ms ease-in-out;
+  border-radius: 4px;
+  opacity: 1;
+}
+.CDB-infowindow.is-loading .CDB-infowindow-media-item {
+  opacity: 0;
+}
+.CDB-infowindow.is-loading .CDB-infowindow-headerMedia {
+  min-height: 104px;
+}
+.CDB-infowindow.is-loading .CDB-infowindow-headerMedia {
+  background: #F5F5F5;
+}
+.CDB-infowindow.is-fail .CDB-infowindow-headerMedia {
+  background: #FEF8F7;
+}
+.CDB-infowindow.is-fail.has-header-image .CDB-hook-image:before {
+  border-top-color: #FEF8F7;
+}
 .CDB-infowindow-media-item {
   display: block;
   width: 100%;
@@ -158,6 +202,7 @@
   left: 24px;
   z-index: 10;
 }
+
 .CDB-hook:before {
   position: absolute;
   top: 0;
@@ -167,6 +212,9 @@
   border-right: 24px solid transparent;
   content: '';
   z-index: 3;
+}
+.CDB-hook:before {
+  border-top: 16px solid #FFF;
 }
 .CDB-hook--green.CDB-hook:before {
   border-top: 16px solid #98E0A8 !important;
@@ -188,7 +236,9 @@
   content: '';
   z-index: 2;
 }
-.CDB-infowindow.is-header-image .CDB-hook-image {
+
+.CDB-hook-image.has-image,
+.CDB-infowindow.has-header-image .CDB-hook-image.has-image {
   position: absolute;
   left: 24px;
   width: 24px;
@@ -199,11 +249,41 @@
   }
 }
 
-.CDB-infowindow.is-header-image .CDB-hook-image-inner {
+.CDB-hook-image-inner {
+  pointer-events: none;
+}
+
+.CDB-hook-image.has-image:before,
+.CDB-infowindow.has-header-image .CDB-hook-image.has-image:before,
+.CDB-hook-image-inner.has-image:before {
+  display: none;
+}
+.CDB-infowindow.has-header-image .CDB-hook-image.has-image .CDB-hook-image-inner {
   position: relative;
   width: 100%;
   height: 100%;
   overflow: hidden;
+  z-index: 3;
+}
+
+.CDB-infowindow.has-header-image .CDB-hook-image {
+  position: absolute;
+  left: 24px;
+  z-index: 10;
+}
+
+.CDB-infowindow.has-header-image .CDB-hook-image:before {
+  border-top: 16px solid #F5F5F5;
+}
+
+.CDB-infowindow.has-header-image .CDB-hook-image:before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  border-right: 24px solid transparent;
+  content: '';
   z-index: 3;
 }
 
@@ -354,6 +434,9 @@
 
 img[data-clipPath]{
   visibility: hidden;
+}
+.CDB-infowindow-mask {
+  pointer-events: none;
 }
 .CDB-infowindow-mask image {
   visibility: visible;

--- a/themes/scss/infowindow/cartodb-infowindow-default.scss
+++ b/themes/scss/infowindow/cartodb-infowindow-default.scss
@@ -100,19 +100,37 @@
   bottom: 12px;
 }
 
+.CDB-infowindow-fail {
+  color: rgb(243, 86, 60);
+  font-size: 9px;
+  text-transform: uppercase;
+  transform: translateY(50px);
+  display: block;
+  text-align: center;
+}
+
+
 .CDB-infowindow-mediaTitle {
   position: absolute;
   right: 24px;
   bottom: 24px;
   left: 24px;
+  + .CDB-infowindow-fail {
+    padding: 16px 0 0 20px;
+    text-align: left;
+    transform: translateY(0);
+  }
 }
 .CDB-infowindow-headerMedia {
   position: relative;
-  min-height: 100px;
+  min-height: 104px;
   overflow: hidden;
   z-index: 1;
   &.is-loading {
     background: #F5F5F5;
+  }
+  &.is-fail {
+    background: rgba(241, 87, 67, 0.04);
   }
 
   .CDB-infowindow-title > span {

--- a/themes/scss/infowindow/cartodb-infowindow-default.scss
+++ b/themes/scss/infowindow/cartodb-infowindow-default.scss
@@ -23,6 +23,10 @@
 .CDB-infowindow-headerBg {
   padding: 20px 24px 18px;
 }
+.is-loading {
+  position: relative;
+  min-height: 50px;
+}
 .CDB-infowindow-inner.CDB-infowindow-inner--scroll .CDB-infowindow-list {
   max-height: 200px;
 }
@@ -107,6 +111,9 @@
   min-height: 100px;
   overflow: hidden;
   z-index: 1;
+  &.is-loading {
+    background: #F5F5F5;
+  }
 
   .CDB-infowindow-title > span {
     display: inline;
@@ -284,6 +291,7 @@
   }
 }
 
+/*
 .CDB-loading {
   padding: 4px 0 10px;
 }
@@ -325,6 +333,7 @@
   background: linear-gradient(to right, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 50%, rgba(0, 0, 0, 0) 100%);
   animation: placeholder ease-in-out 2s infinite;
 }
+*/
 
 img[data-clipPath]{
   visibility: hidden;

--- a/themes/scss/infowindow/cartodb-infowindow-default.scss
+++ b/themes/scss/infowindow/cartodb-infowindow-default.scss
@@ -107,34 +107,31 @@
   justify-content: center;
 }
 
-.CDB-infowindow.has-items.has-title .CDB-infowindow-fail {
-  position: absolute;
-  left: 20px;
-  text-align: left;
-}
-
-.CDB-infowindow.has-title .CDB-infowindow-fail {
-  position: absolute;
-  top: 20px;
-  left: 20px;
-  text-align: left;
-}
-
-.CDB-infowindow.has-title .CDB-infowindow-fail {
-  position: absolute;
-  left: 0;
-  top: 20px;
-  width: 100%;
-  text-align: center;
-}
 
 .CDB-infowindow-fail {
   display: block;
-  width: 100%;
   color: rgb(243, 86, 60);
   font-size: 9px;
   text-align: center;
   text-transform: uppercase;
+}
+.CDB-infowindow.has-title.has-items.has-header-image .CDB-infowindow-fail {
+  position: absolute;
+  left: 20px;
+  top: 20px;
+  text-align: left;
+}
+.CDB-infowindow.has-title .CDB-infowindow-fail {
+  position: absolute;
+  left: 0px;
+  top: 20px;
+  width: 100%;
+  text-align: center;
+}
+.CDB-infowindow-mediaTitle .CDB-infowindow-fail {
+  width: auto;
+  padding: 16px 0 0 20px;
+  text-align: left;
 }
 
 .CDB-infowindow-mediaTitle {
@@ -142,10 +139,6 @@
   right: 24px;
   bottom: 24px;
   left: 24px;
-}
-.CDB-infowindow-mediaTitle .CDB-infowindow-fail {
-  padding: 16px 0 0 20px;
-  text-align: left;
 }
 
 .CDB-infowindow-headerMedia {
@@ -268,16 +261,13 @@
 }
 
 .CDB-infowindow.has-header-image .CDB-hook-image:before {
-  border-top: 16px solid #F5F5F5;
-}
-
-.CDB-infowindow.has-header-image .CDB-hook-image:before {
   position: absolute;
   top: 0;
   left: 0;
   width: 0;
   height: 0;
   border-right: 24px solid transparent;
+  border-top: 16px solid #F5F5F5;
   content: '';
   z-index: 3;
 }

--- a/themes/scss/infowindow/cartodb-infowindow-default.scss
+++ b/themes/scss/infowindow/cartodb-infowindow-default.scss
@@ -107,7 +107,6 @@
   justify-content: center;
 }
 
-
 .CDB-infowindow-fail {
   display: block;
   color: rgb(243, 86, 60);

--- a/themes/scss/infowindow/cartodb-infowindow-default.scss
+++ b/themes/scss/infowindow/cartodb-infowindow-default.scss
@@ -27,10 +27,10 @@
 .CDB-infowindow-inner.CDB-infowindow-inner--scroll .CDB-infowindow-list {
   max-height: 200px;
 }
-.CDB-infowindow.is-header .CDB-infowindow-headerBg {
+.CDB-infowindow.has-header .CDB-infowindow-headerBg {
   padding-bottom: 12px;
 }
-.CDB-infowindow.is-header .CDB-infowindow-inner {
+.CDB-infowindow.has-header .CDB-infowindow-inner {
   padding-top: 12px;
 }
 .CDB-infowindow-header .CDB-infowindow-tabs {
@@ -96,7 +96,7 @@
   background: #888 !important;
 }
 
-.CDB-infowindow.is-header .CDB-infowindow-mediaTitle {
+.CDB-infowindow.has-header .CDB-infowindow-mediaTitle {
   display: block;
   bottom: 12px;
 }
@@ -124,8 +124,7 @@
 .CDB-infowindow.has-title .CDB-infowindow-fail {
   position: absolute;
   top: 20px;
-  left: 0;
-  width: 100%;
+  left: 20px;
   text-align: center;
 }
 .CDB-infowindow-mediaTitle .CDB-infowindow-fail {
@@ -370,50 +369,6 @@
     content: '';
   }
 }
-
-/*
-.CDB-loading {
-  padding: 4px 0 10px;
-}
-.CDB-loading-subtitle {
-  width: 40%;
-  height: 4px;
-  margin-bottom: 8px;
-}
-.CDB-loading-title {
-  width: 90%;
-  height: 8px;
-}
-.CDB-loading-text {
-  position: relative;
-  overflow: hidden;
-}
-
-@-webkit-keyframes placeholder {
-  0% {
-    left: -100%;
-  }
-  100% {
-    left: 70%;
-  }
-}
-@keyframes placeholder {
-  0% {
-    left: -100%;
-  }
-  100% {
-    left: 70%;
-  }
-}
-.CDB-loading-bg {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 50%;
-  background: linear-gradient(to right, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 50%, rgba(0, 0, 0, 0) 100%);
-  animation: placeholder ease-in-out 2s infinite;
-}
-*/
 
 img[data-clipPath]{
   visibility: hidden;

--- a/themes/scss/infowindow/cartodb-infowindow-default.scss
+++ b/themes/scss/infowindow/cartodb-infowindow-default.scss
@@ -97,8 +97,8 @@
 }
 
 .CDB-infowindow.is-header .CDB-infowindow-mediaTitle {
-  bottom: 12px;
   display: block;
+  bottom: 12px;
 }
 
 .CDB-infowindow.is-fail .CDB-infowindow-header {
@@ -117,14 +117,14 @@
 }
 .CDB-infowindow.has-title.has-items.has-header-image .CDB-infowindow-fail {
   position: absolute;
-  left: 20px;
   top: 20px;
+  left: 20px;
   text-align: left;
 }
 .CDB-infowindow.has-title .CDB-infowindow-fail {
   position: absolute;
-  left: 0px;
   top: 20px;
+  left: 0;
   width: 100%;
   text-align: center;
 }
@@ -164,11 +164,6 @@
   }
 }
 
-.CDB-infowindow-media-item {
-  transition: opacity 150ms ease-in-out;
-  border-radius: 4px;
-  opacity: 1;
-}
 .CDB-infowindow.is-loading .CDB-infowindow-media-item {
   opacity: 0;
 }
@@ -185,6 +180,9 @@
 .CDB-infowindow-media-item {
   display: block;
   width: 100%;
+  transition: opacity 150ms ease-in-out;
+  border-radius: 4px;
+  opacity: 1;
 }
 .CDB-hook {
   position: absolute;
@@ -199,8 +197,8 @@
   left: 0;
   width: 0;
   height: 0;
-  border-right: 24px solid transparent;
   border-top: 16px solid #FFF;
+  border-right: 24px solid transparent;
   content: '';
   z-index: 3;
 }
@@ -266,8 +264,8 @@
   left: 0;
   width: 0;
   height: 0;
-  border-right: 24px solid transparent;
   border-top: 16px solid #F5F5F5;
+  border-right: 24px solid transparent;
   content: '';
   z-index: 3;
 }

--- a/themes/scss/infowindow/cartodb-infowindow-default.scss
+++ b/themes/scss/infowindow/cartodb-infowindow-default.scss
@@ -129,12 +129,12 @@
 }
 
 .CDB-infowindow-fail {
-  font-size: 9px;
-  text-transform: uppercase;
-  color: rgb(243, 86, 60);
-  width: 100%;
-  text-align: center;
   display: block;
+  width: 100%;
+  color: rgb(243, 86, 60);
+  font-size: 9px;
+  text-align: center;
+  text-transform: uppercase;
 }
 
 .CDB-infowindow-mediaTitle {
@@ -146,7 +146,6 @@
 .CDB-infowindow-mediaTitle .CDB-infowindow-fail {
   padding: 16px 0 0 20px;
   text-align: left;
-  transform: translateY(0);
 }
 
 .CDB-infowindow-headerMedia {
@@ -182,8 +181,6 @@
 }
 .CDB-infowindow.is-loading .CDB-infowindow-headerMedia {
   min-height: 104px;
-}
-.CDB-infowindow.is-loading .CDB-infowindow-headerMedia {
   background: #F5F5F5;
 }
 .CDB-infowindow.is-fail .CDB-infowindow-headerMedia {
@@ -210,11 +207,9 @@
   width: 0;
   height: 0;
   border-right: 24px solid transparent;
+  border-top: 16px solid #FFF;
   content: '';
   z-index: 3;
-}
-.CDB-hook:before {
-  border-top: 16px solid #FFF;
 }
 .CDB-hook--green.CDB-hook:before {
   border-top: 16px solid #98E0A8 !important;


### PR DESCRIPTION
This PR adds:

- Shows error messages to indicate non-valid URLs for the image cover.
- Adds loader.
- Several fixes (like one for the empty infowindow tip or hook that didn't appear if the infowindow had an image cover; or added ```pointer-events: none``` to certain hidden areas that prevented clicking on the map)
- Renamed  classes:``.is-header``` and ```.is-header-image``` to `.has-header``` and ```.has-header-image```

![loader_image](https://cloud.githubusercontent.com/assets/4933/12052525/3287bd5a-af10-11e5-8dce-c3e8c35ecb68.gif)
![loader](https://cloud.githubusercontent.com/assets/4933/12052526/32a7cac8-af10-11e5-9567-fa3e913a103f.gif)

![screen shot 2016-01-07 at 12 59 54](https://cloud.githubusercontent.com/assets/4933/12170129/dc82c6ea-b53e-11e5-8167-4eb4827c31be.png)

![screen shot 2016-01-07 at 13 19 18](https://cloud.githubusercontent.com/assets/4933/12170385/49bf5122-b541-11e5-9387-562b79b4057f.png)


![screen shot 2016-01-07 at 13 01 32](https://cloud.githubusercontent.com/assets/4933/12170131/dc8b2e2a-b53e-11e5-99f6-6eea2049b3f1.png)
