### PR TITLE
added link to Releases folder instead of specific version number

### DIFF
--- a/doc/api_methods.md
+++ b/doc/api_methods.md
@@ -1,6 +1,6 @@
 # API methods
 
-The documentation below refers to CartoDB.js v3. For major changes in the library we will update the documentation here. This documentation is meant to help developers find specific methods from the CartoDB.js library.
+This documentation is intended for developers and describes specific methods from the [latest version](https://github.com/CartoDB/cartodb.js/releases) of the CartoDB.js library.
 
 ## cartodb.createVis
 


### PR DESCRIPTION
@rochoa , a Support Issue reported the out-of-date versioning number in the CartoDB.js introduction / API Methods.  I have rewritten the intro slightly, and added a link to the more generic Releases folder. That way, whenever versioning changes, this will be correct.

Please let me know if you approve?