### PR TITLE
changed type from torque to cartodb for layer source object

### DIFF
--- a/doc/layer_source_object.md
+++ b/doc/layer_source_object.md
@@ -8,7 +8,7 @@ Used for most maps with tables that are set to public or public with link.
 
 ```javascript
 {
-  type: 'torque', // Required
+  type: 'cartodb', // Required
   order: 1, // Optional
   options: {
     query: "SQL statement",   // Required if table_name is not given


### PR DESCRIPTION
For [Docs issue#626](https://github.com/CartoDB/docs/issues/626), changed type from torque to cartodb for the time being. (Additional issue to enhance this section is also planned, as described in the issue).

@matallo , please merge