### PR TITLE
Fixes issue with non-hidden attribution

### DIFF
--- a/themes/scss/map/attributions.scss
+++ b/themes/scss/map/attributions.scss
@@ -17,18 +17,17 @@ $size: 20px;
   box-sizing: border-box;
   font-family: 'Open Sans';
   line-height: $size;
-  //box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.24), 0 4px 8px 0 rgba(0, 0, 0, 0.16);
   z-index: 10;
-
-  &.is-active {
-    background: rgba(0, 0, 0, 0.64);
-    .CDB-Attribution-text {
-      width: auto;
-      opacity: 1;
-    }
-  }
 }
-.CDB-Attribution:hover {
+.CDB-Attribution.is-active {
+  background: rgba(0, 0, 0, 0.64);
+}
+.CDB-Attribution.is-active .CDB-Attribution-text {
+  pointer-events: initial;
+  width: auto;
+  opacity: 1;
+}
+.CDB-Attribution.is-active.CDB-Attribution-text a {
   cursor: pointer;
 }
 .CDB-Attribution--gmaps {
@@ -54,14 +53,16 @@ $size: 20px;
 }
 .CDB-Attribution-text {
   @include transition(opacity, 150ms);
+  pointer-events: none;
   color: #FFF;
   font-size: $sFontSize-small;
   line-height: $size;
   opacity: 0;
 }
-.CDB-Attribution-text a {
-  color: #FFF !important;
+.CDB-Attribution .CDB-Attribution-text a {
+  color: #FFF;
   text-decoration: underline;
+  cursor: pointer;
 }
 
 @include media-query-mobile() {


### PR DESCRIPTION
Original issue: #980 

This PR fixes a problem with the map attribution. It's possible to inadvertently click on the attribution of the map and follow the linked URLs.

![screen shot 2016-01-04 at 17 53 29](https://cloud.githubusercontent.com/assets/4933/12094979/17e0d7de-b30c-11e5-963d-c4911ef01756.png)

PR: @piensaenpixel 
