### PR TITLE
Retrofit windshaft and add new dataviews + filters concepts

### DIFF
--- a/grunt/tasks/_browserify-bundles.js
+++ b/grunt/tasks/_browserify-bundles.js
@@ -20,9 +20,11 @@ module.exports = {
       'test/fail-tests-if-have-errors-in-src.js',
       'test/spec/api/**/*',
       'test/spec/core/**/*',
+      'test/spec/dataviews/**/*',
       'test/spec/geo/**/*',
       'test/spec/ui/**/*',
       'test/spec/vis/**/*',
+      'test/spec/windshaft/**/*',
 
       // not actually used anywhere in cartodb.js, only for editor?
       // TODO can be (re)moved?

--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -1,0 +1,339 @@
+var _ = require('underscore');
+var DataviewModelBase = require('./dataview-model-base');
+var SearchModel = require('./category-dataview/search-model');
+var CategoryModelRange = require('./category-dataview/category-model-range');
+var CategoriesCollection = require('./category-dataview/categories-collection');
+var LockedCatsCollection = require('./category-dataview/locked-categories-collection');
+
+/**
+ *  Category dataview model
+ *
+ *  - It has several internal models/collections
+ *
+ *  · search model: it manages category search results.
+ *  · locked collection: it stores locked items.
+ *  · filter model: it knows which items are accepted or rejected.
+ *
+ */
+
+module.exports = DataviewModelBase.extend({
+
+  defaults: _.extend(
+    {
+      allCategoryNames: [] // all (new + previously locked), updated on data fetch (see parse)
+    },
+    DataviewModelBase.prototype.defaults
+  ),
+
+  url: function () {
+    return this.get('url') + '?bbox=' + this.get('boundingBox') + '&own_filter=' + (this.get('locked') ? 1 : 0);
+  },
+
+  initialize: function (attrs, opts) {
+    this._data = new CategoriesCollection();
+
+    DataviewModelBase.prototype.initialize.call(this, attrs, opts);
+
+    // Locked categories collection
+    this.locked = new LockedCatsCollection();
+
+    // Internal model for calculating total amount of values in the category
+    this.rangeModel = new CategoryModelRange();
+
+    // Search model
+    this.search = new SearchModel({}, {
+      locked: this.locked
+    });
+  },
+
+  // Set any needed parameter when they have changed in this model
+  _setInternalModels: function () {
+    var url = this.get('url');
+
+    this.search.set({
+      url: url,
+      boundingBox: this.get('boundingBox')
+    });
+
+    this.rangeModel.setUrl(url);
+  },
+
+  _onChangeBinds: function () {
+    this._setInternalModels();
+
+    this.rangeModel.bind('change:totalCount change:categoriesCount', function () {
+      this.set({
+        totalCount: this.rangeModel.get('totalCount'),
+        categoriesCount: this.rangeModel.get('categoriesCount')
+      });
+    }, this);
+
+    this.bind('change:url', function () {
+      if (this.get('sync') && !this.isDisabled()) {
+        this._fetch();
+      }
+    }, this);
+
+    this.bind('change:boundingBox', function () {
+      // If a search is applied and bounding bounds has changed,
+      // don't fetch new raw data
+      if (this.get('bbox') && !this.isSearchApplied() && !this.isDisabled()) {
+        this._fetch();
+      }
+    }, this);
+
+    this.bind('change:url change:boundingBox', function () {
+      this.search.set({
+        url: this.get('url'),
+        boundingBox: this.get('boundingBox')
+      });
+    }, this);
+
+    this.bind('change:disabled', function (mdl, isDisabled) {
+      if (!isDisabled) {
+        if (mdl.changedAttributes(this._previousAttrs)) {
+          this._fetch();
+        }
+      } else {
+        this._previousAttrs = {
+          url: this.get('url'),
+          boundingBox: this.get('boundingBox')
+        };
+      }
+    }, this);
+
+    this.locked.bind('change add remove', function () {
+      this.trigger('change:lockCollection', this.locked, this);
+    }, this);
+
+    this.search.bind('loading', function () {
+      this.trigger('loading', this);
+    }, this);
+    this.search.bind('sync', function () {
+      this.trigger('sync', this);
+    }, this);
+    this.search.bind('error', function (e) {
+      if (!e || (e && e.statusText !== 'abort')) {
+        this.trigger('error', this);
+      }
+    }, this);
+    this.search.bind('change:data', function () {
+      this.trigger('change:searchData', this.search, this);
+    }, this);
+  },
+
+  getLockedSize: function () {
+    return this.locked.size();
+  },
+
+  isLocked: function () {
+    return this.get('locked');
+  },
+
+  canBeLocked: function () {
+    return this.isLocked() ||
+    this.getAcceptedCount() > 0;
+  },
+
+  canApplyLocked: function () {
+    var acceptedCollection = this.filter.getAccepted();
+    if (this.filter.getAccepted().size() !== this.locked.size()) {
+      return true;
+    }
+
+    return acceptedCollection.find(function (m) {
+      return !this.locked.isItemLocked(m.get('name'));
+    }, this);
+  },
+
+  applyLocked: function () {
+    var currentLocked = this.locked.getItemsName();
+    if (!currentLocked.length) {
+      this.unlockCategories();
+      return false;
+    }
+    this.set('locked', true);
+    this.filter.cleanFilter(false);
+    this.filter.accept(currentLocked);
+    this.filter.applyFilter();
+    this.cleanSearch();
+  },
+
+  lockCategories: function () {
+    this.set('locked', true);
+    this._fetch();
+  },
+
+  unlockCategories: function () {
+    this.set('locked', false);
+    this.acceptAll();
+  },
+
+  // Search model helper methods //
+
+  getSearchQuery: function () {
+    return this.search.getSearchQuery();
+  },
+
+  setSearchQuery: function (q) {
+    this.search.set('q', q);
+  },
+
+  isSearchValid: function () {
+    return this.search.isValid();
+  },
+
+  getSearchResult: function () {
+    return this.search.getData();
+  },
+
+  getSearchCount: function () {
+    return this.search.getCount();
+  },
+
+  applySearch: function () {
+    this.search.fetch();
+  },
+
+  isSearchApplied: function () {
+    return this.search.isSearchApplied();
+  },
+
+  cleanSearch: function () {
+    this.locked.resetItems([]);
+    this.search.resetData();
+  },
+
+  setupSearch: function () {
+    if (!this.isSearchApplied()) {
+      var acceptedCats = this.filter.getAccepted().toJSON();
+      this.locked.addItems(acceptedCats);
+      this.search.setData(
+        this._data.toJSON()
+      );
+    }
+  },
+
+  // Filter model helper methods //
+
+  getRejectedCount: function () {
+    return this.filter.rejectedCategories.size();
+  },
+
+  getAcceptedCount: function () {
+    return this.filter.acceptedCategories.size();
+  },
+
+  acceptFilters: function (values) {
+    this.filter.accept(values);
+  },
+
+  rejectFilters: function (values) {
+    this.filter.reject(values);
+  },
+
+  rejectAll: function () {
+    this.filter.rejectAll();
+  },
+
+  acceptAll: function () {
+    this.filter.acceptAll();
+  },
+
+  isAllFiltersRejected: function () {
+    return this.filter.get('rejectAll');
+  },
+
+  // Proper model helper methods //
+
+  getData: function () {
+    return this._data;
+  },
+
+  getSize: function () {
+    return this._data.size();
+  },
+
+  getCount: function () {
+    return this.get('categoriesCount');
+  },
+
+  isOtherAvailable: function () {
+    return this._data.isOtherAvailable();
+  },
+
+  refresh: function () {
+    if (this.isSearchApplied()) {
+      this.search.fetch();
+    } else {
+      this._fetch();
+    }
+  },
+
+  parse: function (d) {
+    var newData = [];
+    var _tmpArray = {};
+    var allNewCategories = d.categories;
+    var allNewCategoryNames = [];
+    var acceptedCategoryNames = [];
+
+    _.each(allNewCategories, function (datum, i) {
+      // Category might be a non-string type (e.g. number), make sure it's always a string for concistency
+      var category = datum.category.toString();
+
+      allNewCategoryNames.push(category);
+      var isRejected = this.filter.isRejected(category);
+      _tmpArray[category] = true;
+
+      newData.push({
+        selected: !isRejected,
+        name: category,
+        agg: datum.agg,
+        value: datum.value
+      });
+    }, this);
+
+    if (this.isLocked()) {
+      // Add accepted items that are not present in the categories data
+      this.filter.getAccepted().each(function (mdl, i) {
+        var category = mdl.get('name');
+        acceptedCategoryNames.push(category);
+        if (!_tmpArray[category]) {
+          newData.push({
+            selected: true,
+            name: category,
+            agg: false,
+            value: 0
+          });
+        }
+      }, this);
+    }
+
+    this._data.reset(newData);
+    return {
+      allCategoryNames: _
+        .chain(allNewCategoryNames)
+        .union(acceptedCategoryNames)
+        .unique()
+        .value(),
+      data: newData,
+      nulls: d.nulls,
+      min: d.min,
+      max: d.max,
+      count: d.count
+    };
+  },
+
+  // Backbone toJson function override
+  toJSON: function () {
+    return {
+      type: 'aggregation',
+      options: {
+        column: this.get('column'),
+        aggregation: this.get('aggregation'),
+        aggregationColumn: this.get('aggregationColumn')
+      }
+    };
+  }
+
+});

--- a/src/dataviews/category-dataview/categories-collection.js
+++ b/src/dataviews/category-dataview/categories-collection.js
@@ -1,0 +1,32 @@
+var Backbone = require('backbone');
+var CategoryItemModel = require('./category-item-model');
+
+/**
+ *  Data categories collection
+ *
+ *  - It basically sorts by (value, selected and "Other").
+ */
+
+module.exports = Backbone.Collection.extend({
+  model: CategoryItemModel,
+
+  comparator: function (a, b) {
+    if (a.get('name') === 'Other') {
+      return 1;
+    } else if (b.get('name') === 'Other') {
+      return -1;
+    } else if (a.get('value') === b.get('value')) {
+      return (a.get('selected') < b.get('selected')) ? 1 : -1;
+    } else {
+      return (a.get('value') < b.get('value')) ? 1 : -1;
+    }
+  },
+
+  isOtherAvailable: function () {
+    return this.where({
+      agg: true,
+      name: 'Other'
+    }).length > 0;
+  }
+
+});

--- a/src/dataviews/category-dataview/category-item-model.js
+++ b/src/dataviews/category-dataview/category-item-model.js
@@ -1,0 +1,14 @@
+var Model = require('../../core/model');
+
+/**
+ * Model for a category
+ */
+module.exports = Model.extend({
+
+  defaults: {
+    name: '',
+    agg: false,
+    value: 0
+  }
+
+});

--- a/src/dataviews/category-dataview/category-model-range.js
+++ b/src/dataviews/category-dataview/category-model-range.js
@@ -1,0 +1,45 @@
+var _ = require('underscore');
+var Model = require('../../core/model');
+
+/**
+ *  This model is used for getting the total amount of values
+ *  from the category.
+ *
+ */
+
+module.exports = Model.extend({
+  defaults: {
+    url: '',
+    totalCount: 0,
+    categoriesCount: 0
+  },
+
+  url: function () {
+    return this.get('url');
+  },
+
+  initialize: function () {
+    this.bind('change:url', function () {
+      this.fetch();
+    }, this);
+  },
+
+  setUrl: function (url) {
+    this.set('url', url);
+  },
+
+  parse: function (d) {
+    // Calculating the total amount of all categories with the sum of all
+    // values from this model included the aggregated (Other)
+    return {
+      categoriesCount: d.categoriesCount,
+      totalCount: _.reduce(
+        _.pluck(d.categories, 'value'),
+        function (memo, value) {
+          return memo + value;
+        },
+        0
+      )
+    };
+  }
+});

--- a/src/dataviews/category-dataview/locked-categories-collection.js
+++ b/src/dataviews/category-dataview/locked-categories-collection.js
@@ -1,0 +1,52 @@
+var _ = require('underscore');
+var Backbone = require('backbone');
+var CategoryItemModel = require('./category-item-model');
+
+/**
+ *  Locked categories collection
+ *
+ */
+
+module.exports = Backbone.Collection.extend({
+  model: CategoryItemModel,
+
+  addItem: function (mdl) {
+    if (!this.isItemLocked(mdl.get('name'))) {
+      this.add(mdl);
+    }
+  },
+
+  addItems: function (mdls) {
+    _.each(mdls, function (m) {
+      if (!this.isItemLocked(m.name)) {
+        this.add(m);
+      }
+    }, this);
+  },
+
+  resetItems: function (mdls) {
+    this.reset(mdls);
+  },
+
+  removeItem: function (mdl) {
+    var lockedItem = this.isItemLocked(mdl.get('name'));
+    if (lockedItem) {
+      this.remove(lockedItem);
+    }
+  },
+
+  removeItems: function () {
+    this.reset([]);
+  },
+
+  isItemLocked: function (name) {
+    return this.find(function (d) {
+      return d.get('name') === name;
+    });
+  },
+
+  getItemsName: function () {
+    return this.pluck('name');
+  }
+
+});

--- a/src/dataviews/category-dataview/search-model.js
+++ b/src/dataviews/category-dataview/search-model.js
@@ -1,0 +1,121 @@
+var _ = require('underscore');
+var Model = require('../../core/model');
+var CategoriesCollection = require('./categories-collection');
+
+/**
+ * Category search model
+ */
+module.exports = Model.extend({
+  defaults: {
+    q: '',
+    data: [],
+    url: ''
+  },
+
+  url: function () {
+    return this.get('url') + '/search?q=' + encodeURIComponent(this.get('q'));
+  },
+
+  initialize: function (attrs, opts) {
+    // Locked collection will have the status
+    // of the selected/locked items
+    this.locked = opts.locked;
+    this._data = new CategoriesCollection();
+    this._initBinds();
+  },
+
+  _initBinds: function () {
+    this._data.bind('change:selected', this._onChangeSelected, this);
+    this.bind('change:boundingBox', function () {
+      if (this.isSearchApplied()) {
+        this.fetch();
+      }
+    }, this);
+  },
+
+  setData: function (data) {
+    var categories = this._parseData(data);
+    this._data.reset(categories);
+    this.set('data', categories);
+  },
+
+  getData: function () {
+    return this._data;
+  },
+
+  getSize: function () {
+    return this._data.size();
+  },
+
+  getCount: function () {
+    return this.getSize();
+  },
+
+  isValid: function () {
+    var str = this.get('q');
+    return !!(str || '');
+  },
+
+  isLocked: function () {},
+
+  resetData: function () {
+    this.setData([]);
+    this.set('q', '');
+  },
+
+  getSearchQuery: function () {
+    return this.get('q');
+  },
+
+  isSearchApplied: function () {
+    return this.isValid() && this.getSize() > 0;
+  },
+
+  _onChangeSelected: function (mdl, isSelected) {
+    this.locked[ isSelected ? 'addItem' : 'removeItem' ](mdl);
+  },
+
+  _parseData: function (categories) {
+    var newData = [];
+    _.each(categories, function (d) {
+      if (!d.agg) {
+        var category = (d.category || d.name).toString();
+        var isLocked = this.locked.isItemLocked(category);
+        newData.push({
+          selected: isLocked,
+          name: category,
+          agg: d.agg,
+          value: d.value
+        });
+      }
+    }, this);
+
+    return newData;
+  },
+
+  parse: function (r) {
+    var categories = this._parseData(r.categories);
+    this._data.reset(categories);
+    return {
+      data: categories
+    };
+  },
+
+  fetch: function (opts) {
+    this.trigger('loading', this);
+    return cdb.core.Model.prototype.fetch.call(this, opts);
+  },
+
+  sync: function () {
+    var self = arguments[1];
+    if (this._xhr) {
+      this._xhr.abort();
+    }
+    this._xhr = cdb.core.Model.prototype.sync.apply(this, arguments);
+    this._xhr.always(function () {
+      self._xhr = null;
+    });
+    return this._xhr;
+  }
+
+});

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -1,0 +1,121 @@
+var Model = require('../core/model');
+
+/**
+ * Default dataview model
+ */
+module.exports = Model.extend({
+  defaults: {
+    url: '',
+    data: [],
+    columns: [],
+    sync: true,
+    bbox: true,
+    disabled: false
+  },
+
+  url: function () {
+    return this.get('url') + '?bbox=' + this.get('boundingBox');
+  },
+
+  initialize: function (attrs, opts) {
+    attrs = attrs || {};
+    opts = opts || {};
+
+    if (!attrs.id) {
+      this.set('id', attrs.type + '-' + this.cid);
+    }
+
+    this.layer = opts.layer;
+
+    // filter is optional, so have to guard before using it
+    this.filter = opts.filter;
+    if (this.filter) {
+      this.filter.set('dataviewId', this.id);
+    }
+
+    this._initBinds();
+  },
+
+  _initBinds: function () {
+    this.once('change:url', function () {
+      var self = this;
+      this._fetch(function () {
+        self._onChangeBinds();
+      });
+    }, this);
+
+    // Retrigger an event when the filter changes
+    if (this.filter) {
+      this.filter.bind('change', this._onFilterChanged, this);
+    }
+  },
+
+  _onChangeBinds: function () {
+    this.bind('change:url', function () {
+      if (this.get('sync') && !this.isDisabled()) {
+        this._fetch();
+      }
+    }, this);
+    this.bind('change:boundingBox', function () {
+      if (this.get('bbox') && !this.isDisabled()) {
+        this._fetch();
+      }
+    }, this);
+
+    this.bind('change:disabled', function (mdl, isDisabled) {
+      if (!isDisabled) {
+        if (mdl.changedAttributes(this._previousAttrs)) {
+          this._fetch();
+        }
+      } else {
+        this._previousAttrs = {
+          url: this.get('url'),
+          boundingBox: this.get('boundingBox')
+        };
+      }
+    }, this);
+  },
+
+  _fetch: function (callback) {
+    var self = this;
+    this.fetch({
+      success: callback,
+      error: function () {
+        self.trigger('error');
+      }
+    });
+  },
+
+  refresh: function () {
+    this._fetch();
+  },
+
+  isDisabled: function () {
+    return this.get('disabled');
+  },
+
+  setDisabled: function (disabled) {
+    this.set('disabled', !!disabled);
+  },
+
+  _onFilterChanged: function (filter) {
+    this.trigger('change:filter', this, filter);
+  },
+
+  getData: function () {
+    return this.get('data');
+  },
+
+  getPreviousData: function () {
+    return this.previous('data');
+  },
+
+  fetch: function (opts) {
+    this.trigger('loading', this);
+    return Model.prototype.fetch.call(this, opts);
+  },
+
+  toJSON: function () {
+    throw new Error('toJSON should be defined for each dataview');
+  }
+});

--- a/src/dataviews/dataviews-collection.js
+++ b/src/dataviews/dataviews-collection.js
@@ -1,0 +1,20 @@
+var Backbone = require('backbone');
+
+/**
+ * Collection of Dataviews
+ */
+module.exports = Backbone.Collection.extend({
+  initialize: function () {
+    // If a histogram model applies the histogram sizes, rest should remove/disable
+    // the sizes applied before.
+    this.bind('change:histogramSizes', function (m, isSizesApplied) {
+      if (isSizesApplied) {
+        this.each(function (mdl) {
+          if (mdl !== m && mdl.get('histogramSizes')) {
+            mdl.set('histogramSizes', false);
+          }
+        });
+      }
+    }, this);
+  }
+});

--- a/src/dataviews/dataviews-factory.js
+++ b/src/dataviews/dataviews-factory.js
@@ -1,0 +1,80 @@
+var Model = require('../core/model');
+// var DataviewsCollection = require('./dataviews-collection');
+var CategoryFilter = require('../windshaft/filters/category');
+var RangeFilter = require('../windshaft/filters/range');
+var CategorDataviewModel = require('./category-dataview-model');
+var FormulaDataviewModel = require('./formula-dataview-model');
+var HistogramDataviewModel = require('./histogram-dataview-model');
+var ListDataviewModel = require('./list-dataview-model');
+
+/**
+ * Factory to create dataviews.
+ * Takes care of adding and wiring up lifeceycle to other related objects (e.g. dataviews collection, layers etc.)
+ */
+module.exports = Model.extend({
+
+  initialize: function (attrs, opts) {
+    if (!opts.dataviewsCollection) throw new Error('dataviewsCollection is required');
+    if (!opts.interactiveLayersCollection) throw new Error('interactiveLayersCollection is required');
+
+    this._dataviewsCollection = opts.dataviewsCollection;
+    this._interactiveLayersCollection = opts.interactiveLayersCollection;
+  },
+
+  createCategoryDataview: function (layerModel, attrs) {
+    var categoryFilter = new CategoryFilter({
+      // TODO Setting layer-index on filters here is not good, if order change the filters won't work on the expected layer anymore!
+      layerIndex: this._indexOf(layerModel)
+    });
+    return this._newModel(
+      new CategorDataviewModel(attrs, {
+        filter: categoryFilter,
+        layer: layerModel
+      })
+    );
+  },
+
+  createFormulaDataview: function (layerModel, attrs) {
+    return this._newModel(
+      new FormulaDataviewModel(attrs, {
+        layer: layerModel
+      })
+    );
+  },
+
+  createHistogramDataview: function (layerModel, attrs) {
+    var rangeFilter = new RangeFilter({
+      // TODO Setting layer-index on filters here is not good, if order change the filters won't work on the expected layer anymore!
+      layerIndex: this._indexOf(layerModel)
+    });
+    return this._newModel(
+      new HistogramDataviewModel(attrs, {
+        filter: rangeFilter,
+        layer: layerModel
+      })
+    );
+  },
+
+  createListDataview: function (layerModel, attrs) {
+    return this._newModel(
+      new ListDataviewModel(attrs, {
+        layer: layerModel
+      })
+    );
+  },
+
+  _newModel: function (m) {
+    this._dataviewsCollection.add(m);
+    return m;
+  },
+
+  _indexOf: function (layerModel) {
+    var index = this._interactiveLayersCollection.indexOf(layerModel);
+    if (index >= 0) {
+      return index;
+    } else {
+      throw new Error('layer must be located in layers collection to work');
+    }
+  }
+
+});

--- a/src/dataviews/formula-dataview-model.js
+++ b/src/dataviews/formula-dataview-model.js
@@ -12,7 +12,6 @@ module.exports = DataviewModelBase.extend({
     }
   ),
 
-  // TODO: The response format has probably changed
   parse: function (r) {
     return {
       data: r.result,

--- a/src/dataviews/formula-dataview-model.js
+++ b/src/dataviews/formula-dataview-model.js
@@ -1,0 +1,33 @@
+var _ = require('underscore');
+var DataviewModelBase = require('./dataview-model-base');
+
+module.exports = DataviewModelBase.extend({
+  defaults: _.extend(
+    {},
+    DataviewModelBase.prototype.defaults,
+    {
+      data: '',
+      suffix: '',
+      prefix: ''
+    }
+  ),
+
+  // TODO: The response format has probably changed
+  parse: function (r) {
+    return {
+      data: r.result,
+      nulls: r.nulls
+    };
+  },
+
+  toJSON: function (d) {
+    return {
+      type: 'formula',
+      options: {
+        column: this.get('column'),
+        operation: this.get('operation')
+      }
+    };
+  }
+
+});

--- a/src/dataviews/histogram-dataview-model.js
+++ b/src/dataviews/histogram-dataview-model.js
@@ -1,0 +1,105 @@
+var _ = require('underscore');
+var Backbone = require('backbone');
+var DataviewModelBase = require('./dataview-model-base');
+
+module.exports = DataviewModelBase.extend({
+  url: function () {
+    var params = [];
+
+    if (this.get('columnType')) {
+      params.push('column_type=' + this.get('columnType'));
+    }
+    if (_.isNumber(this.get('start'))) {
+      params.push('start=' + this.get('start'));
+    }
+    if (_.isNumber(this.get('end'))) {
+      params.push('end=' + this.get('end'));
+    }
+    if (_.isNumber(this.get('bins'))) {
+      params.push('bins=' + this.get('bins'));
+    }
+    if (_.isNumber(this.get('own_filter'))) {
+      params.push('own_filter=' + this.get('own_filter'));
+    }
+    if (this.get('boundingBox') && this.get('submitBBox')) {
+      params.push('bbox=' + this.get('boundingBox'));
+    }
+
+    var url = this.get('url');
+    if (params.length > 0) {
+      url += '?' + params.join('&');
+    }
+    return url;
+  },
+
+  initialize: function (attrs, opts) {
+    DataviewModelBase.prototype.initialize.apply(this, arguments);
+    this._data = new Backbone.Collection(this.get('data'));
+
+    // BBox should only be included until after the first fetch, since we want to get the range of the full dataset
+    this.once('change:data', function () {
+      this.set('submitBBox', true);
+    }, this);
+
+    this.layer.bind('change:meta', this._onChangeLayerMeta, this);
+  },
+
+  getData: function () {
+    return this._data.toJSON();
+  },
+
+  getSize: function () {
+    return this._data.size();
+  },
+
+  parse: function (data) {
+    var numberOfBins = data.bins_count;
+    var width = data.bin_width;
+    var start = data.bins_start;
+
+    var buckets = new Array(numberOfBins);
+
+    _.each(data.bins, function (b) {
+      buckets[b.bin] = b;
+    });
+
+    for (var i = 0; i < numberOfBins; i++) {
+      buckets[i] = _.extend({
+        bin: i,
+        start: start + (i * width),
+        end: start + ((i + 1) * width),
+        freq: 0
+      }, buckets[i]);
+    }
+
+    this._data.reset(buckets);
+
+    return {
+      data: buckets,
+      nulls: data.nulls
+    };
+  },
+
+  toJSON: function (d) {
+    return {
+      type: 'histogram',
+      options: {
+        column: this.get('column'),
+        bins: this.get('bins')
+      }
+    };
+  },
+
+  _onChangeLayerMeta: function () {
+    this.filter.set('columnType', this.layer.get('meta').column_type);
+  },
+
+  _onChangeBinds: function () {
+    DataviewModelBase.prototype._onChangeBinds.call(this);
+    this.bind('change:histogramSizes', function (mdl, isSizesApplied, d) {
+      if (isSizesApplied) {
+        this.trigger('histogramSizes', this);
+      }
+    }, this);
+  }
+});

--- a/src/dataviews/list-dataview-model.js
+++ b/src/dataviews/list-dataview-model.js
@@ -1,0 +1,39 @@
+var Backbone = require('backbone');
+var DataviewModelBase = require('./dataview-model-base');
+
+module.exports = DataviewModelBase.extend({
+  options: {
+    page: 0,
+    per_page: 100
+  },
+
+  initialize: function (attrs, opts) {
+    this._data = new Backbone.Collection(this.get('data'));
+    DataviewModelBase.prototype.initialize.call(this, attrs, opts);
+  },
+
+  getData: function () {
+    return this._data;
+  },
+
+  getSize: function () {
+    return this._data.size();
+  },
+
+  parse: function (data) {
+    var rows = data.rows;
+    this._data.reset(rows);
+    return {
+      data: rows
+    };
+  },
+
+  toJSON: function () {
+    return {
+      type: 'list',
+      options: {
+        columns: this.get('columns')
+      }
+    };
+  }
+});

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -22,17 +22,19 @@ var Overlay = require('./vis/overlay');
 var INFOWINDOW_TEMPLATE = require('./vis/infowindow-template');
 var CartoDBLayerGroupNamed = require('../geo/map/cartodb-layer-group-named');
 var CartoDBLayerGroupAnonymous = require('../geo/map/cartodb-layer-group-anonymous');
+var DataviewsFactory = require('../dataviews/dataviews-factory');
+var DataviewCollection = require('../dataviews/dataviews-collection');
 var WindshaftConfig = require('../windshaft/config');
 var WindshaftClient = require('../windshaft/client');
 var WindshaftLayerGroupConfig = require('../windshaft/layergroup-config');
 var WindshaftNamedMapConfig = require('../windshaft/namedmap-config');
+var WindshaftDashboard = require('../windshaft/dashboard');
 
 /**
  * Visualization creation
  */
 var Vis = View.extend({
   DEFAULT_MAX_ZOOM: 20,
-
   DEFAULT_MIN_ZOOM: 0,
 
   initialize: function () {
@@ -392,60 +394,108 @@ var Vis = View.extend({
       self.trigger('done', self, map.layers);
     });
 
+    this.interactiveLayers = new Backbone.Collection();
+    this.map.layers.each(function (layer) {
+      var layerType = layer.get('type');
+      var isLayerGroup = layerType === 'layergroup';
+
+      if (isLayerGroup) {
+        cartoDBLayerGroup = layer;
+      }
+
+      if (isLayerGroup || layerType === 'namedmap') {
+        layer.layers.each(function (subLayer) {
+          this.interactiveLayers.add(subLayer);
+        }, this);
+      } else {
+        if (layerType === 'torque') {
+          this.interactiveLayers.add(layer);
+        }
+      }
+    }, this);
+
+    this._dataviewsCollection = new DataviewCollection();
+    this.dataviewsFactory = new DataviewsFactory(null, {
+      dataviewsCollection: this._dataviewsCollection,
+      interactiveLayersCollection: this.interactiveLayers
+    });
+    // TODO: rethink this
+    this._dataviewsCollection.on('add reset remove', _.debounce(this._invalidateSizeOnDataviewsChanges, 10), this);
+
     // TODO: This method is creating an instance of the layer group
     // and setting the tiles and grid urls on the layerGroup model, which
     // cause the layergroup view to fetch and render the tiles. This needs
     // to happen everytime a layer that belongs to the layerGroup changes
     // (eg: when the layer is hidden or it's SQL is changed)
     if (cartoDBLayerGroup) {
-      this._createLayerGroupInstance(cartoDBLayerGroup);
+      var endpoint;
+      var mapsApiTemplate;
+      var userName;
+      var statTag;
+      var forceCors = true;
+      var configGenerator;
+
+      var datasource = data.datasource;
+      if (datasource) {
+        mapsApiTemplate = datasource.maps_api_template;
+        userName = datasource.user_name;
+        statTag = datasource.stat_tag;
+        forceCors = datasource.force_cors;
+
+        // TODO: We can use something else to differentiate types of "datasource"s
+        if (datasource.template_name) {
+          endpoint = [WindshaftConfig.MAPS_API_BASE_URL, 'named', datasource.template_name].join('/');
+          configGenerator = WindshaftNamedMapConfig;
+        } else {
+          endpoint = WindshaftConfig.MAPS_API_BASE_URL;
+          configGenerator = WindshaftLayerGroupConfig;
+        }
+      } else {
+        // No datasource, get necessary windshaft data from layerGroup directly instead
+        userName = cartoDBLayerGroup.get('userName');
+        mapsApiTemplate = cartoDBLayerGroup.get('mapsApiTemplate');
+        statTag = cartoDBLayerGroup.get('statTag');
+
+        if (cartoDBLayerGroup.get('type') === 'namedmap') {
+          var namedMapId = cartoDBLayerGroup.get('namedMapId');
+          endpoint = [
+            WindshaftConfig.MAPS_API_BASE_URL, 'named', namedMapId
+          ].join('/');
+          configGenerator = WindshaftNamedMapConfig;
+        } else if (cartoDBLayerGroup.get('type') === 'layergroup') {
+          endpoint = WindshaftConfig.MAPS_API_BASE_URL;
+          configGenerator = WindshaftLayerGroupConfig;
+        }
+      }
+
+      var windshaftClient = new WindshaftClient({
+        endpoint: endpoint,
+        urlTemplate: mapsApiTemplate,
+        userName: userName,
+        statTag: statTag,
+        forceCors: forceCors
+      });
+
+      new WindshaftDashboard({ // eslint-disable-line
+        client: windshaftClient,
+        configGenerator: configGenerator,
+        statTag: statTag,
+        // TODO: assuming here all viz.json has a layergroup and that may not be true
+        layerGroup: cartoDBLayerGroup,
+        layers: this.interactiveLayers,
+        dataviews: this._dataviewsCollection,
+        map: this.map
+      });
+      // this._createLayerGroupInstance(cartoDBLayerGroup);
     }
 
     return this;
   },
 
-  _createLayerGroupInstance: function (layerGroup) {
-    if (!layerGroup) {
-      throw new Error('Error creating instance of layergroup, layerGroup is not defined.');
+  _invalidateSizeOnDataviewsChanges: function () {
+    if (this._dataviewsCollection.size() > 0) {
+      this.mapView.invalidateSize();
     }
-    if (layerGroup.get('type') === 'namedmap') {
-      var userName = layerGroup.get('userName');
-      var mapsApiTemplate = layerGroup.get('mapsApiTemplate');
-      var namedMapId = layerGroup.get('namedMapId');
-      var statTag = layerGroup.get('statTag');
-      var endpoint = [
-        WindshaftConfig.MAPS_API_BASE_URL, 'named', namedMapId
-      ].join('/');
-      var configGenerator = WindshaftNamedMapConfig;
-    } else if (layerGroup.get('type') === 'layergroup') {
-      var userName = layerGroup.get('userName');
-      var mapsApiTemplate = layerGroup.get('mapsApiTemplate');
-      var statTag = layerGroup.get('statTag');
-      var endpoint = WindshaftConfig.MAPS_API_BASE_URL;
-      var configGenerator = WindshaftLayerGroupConfig;
-    }
-
-    var windshaftClient = new WindshaftClient({
-      endpoint: endpoint,
-      urlTemplate: mapsApiTemplate,
-      userName: userName,
-      statTag: statTag,
-      forceCors: true
-    });
-
-    var mapConfig = configGenerator.generate({
-      layers: layerGroup.layers.models
-    });
-
-    windshaftClient.instantiateMap({
-      mapDefinition: mapConfig,
-      success: function (dashboardInstance) {
-        layerGroup.set({
-          baseURL: dashboardInstance.getBaseURL(),
-          urls: dashboardInstance.getTiles('mapnik')
-        });
-      }
-    });
   },
 
   _createOverlays: function (overlays, vis_data, options) {

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -415,7 +415,7 @@ var Vis = View.extend({
     }, this);
 
     this._dataviewsCollection = new DataviewCollection();
-    this.dataviewsFactory = new DataviewsFactory(null, {
+    this.dataviews = new DataviewsFactory(null, {
       dataviewsCollection: this._dataviewsCollection,
       interactiveLayersCollection: this.interactiveLayers
     });

--- a/src/windshaft/dashboard-instance.js
+++ b/src/windshaft/dashboard-instance.js
@@ -191,5 +191,25 @@ module.exports = Model.extend({
       return -1;
     }
     return tilerLayerIndex[index];
+  },
+
+  getDataviewURL: function (options) {
+    var dataviewId = options.dataviewId;
+    var protocol = options.protocol;
+    var url;
+    var layers = this.get('metadata') && this.get('metadata').layers;
+
+    _.each(layers, function (layer) {
+      // TODO layer.widgets is the raw data returned from metadata… should be renamed once the result from Windshaft is changed
+      var dataviews = layer.widgets;
+      for (var id in dataviews) {
+        if (dataviewId === id) {
+          url = dataviews[id].url[protocol];
+          return;
+        }
+      }
+    });
+
+    return url;
   }
 });

--- a/src/windshaft/dashboard.js
+++ b/src/windshaft/dashboard.js
@@ -1,0 +1,133 @@
+var _ = require('underscore');
+var WindshaftFiltersCollection = require('./filters/collection');
+var WindshaftFiltersBoundingBoxFilter = require('./filters/bounding-box');
+var WindshaftDashboardInstance = require('./dashboard-instance');
+
+var WindshaftDashboard = function (options) {
+  var BOUNDING_BOX_FILTER_WAIT = 500;
+
+  this.layerGroup = options.layerGroup;
+  this.layers = options.layers;
+  this.dataviews = options.dataviews;
+  this.map = options.map;
+  this.client = options.client;
+  this.statTag = options.statTag;
+  this.configGenerator = options.configGenerator;
+  this.instance = new WindshaftDashboardInstance();
+
+  this.map.bind('change:center change:zoom', _.debounce(this._boundingBoxChanged, BOUNDING_BOX_FILTER_WAIT), this);
+  this.layers.bind('change', this._layerChanged, this);
+  this.dataviews.bind('change:filter', this._dataviewChanged, this);
+  this.dataviews.bind('add', _.debounce(this._dataviewChanged, 10), this);
+
+  // delay initial instance creation until sure there are not any dataviews added that will re-create the instance
+  // TODO tmp fix; this is far from ideal and prone to timing issues, can we do something more elegant?
+  var timeout = setTimeout(function () {
+    this._createInstance();
+  }.bind(this), 50);
+  this.dataviews.once('all', function () {
+    // Dataviews incoming, skip initial instance creation
+    clearTimeout(timeout);
+  }, this);
+};
+
+WindshaftDashboard.prototype._createInstance = function (options) {
+  options = options || {};
+
+  var cfg = this.configGenerator.generate({
+    layers: this.layers.models,
+    dataviews: this.dataviews
+  });
+
+  var filtersFromVisibleLayers = this.dataviews.chain()
+    .filter(function (dataview) { return dataview.layer.isVisible(); })
+    .map(function (dataview) { return dataview.filter; })
+    .compact() // not all dataviews have filters
+    .value();
+
+  var filters = new WindshaftFiltersCollection(filtersFromVisibleLayers);
+
+  this.client.instantiateMap({
+    mapDefinition: cfg,
+    filters: filters.toJSON(),
+    success: function (dashboardInstance) {
+      // Update the dashboard instance with the attributes of the new one
+      this.instance.set(dashboardInstance.toJSON());
+
+      // TODO: Set the URL of the attributes service once it's available
+      this.layerGroup && this.layerGroup.set({
+        baseURL: dashboardInstance.getBaseURL(),
+        urls: dashboardInstance.getTiles('mapnik')
+      });
+
+      // update other kind of layers too
+      this.layers.each(function (layer, layerIndex) {
+        if (layer.get('type') === 'torque') {
+          layer.set('meta', dashboardInstance.getLayerMeta(layerIndex));
+          layer.set('urls', dashboardInstance.getTiles('torque'));
+        }
+      });
+
+      this._updateDataviewURLs({
+        layerId: options.layerId
+      });
+    }.bind(this),
+    error: function (error) {
+      console.log('Error creating dashboard instance: ' + error);
+    }
+  });
+
+  return this.instance;
+};
+
+WindshaftDashboard.prototype._boundingBoxChanged = function () {
+  if (this.instance.isLoaded()) {
+    this._updateDataviewURLs();
+  }
+};
+
+WindshaftDashboard.prototype._updateDataviewURLs = function (options) {
+  options = options || {};
+  var boundingBoxFilter = new WindshaftFiltersBoundingBoxFilter(this.map.getViewBounds());
+  var boundingBox = boundingBoxFilter.toString();
+  var layerId = options.layerId;
+
+  this.dataviews.each(function (dataview) {
+    var url = this.instance.getDataviewURL({
+      dataviewId: dataview.get('id'),
+      protocol: 'http'
+    });
+
+    var layerMeta = dataview.layer.get('meta') || {};
+    var extraAttrs = {};
+    if (layerMeta.steps && layerMeta.column_type && _.isNumber(layerMeta.start) && _.isNumber(layerMeta.end)) {
+      extraAttrs = {
+        bins: layerMeta.steps,
+        columnType: layerMeta.column_type,
+        start: layerMeta.start / 1000,
+        end: layerMeta.end / 1000
+      };
+    }
+
+    dataview.set(_.extend({
+      'url': url,
+      'boundingBox': boundingBox
+    }, extraAttrs), {
+      silent: layerId && layerId !== dataview.layer.get('id')
+    });
+  }, this);
+};
+
+WindshaftDashboard.prototype._dataviewChanged = function (dataview) {
+  this._createInstance({
+    layerId: dataview.layer.get('id')
+  });
+};
+
+WindshaftDashboard.prototype._layerChanged = function (layer) {
+  this._createInstance({
+    layerId: layer.get('id')
+  });
+};
+
+module.exports = WindshaftDashboard;

--- a/src/windshaft/filters/base.js
+++ b/src/windshaft/filters/base.js
@@ -1,0 +1,11 @@
+var Model = require('../../core/model');
+
+module.exports = Model.extend({
+  isEmpty: function () {
+    throw new Error('Filters must implement the .isEmpty method');
+  },
+
+  toJSON: function () {
+    throw new Error('Filters must implement the .toJSON method');
+  }
+});

--- a/src/windshaft/filters/bounding-box.js
+++ b/src/windshaft/filters/bounding-box.js
@@ -1,0 +1,25 @@
+var Model = require('../../core/model');
+
+module.exports = Model.extend({
+  initialize: function (bounds) {
+    this.setBounds(bounds);
+  },
+
+  setBounds: function (bounds) {
+    this.set({
+      west: bounds[0][1],
+      south: bounds[0][0],
+      east: bounds[1][1],
+      north: bounds[1][0]
+    });
+  },
+
+  toString: function () {
+    return [
+      this.get('west'),
+      this.get('south'),
+      this.get('east'),
+      this.get('north')
+    ].join(',');
+  }
+});

--- a/src/windshaft/filters/category.js
+++ b/src/windshaft/filters/category.js
@@ -1,0 +1,141 @@
+var _ = require('underscore');
+var Backbone = require('backbone');
+var WindshaftFilterBase = require('./base');
+
+/**
+ *  Filter used by the category dataview
+ *
+ */
+module.exports = WindshaftFilterBase.extend({
+  defaults: {
+    rejectAll: false
+  },
+
+  initialize: function () {
+    this.rejectedCategories = new Backbone.Collection();
+    this.acceptedCategories = new Backbone.Collection();
+    this._initBinds();
+  },
+
+  _initBinds: function () {
+    this.rejectedCategories.bind('add remove', function () {
+      this.set('rejectAll', false);
+    }, this);
+    this.acceptedCategories.bind('add remove', function () {
+      this.set('rejectAll', false);
+    }, this);
+  },
+
+  isEmpty: function () {
+    return this.rejectedCategories.size() === 0 && this.acceptedCategories.size() === 0 && !this.get('rejectAll');
+  },
+
+  accept: function (values, applyFilter) {
+    values = !_.isArray(values) ? [values] : values;
+
+    _.each(values, function (value) {
+      var d = { name: value };
+      var rejectedMdls = this.rejectedCategories.where(d);
+      var acceptedMdls = this.acceptedCategories.where(d);
+      if (rejectedMdls.length > 0) {
+        this.rejectedCategories.remove(rejectedMdls);
+      }
+      if (!acceptedMdls.length) {
+        this.acceptedCategories.add(d);
+      }
+    }, this);
+
+    if (applyFilter !== false) {
+      this.applyFilter();
+    }
+  },
+
+  acceptAll: function () {
+    this.set('rejectAll', false);
+    this.cleanFilter();
+  },
+
+  isAccepted: function (name) {
+    return this.acceptedCategories.where({ name: name }).length > 0;
+  },
+
+  getAccepted: function () {
+    return this.acceptedCategories;
+  },
+
+  reject: function (values, applyFilter) {
+    values = !_.isArray(values) ? [values] : values;
+
+    _.each(values, function (value) {
+      var d = { name: value };
+      var acceptedMdls = this.acceptedCategories.where(d);
+      var rejectedMdls = this.rejectedCategories.where(d);
+      if (acceptedMdls.length > 0) {
+        this.acceptedCategories.remove(acceptedMdls);
+      } else {
+        if (!rejectedMdls.length) {
+          this.rejectedCategories.add(d);
+        }
+      }
+    }, this);
+
+    if (applyFilter !== false) {
+      this.applyFilter();
+    }
+  },
+
+  isRejected: function (name) {
+    var acceptCount = this.acceptedCategories.size();
+    if (this.rejectedCategories.where({ name: name }).length > 0) {
+      return true;
+    } else if (acceptCount > 0 && this.acceptedCategories.where({ name: name }).length === 0) {
+      return true;
+    } else if (this.get('rejectAll')) {
+      return true;
+    } else {
+      return false;
+    }
+  },
+
+  getRejected: function () {
+    return this.rejectedCategories;
+  },
+
+  rejectAll: function () {
+    this.set('rejectAll', true);
+    this.cleanFilter();
+  },
+
+  cleanFilter: function (triggerChange) {
+    this.acceptedCategories.reset();
+    this.rejectedCategories.reset();
+    if (triggerChange !== false) {
+      this.applyFilter();
+    }
+  },
+
+  applyFilter: function () {
+    this.trigger('change', this);
+  },
+
+  toJSON: function () {
+    var filter = {};
+    var rejectCount = this.rejectedCategories.size();
+    var acceptCount = this.acceptedCategories.size();
+    var acceptedCats = { accept: _.pluck(this.acceptedCategories.toJSON(), 'name') };
+    var rejectedCats = { reject: _.pluck(this.rejectedCategories.toJSON(), 'name') };
+
+    if (this.get('rejectAll')) {
+      filter = { accept: [] };
+    } else if (acceptCount > 0) {
+      filter = acceptedCats;
+    } else if (rejectCount > 0 && acceptCount === 0) {
+      filter = rejectedCats;
+    }
+
+    var json = {};
+    json[this.get('dataviewId')] = filter;
+
+    return json;
+  }
+});

--- a/src/windshaft/filters/collection.js
+++ b/src/windshaft/filters/collection.js
@@ -1,0 +1,38 @@
+var _ = require('underscore');
+var Backbone = require('backbone');
+
+module.exports = Backbone.Collection.extend({
+  toJSON: function () {
+    var json = {};
+    var activeFilters = this.getActiveFilters();
+    if (activeFilters.length) {
+      json.layers = [];
+      _.each(activeFilters, function (filter) {
+        if (!filter.isEmpty()) {
+          var index = filter.get('layerIndex');
+          if (index >= 0) {
+            if (json.layers[index]) {
+              _.extend(json.layers[index], filter.toJSON());
+            } else {
+              json.layers[index] = filter.toJSON();
+            }
+          } else {
+            throw new Error('layerIndex missing for filter ' + JSON.stringify(filter.toJSON()));
+          }
+        }
+      });
+      // fill the holes
+      for (var i = 0; i < json.layers.length; ++i) {
+        json.layers[i] = json.layers[i] || {};
+      }
+    }
+
+    return json;
+  },
+
+  getActiveFilters: function () {
+    return this.filter(function (filter) {
+      return !filter.isEmpty();
+    });
+  }
+});

--- a/src/windshaft/filters/range.js
+++ b/src/windshaft/filters/range.js
@@ -1,0 +1,30 @@
+var _ = require('underscore');
+var WindshaftFilterBase = require('./base');
+
+module.exports = WindshaftFilterBase.extend({
+  isEmpty: function () {
+    return _.isUndefined(this.get('min')) && _.isUndefined(this.get('max'));
+  },
+
+  setRange: function (min, max) {
+    this.set({
+      min: min,
+      max: max
+    });
+  },
+
+  unsetRange: function () {
+    this.setRange(undefined, undefined);
+  },
+
+  toJSON: function () {
+    var json = {};
+    json[this.get('dataviewId')] = {
+      min: this.get('min'),
+      max: this.get('max'),
+      column_type: this.get('columnType')
+    };
+
+    return json;
+  }
+});

--- a/src/windshaft/layergroup-config.js
+++ b/src/windshaft/layergroup-config.js
@@ -3,6 +3,7 @@ var LayerGroupConfig = {};
 
 LayerGroupConfig.generate = function (options) {
   var layers = options.layers;
+  var dataviews = options.dataviews;
   var config = { layers: [] };
   _.each(layers, function (layer) {
     if (layer.isVisible()) {
@@ -12,15 +13,24 @@ LayerGroupConfig.generate = function (options) {
           sql: layer.get('sql'),
           cartocss: layer.get('cartocss'),
           cartocss_version: layer.get('cartocss_version'),
-          interactivity: layer.getInteractiveColumnNames()
+          interactivity: layer.getInteractiveColumnNames(),
+          // TODO widgets should be renamed to dataviews, requires Windshaft to be changed first though
+          widgets: dataviews.reduce(function (memo, m) {
+            if (layer.get('id') === m.layer.get('id')) {
+              memo[m.get('id')] = m.toJSON();
+            }
+            return memo;
+          }, {})
         }
       };
+
       if (layer.getInfowindowFieldNames().length) {
         layerConfig.options.attributes = {
           id: 'cartodb_id',
           columns: layer.getInfowindowFieldNames()
         };
       }
+
       config.layers.push(layerConfig);
     }
   });

--- a/test/spec/dataviews/category-dataview-model.spec.js
+++ b/test/spec/dataviews/category-dataview-model.spec.js
@@ -1,0 +1,282 @@
+var _ = require('underscore');
+var CategoryDataviewModel = require('../../../src/dataviews/category-dataview-model.js');
+var WindshaftFiltersCategory = require('../../../src/windshaft/filters/category');
+
+describe('dataviews/category-dataview-model', function () {
+  beforeEach(function () {
+    this.model = new CategoryDataviewModel(null, {
+      filter: new WindshaftFiltersCategory()
+    });
+  });
+
+  it('should define several internal models/collections', function () {
+    expect(this.model._data).toBeDefined();
+    expect(this.model.search).toBeDefined();
+    expect(this.model.filter).toBeDefined();
+  });
+
+  describe('binds', function () {
+    beforeEach(function () {
+      this.model.set({
+        url: 'http://heytest.io'
+      });
+      // Simulating first interaction with client.js
+      this.model._onChangeBinds();
+    });
+
+    describe('url', function () {
+      beforeEach(function () {
+        spyOn(this.model, 'fetch');
+        spyOn(this.model.search, 'fetch');
+        spyOn(this.model.rangeModel, 'fetch');
+      });
+
+      it('should set search url when it changes', function () {
+        expect(this.model.search.get('url')).toBe('http://heytest.io');
+        expect(this.model.search.url()).toBe('http://heytest.io/search?q=');
+      });
+
+      it('should set rangeModel url when it changes', function () {
+        expect(this.model.rangeModel.get('url')).toBe('http://heytest.io');
+        expect(this.model.rangeModel.url()).toBe('http://heytest.io');
+      });
+    });
+
+    describe('boundingBox', function () {
+      it('should set search boundingBox when it changes', function () {
+        expect(this.model.search.get('boundingBox')).toBeUndefined();
+        this.model.set('boundingBox', 'hey');
+        expect(this.model.search.get('boundingBox')).toBe('hey');
+      });
+
+      it('should fetch itself if bounding box changes only when search is not applied', function () {
+        spyOn(this.model, '_fetch');
+        spyOn(this.model, 'isSearchApplied').and.returnValue(true);
+        this.model.set('boundingBox', 'comeon');
+        expect(this.model._fetch).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('search events dispatcher', function () {
+      it('should trigger search related events', function () {
+        var eventNames = ['loading', 'sync', 'error'];
+        _.each(eventNames, function (eventName) {
+          _.bind(eventDispatcher, this)(this.model.search, eventName);
+        }, this);
+      });
+
+      it('should trigger a change:searchData when search model is fetched', function () {
+        _.bind(eventDispatcher, this)(this.model.search, 'change:data', 'change:searchData');
+      });
+    });
+
+    describe('locked collection', function () {
+      it('should trigger any change done over locked collection', function () {
+        var eventNames = ['change', 'add', 'remove'];
+        _.each(eventNames, function (eventName) {
+          _.bind(eventDispatcher, this)(this.model.locked, eventName, 'change:lockCollection');
+        }, this);
+      });
+    });
+
+    describe('range model', function () {
+      it('should set totalCount when rangeModel has changed', function () {
+        expect(this.model.get('totalCount')).toBeUndefined();
+        this.model.rangeModel.set({ totalCount: 1000 });
+        expect(this.model.get('totalCount')).toBe(1000);
+      });
+
+      it('should set categoriesCount when rangeModel has changed', function () {
+        expect(this.model.get('categoriesCount')).toBeUndefined();
+        this.model.rangeModel.set({ categoriesCount: 123 });
+        expect(this.model.get('categoriesCount')).toBe(123);
+      });
+    });
+  });
+
+  describe('locked collection helpers', function () {
+    describe('canApplyLocked', function () {
+      beforeEach(function () {
+        this.model.filter.accept(['Hey', 'Neno']);
+      });
+
+      it('could apply locked when accepted filter collection size is different than locked collection', function () {
+        this.model.locked.addItems({ name: 'Neno' });
+        expect(this.model.canApplyLocked()).toBeTruthy();
+      });
+
+      it('could apply locked when accepted filter has different items then locked', function () {
+        this.model.locked.addItems([{ name: 'Neno' }, { name: 'Comeon' }]);
+        expect(this.model.canApplyLocked()).toBeTruthy();
+        this.model.locked.reset();
+        expect(this.model.canApplyLocked()).toBeTruthy();
+      });
+
+      it('could not apply locked when accepted filter has same items than locked collection', function () {
+        this.model.locked.addItems([{ name: 'Neno' }, { name: 'Hey' }]);
+        expect(this.model.canApplyLocked()).toBeFalsy();
+      });
+    });
+
+    describe('applyLocked', function () {
+      beforeEach(function () {
+        this.model.locked.reset([{ name: 'Hey', value: 1 }]);
+        spyOn(this.model, 'unlockCategories');
+        spyOn(this.model.filter, 'applyFilter');
+        spyOn(this.model, 'cleanSearch');
+      });
+
+      it('should apply locked state properly', function () {
+        this.model.applyLocked();
+        expect(this.model.unlockCategories).not.toHaveBeenCalled();
+        expect(this.model.cleanSearch).toHaveBeenCalled();
+        expect(this.model.getAcceptedCount()).toBe(1);
+        expect(this.model.filter.applyFilter).toHaveBeenCalled();
+      });
+
+      it('should remove previous accept filters', function () {
+        this.model.acceptFilters('Comeon');
+        this.model.applyLocked();
+        expect(this.model.filter.isAccepted('Comeon')).toBeFalsy();
+      });
+
+      it('should "unlock" categories if locked collection is empty', function () {
+        this.model.locked.reset();
+        this.model.applyLocked();
+        expect(this.model.unlockCategories).toHaveBeenCalled();
+        expect(this.model.cleanSearch).not.toHaveBeenCalled();
+        expect(this.model.filter.applyFilter).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('locked/unlocked', function () {
+      beforeEach(function () {
+        spyOn(this.model, '_fetch');
+        spyOn(this.model, 'acceptAll');
+      });
+
+      it('should lock dataview', function () {
+        this.model.lockCategories();
+        expect(this.model.get('locked')).toBeTruthy();
+        expect(this.model._fetch).toHaveBeenCalled();
+      });
+
+      it('should unlock dataview', function () {
+        this.model.unlockCategories();
+        expect(this.model.get('locked')).toBeFalsy();
+        expect(this.model._fetch).not.toHaveBeenCalled();
+        expect(this.model.acceptAll).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('search model helpers', function () {
+    it('should clean search properly', function () {
+      spyOn(this.model.locked, 'resetItems');
+      spyOn(this.model.search, 'resetData');
+      this.model.cleanSearch();
+      expect(this.model.locked.resetItems).toHaveBeenCalled();
+      expect(this.model.search.resetData).toHaveBeenCalled();
+    });
+
+    describe('setupSearch', function () {
+      beforeEach(function () {
+        spyOn(this.model.locked, 'addItems').and.callThrough();
+        spyOn(this.model.search, 'setData').and.callThrough();
+      });
+
+      it('should not setup search if search is already applied', function () {
+        spyOn(this.model, 'isSearchApplied').and.returnValue(true);
+        this.model.setupSearch();
+        expect(this.model.locked.addItems).not.toHaveBeenCalled();
+        expect(this.model.search.setData).not.toHaveBeenCalled();
+      });
+
+      it('should setup search if it is gonna be enabled', function () {
+        spyOn(this.model, 'isSearchApplied').and.returnValue(false);
+        _parseData(this.model, _generateData(3));
+        this.model.acceptFilters(['4', '5', '6']);
+        this.model.setupSearch();
+        expect(this.model.locked.addItems).toHaveBeenCalled();
+        expect(this.model.search.setData).toHaveBeenCalled();
+        expect(this.model.getLockedSize()).toBe(3);
+        expect(this.model.getSearchCount()).toBe(3);
+      });
+    });
+  });
+
+  it('should refresh its own data only if the search is not applied', function () {
+    spyOn(this.model, '_fetch');
+    spyOn(this.model.search, 'fetch');
+    this.model.refresh();
+    expect(this.model._fetch.calls.count()).toEqual(1);
+    expect(this.model._fetch).toHaveBeenCalled();
+    expect(this.model.search.fetch).not.toHaveBeenCalled();
+    spyOn(this.model, 'isSearchApplied').and.returnValue(true);
+    this.model.refresh();
+    expect(this.model.search.fetch).toHaveBeenCalled();
+    expect(this.model._fetch.calls.count()).toEqual(1);
+  });
+
+  describe('parseData', function () {
+    it('should provide data as an object', function () {
+      _parseData(this.model, _generateData(10));
+      var data = this.model.get('data');
+      expect(data).toBeDefined();
+      expect(data.length).toBe(10);
+    });
+
+    it('should complete data with accepted items (if they are not present already) when dataview is locked', function () {
+      spyOn(this.model, 'isLocked').and.returnValue(true);
+      this.model.acceptFilters(['9', '10', '11']);
+      _parseData(this.model, _generateData(8));
+      var data = this.model.get('data');
+      expect(data.length).toBe(11);
+
+      this.model.acceptFilters(['2']);
+      // The '2' should not be repeated in the data array
+      _parseData(this.model, _generateData(8));
+      data = this.model.get('data');
+      expect(data.length).toBe(11);
+    });
+  });
+
+  describe('.parse', function () {
+    it('should change internal data collection when parse is called', function () {
+      var resetSpy = jasmine.createSpy('reset');
+      this.model._data.bind('reset', resetSpy);
+
+      _parseData(this.model, _generateData(2));
+      expect(resetSpy).toHaveBeenCalled();
+    });
+  });
+
+  it('should have defined "_onFilterChanged" method', function () {
+    expect(this.model._onFilterChanged).toBeDefined();
+  });
+});
+
+function eventDispatcher (originModel, eventName, triggerName) {
+  var spyObj = jasmine.createSpy(eventName);
+  this.model.bind(triggerName || eventName, spyObj);
+  originModel.trigger(eventName);
+  expect(spyObj).toHaveBeenCalled();
+}
+
+function _generateData (n) {
+  return _.times(n, function (i) {
+    return {
+      category: i,
+      value: 2
+    };
+  });
+}
+
+function _parseData (model, categories) {
+  model.sync = function (method, model, options) {
+    options.success({
+      'categories': categories
+    });
+  };
+  model.fetch();
+}

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -1,0 +1,84 @@
+var DataviewModelBase = require('../../../src/dataviews/dataview-model-base');
+
+describe('dataviews/dataview-model-base', function () {
+  beforeEach(function () {
+    this.model = new DataviewModelBase();
+  });
+
+  it('should listen to a dashboardBaseURL attribute change at the beginning', function () {
+    spyOn(this.model, 'once').and.callThrough();
+    this.model._initBinds(); // _initBinds is called when object is created, so
+    // it is necessary to called again to have the spy
+    // correctly set.
+    expect(this.model.once.calls.argsFor(0)[0]).toEqual('change:url');
+  });
+
+  it('should add binds for url and bbox changes after first load', function () {
+    spyOn(this.model, 'bind').and.callThrough();
+    this.model.fetch = function (opts) {
+      opts.success();
+    };
+    this.model.set('url', 'newurl');
+    expect(this.model.bind.calls.argsFor(0)[0]).toEqual('change:url');
+    expect(this.model.bind.calls.argsFor(1)[0]).toEqual('change:boundingBox');
+  });
+
+  describe('after first load', function () {
+    beforeEach(function () {
+      this.model.fetch = function (opts) {
+        opts.success();
+      };
+      this.model.set('url', 'newurl');
+    });
+
+    it('should not fetch new data when url changes and sync is not enabled', function () {
+      this.model.set('sync', false);
+      spyOn(this.model, 'fetch');
+      this.model.trigger('change:url', this.model);
+      expect(this.model.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should not fetch new data when url changes and dataview is disabled', function () {
+      this.model.set('disabled', true);
+      spyOn(this.model, 'fetch');
+      this.model.trigger('change:url', this.model);
+      expect(this.model.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should not fetch new data when bbox changes and bbox is not enabled', function () {
+      this.model.set('bbox', false);
+      spyOn(this.model, 'fetch');
+      this.model.trigger('change:boundingBox', this.model);
+      expect(this.model.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should not fetch new data when bbox changes and dataview is disabled', function () {
+      this.model.set('disabled', true);
+      spyOn(this.model, 'fetch');
+      this.model.trigger('change:boundingBox', this.model);
+      expect(this.model.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when disabled', function () {
+    it('should fetch again when disabled is disabled and url or boundingBox has changed', function () {
+      spyOn(this.model, '_fetch');
+      this.model.set('disabled', true);
+      this.model.set('url', 'hello');
+      this.model.set('disabled', false);
+      expect(this.model._fetch).toHaveBeenCalled();
+    });
+
+    it('should not fetch when disabled is enabled', function () {
+      spyOn(this.model, '_fetch');
+      this.model.set('disabled', true);
+      expect(this.model._fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should trigger loading event when fetch is launched', function () {
+    spyOn(this.model, 'trigger');
+    this.model.fetch();
+    expect(this.model.trigger).toHaveBeenCalledWith('loading', this.model);
+  });
+});

--- a/test/spec/dataviews/dataviews-factory.spec.js
+++ b/test/spec/dataviews/dataviews-factory.spec.js
@@ -1,0 +1,21 @@
+var Backbone = require('backbone');
+var DataviewsFactory = require('../../../src/dataviews/dataviews-factory');
+
+describe('dataviews/dataviews-factory', function () {
+  beforeEach(function () {
+    this.dataviewsCollection = new Backbone.Collection();
+    this.interactiveLayersCollection = new Backbone.Collection();
+    this.factory = new DataviewsFactory(null, {
+      dataviewsCollection: this.dataviewsCollection,
+      interactiveLayersCollection: this.interactiveLayersCollection
+    });
+  });
+
+  it('should create the factory as expected', function () {
+    expect(this.factory).toBeDefined();
+    expect(this.factory.createCategoryDataview).toEqual(jasmine.any(Function));
+    expect(this.factory.createFormulaDataview).toEqual(jasmine.any(Function));
+    expect(this.factory.createHistogramDataview).toEqual(jasmine.any(Function));
+    expect(this.factory.createListDataview).toEqual(jasmine.any(Function));
+  });
+});

--- a/test/spec/dataviews/histogram-dataview-model.spec.js
+++ b/test/spec/dataviews/histogram-dataview-model.spec.js
@@ -1,0 +1,59 @@
+var Model = require('../../../src/core/model');
+var HistogramDataviewModel = require('../../../src/dataviews/histogram-dataview-model');
+
+describe('dataviews/histogram-dataview-model', function () {
+  beforeEach(function () {
+    this.filter = new Model();
+    this.layer = new Model();
+    this.model = new HistogramDataviewModel({}, {
+      filter: this.filter,
+      layer: this.layer
+    });
+  });
+
+  it('should submit the bbox if enabled', function () {
+    this.model.set({ boundingBox: 1234 });
+    expect(this.model.url()).toBe('');
+
+    this.model.set({ submitBBox: true });
+    expect(this.model.url()).toBe('?bbox=1234');
+  });
+
+  it('should parse the bins', function () {
+    var data = {
+      bin_width: 14490.25,
+      bins: [
+        { bin: 0, freq: 2, max: 70151, min: 55611 },
+        { bin: 1, freq: 2, max: 79017, min: 78448 },
+        { bin: 3, freq: 1, max: 113572, min: 113572 }
+      ],
+      bins_count: 4,
+      bins_start: 55611,
+      nulls: 0,
+      type: 'histogram'
+    };
+
+    this.model.parse(data);
+
+    var parsedData = this.model.getData();
+
+    expect(data.nulls).toBe(0);
+    expect(parsedData.length).toBe(4);
+    expect(JSON.stringify(parsedData)).toBe('[{"bin":0,"start":55611,"end":70101.25,"freq":2,"max":70151,"min":55611},{"bin":1,"start":70101.25,"end":84591.5,"freq":2,"max":79017,"min":78448},{"bin":2,"start":84591.5,"end":99081.75,"freq":0},{"bin":3,"start":99081.75,"end":113572,"freq":1,"max":113572,"min":113572}]');
+  });
+
+  describe('when layer changes meta', function () {
+    beforeEach(function () {
+      expect(this.model.filter.get('columnType')).not.toEqual('date');
+      this.model.layer.set({
+        meta: {
+          column_type: 'date'
+        }
+      });
+    });
+
+    it('should change the filter columnType', function () {
+      expect(this.model.filter.get('columnType')).toEqual('date');
+    });
+  });
+});

--- a/test/spec/windshaft/client.spec.js
+++ b/test/spec/windshaft/client.spec.js
@@ -1,0 +1,177 @@
+var $ = require('jquery');
+var util = require('cdb.core.util');
+var WindshaftClient = require('../../../src/windshaft/client');
+
+describe('windshaft/client', function () {
+  it('should throw an error if required options are not passed to the constructor', function () {
+    expect(function () {
+      new WindshaftClient({}, ['urlTemplate', 'userName', 'endpoint', 'statTag']); // eslint-disable-line
+    }).toThrowError('WindshaftClient could not be initialized. The following options are missing: urlTemplate, userName, endpoint, statTag');
+  });
+
+  describe('#instantiateMap', function () {
+    beforeEach(function () {
+      spyOn($, 'ajax').and.callFake(function (params) {
+        this.ajaxParams = params;
+      }.bind(this));
+
+      spyOn(util, 'uniqueCallbackName').and.callFake(function () {
+        return 'callbackName';
+      });
+
+      this.client = new WindshaftClient({
+        urlTemplate: 'https://{user}.example.com:443',
+        userName: 'rambo',
+        statTag: 'stat_tag',
+        endpoint: 'api/v1'
+      });
+    });
+
+    it('should trigger a GET request to instantiate a map', function () {
+      this.client.instantiateMap({
+        mapDefinition: { some: 'json that must be encoded' },
+        filters: { some: 'filters that will be applied' }
+      });
+
+      var url = this.ajaxParams.url.split('?')[0];
+      var params = this.ajaxParams.url.split('?')[1].split('&');
+
+      expect(url).toEqual('https://rambo.example.com:443/api/v1');
+      expect(params[0]).toEqual('stat_tag=stat_tag');
+      expect(params[1]).toEqual('filters=%7B%22some%22%3A%22filters%20that%20will%20be%20applied%22%7D');
+      expect(params[2]).toEqual('config=%7B%22some%22%3A%22json%20that%20must%20be%20encoded%22%7D');
+      expect(this.ajaxParams.method).toEqual('GET');
+      expect(this.ajaxParams.dataType).toEqual('jsonp');
+      expect(this.ajaxParams.jsonpCallback).toMatch('_cdbc_callbackName');
+      expect(this.ajaxParams.cache).toEqual(true);
+    });
+
+    it('should invoke the success callback with an instance of the dasboard', function () {
+      var successCallback = jasmine.createSpy('successCallback');
+
+      this.client.instantiateMap({
+        mapDefinition: 'mapDefinition',
+        filters: {},
+        success: successCallback
+      });
+
+      this.ajaxParams.success({});
+
+      expect(successCallback).toHaveBeenCalled();
+      var dasboardInstance = successCallback.calls.mostRecent().args[0];
+
+      expect(dasboardInstance).toBeDefined();
+      expect(dasboardInstance.getBaseURL()).toEqual('https://rambo.example.com:443/api/v1/map/');
+    });
+
+    it('should invoke the error callback if Windshaft returns some errors', function () {
+      var errorCallback = jasmine.createSpy('errorCallback');
+
+      this.client.instantiateMap({
+        mapDefinition: 'mapDefinition',
+        filters: {},
+        error: errorCallback
+      });
+
+      this.ajaxParams.success({
+        errors: [ 'something went wrong!' ]
+      });
+
+      expect(errorCallback).toHaveBeenCalledWith('something went wrong!');
+    });
+
+    it('should invoke the error callback if ajax request goes wrong', function () {
+      var errorCallback = jasmine.createSpy('errorCallback');
+
+      this.client.instantiateMap({
+        mapDefinition: 'mapDefinition',
+        filters: {},
+        error: errorCallback
+      });
+
+      this.ajaxParams.error({ responseText: 'something went wrong!' });
+
+      expect(errorCallback).toHaveBeenCalledWith('Unknown error');
+    });
+
+    it('should use POST if forceCors is true', function () {
+      spyOn(util, 'isCORSSupported').and.returnValue(true);
+
+      this.client = new WindshaftClient({
+        urlTemplate: 'https://{user}.example.com:443',
+        userName: 'rambo',
+        statTag: 'stat_tag',
+        endpoint: 'api/v1',
+        forceCors: true
+      });
+
+      this.client.instantiateMap({
+        mapDefinition: { some: 'json that must be encoded' },
+        filters: { some: 'filters that will be applied' }
+      });
+
+      var url = this.ajaxParams.url.split('?')[0];
+      var params = this.ajaxParams.url.split('?')[1].split('&');
+
+      expect(url).toEqual('https://rambo.example.com:443/api/v1');
+      expect(params[0]).toEqual('stat_tag=stat_tag');
+      expect(params[1]).toEqual('filters=%7B%22some%22%3A%22filters%20that%20will%20be%20applied%22%7D');
+      expect(this.ajaxParams.crossOrigin).toEqual(true);
+      expect(this.ajaxParams.method).toEqual('POST');
+      expect(this.ajaxParams.dataType).toEqual('json');
+      expect(this.ajaxParams.contentType).toEqual('application/json');
+    });
+
+    it('should use POST if payload is too big to be sent as a URL param', function () {
+      spyOn(util, 'isCORSSupported').and.returnValue(true);
+
+      this.client = new WindshaftClient({
+        urlTemplate: 'https://{user}.example.com:443',
+        userName: 'rambo',
+        statTag: 'stat_tag',
+        endpoint: 'api/v1',
+        forceCors: false
+      });
+
+      var mapDefinition = { key: '' };
+      for (var i = 0; i < 3000; i++) {
+        mapDefinition.key += 'x';
+      }
+
+      this.client.instantiateMap({
+        mapDefinition: mapDefinition,
+        filters: { some: 'filters that will be applied' }
+      });
+
+      var url = this.ajaxParams.url.split('?')[0];
+      var params = this.ajaxParams.url.split('?')[1].split('&');
+
+      expect(url).toEqual('https://rambo.example.com:443/api/v1');
+      expect(params[0]).toEqual('stat_tag=stat_tag');
+      expect(params[1]).toEqual('filters=%7B%22some%22%3A%22filters%20that%20will%20be%20applied%22%7D');
+      expect(this.ajaxParams.crossOrigin).toEqual(true);
+      expect(this.ajaxParams.method).toEqual('POST');
+      expect(this.ajaxParams.dataType).toEqual('json');
+      expect(this.ajaxParams.contentType).toEqual('application/json');
+    });
+
+    it('should NOT use POST if forceCors is true but cors is not supported', function () {
+      spyOn(util, 'isCORSSupported').and.returnValue(false);
+
+      this.client = new WindshaftClient({
+        urlTemplate: 'https://{user}.example.com:443',
+        userName: 'rambo',
+        statTag: 'stat_tag',
+        endpoint: 'api/v1',
+        forceCors: true
+      });
+
+      this.client.instantiateMap({
+        mapDefinition: { some: 'json that must be encoded' },
+        filters: { some: 'filters that will be applied' }
+      });
+
+      expect(this.ajaxParams.method).toEqual('GET');
+    });
+  });
+});

--- a/test/spec/windshaft/dashboard-instance.spec.js
+++ b/test/spec/windshaft/dashboard-instance.spec.js
@@ -1,0 +1,381 @@
+var WindshaftDashboardInstance = require('../../../src/windshaft/dashboard-instance');
+
+describe('windshaft/dashboard-instance', function () {
+  describe('#getBaseURL', function () {
+    it("should return Windshaft's url if no CDN info is present", function () {
+      var dashboard = new WindshaftDashboardInstance({
+        layergroupid: '0123456789',
+        urlTemplate: 'https://{user}.example.com:443',
+        userName: 'rambo'
+      });
+      expect(dashboard.getBaseURL()).toEqual('https://rambo.example.com:443/api/v1/map/0123456789');
+    });
+
+    it('should return the CDN URL for http when CDN info is present', function () {
+      var dashboard = new WindshaftDashboardInstance({
+        urlTemplate: 'http://{user}.example.com:80',
+        userName: 'rambo',
+        cdn_url: {
+          http: 'cdn.http.example.com',
+          https: 'cdn.https.example.com'
+        }
+      });
+      expect(dashboard.getBaseURL()).toEqual('http://cdn.http.example.com/rambo/api/v1/map/');
+    });
+
+    it('should return the CDN URL for https when CDN info is present', function () {
+      var dashboard = new WindshaftDashboardInstance({
+        urlTemplate: 'https://{user}.example.com:80',
+        userName: 'rambo',
+        cdn_url: {
+          http: 'cdn.http.example.com',
+          https: 'cdn.https.example.com'
+        }
+      });
+      expect(dashboard.getBaseURL()).toEqual('https://cdn.https.example.com/rambo/api/v1/map/');
+    });
+  });
+
+  describe('#getTiles', function () {
+    it('should return the URLs for tiles and grids by default or when requesting "mapnik" layers', function () {
+      var dashboard = new WindshaftDashboardInstance({
+        'layergroupid': '0123456789',
+        'urlTemplate': 'https://{user}.example.com:443',
+        'userName': 'rambo',
+        'metadata': {
+          'layers': [
+            {
+              'type': 'mapnik',
+              'meta': {}
+            },
+            {
+              'type': 'torque',
+              'meta': {}
+            }
+          ]
+        }
+      });
+
+      // No type specified
+      expect(dashboard.getTiles()).toEqual({
+        tiles: [ 'https://rambo.example.com:443/api/v1/map/0123456789/0/{z}/{x}/{y}.png' ],
+        grids: [
+          [ 'https://rambo.example.com:443/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json' ]
+        ]
+      });
+
+      // Request tiles for "mapnik" layers specifically
+      expect(dashboard.getTiles('mapnik')).toEqual({
+        tiles: [ 'https://rambo.example.com:443/api/v1/map/0123456789/0/{z}/{x}/{y}.png' ],
+        grids: [
+          [ 'https://rambo.example.com:443/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json' ]
+        ]
+      });
+    });
+
+    it('should return the URLs for tiles and grids for "torque" layers', function () {
+      var dashboard = new WindshaftDashboardInstance({
+        'layergroupid': '0123456789',
+        'urlTemplate': 'https://{user}.example.com:443',
+        'userName': 'rambo',
+        'metadata': {
+          'layers': [
+            {
+              'type': 'mapnik',
+              'meta': {}
+            },
+            {
+              'type': 'torque',
+              'meta': {}
+            }
+          ]
+        }
+      });
+
+      // Request tiles for "torque" layers specifically
+      expect(dashboard.getTiles('torque')).toEqual({
+        tiles: [ 'https://rambo.example.com:443/api/v1/map/0123456789/1/{z}/{x}/{y}.json.torque' ],
+        grids: []
+      });
+    });
+
+    it('should handle layer indexes correctly when a layer type is specified', function () {
+      var dashboard = new WindshaftDashboardInstance({
+        'layergroupid': '0123456789',
+        'urlTemplate': 'https://{user}.example.com:443',
+        'userName': 'rambo',
+        'metadata': {
+          'layers': [
+            {
+              'type': 'mapnik',
+              'meta': {}
+            },
+            {
+              'type': 'torque',
+              'meta': {}
+            },
+            {
+              'type': 'mapnik',
+              'meta': {}
+            },
+            {
+              'type': 'torque',
+              'meta': {}
+            }
+          ]
+        }
+      });
+
+      // Request tiles for "mapnik" layers specifically (#0 and #2)
+      expect(dashboard.getTiles('mapnik')).toEqual({
+        tiles: [ 'https://rambo.example.com:443/api/v1/map/0123456789/0,2/{z}/{x}/{y}.png' ],
+        grids: [
+          [ 'https://rambo.example.com:443/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json' ],
+          [ 'https://rambo.example.com:443/api/v1/map/0123456789/2/{z}/{x}/{y}.grid.json' ]
+        ]
+      });
+
+      // Request tiles for "torque" layers specifically (#1 and #3)
+      expect(dashboard.getTiles('torque')).toEqual({
+        tiles: [ 'https://rambo.example.com:443/api/v1/map/0123456789/1,3/{z}/{x}/{y}.json.torque' ],
+        grids: []
+      });
+    });
+
+    describe('when NOT using a CDN', function () {
+      it('should return the URLS for tiles and grids for https', function () {
+        var dashboard = new WindshaftDashboardInstance({
+          'layergroupid': '0123456789',
+          'urlTemplate': 'https://{user}.example.com:443',
+          'userName': 'rambo',
+          'metadata': {
+            'layers': [
+              {
+                'type': 'mapnik',
+                'meta': {}
+              },
+              {
+                'type': 'mapnik',
+                'meta': {}
+              }
+            ]
+          }
+        });
+        expect(dashboard.getTiles()).toEqual({
+          tiles: [ 'https://rambo.example.com:443/api/v1/map/0123456789/0,1/{z}/{x}/{y}.png' ],
+          grids: [
+            [ 'https://rambo.example.com:443/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json' ],
+            [ 'https://rambo.example.com:443/api/v1/map/0123456789/1/{z}/{x}/{y}.grid.json' ]
+          ]
+        });
+      });
+
+      it('should return the URLS for tiles and grids for http', function () {
+        var dashboard = new WindshaftDashboardInstance({
+          'layergroupid': '0123456789',
+          'urlTemplate': 'http://{user}.example.com:443',
+          'userName': 'rambo',
+          'metadata': {
+            'layers': [
+              {
+                'type': 'mapnik',
+                'meta': {}
+              },
+              {
+                'type': 'mapnik',
+                'meta': {}
+              }
+            ]
+          }
+        });
+        expect(dashboard.getTiles()).toEqual({
+          'tiles': [
+            'http://rambo.example.com:443/api/v1/map/0123456789/0,1/{z}/{x}/{y}.png',
+            'http://rambo.example.com:443/api/v1/map/0123456789/0,1/{z}/{x}/{y}.png',
+            'http://rambo.example.com:443/api/v1/map/0123456789/0,1/{z}/{x}/{y}.png',
+            'http://rambo.example.com:443/api/v1/map/0123456789/0,1/{z}/{x}/{y}.png'
+          ],
+          'grids': [
+            [
+              'http://rambo.example.com:443/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json',
+              'http://rambo.example.com:443/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json',
+              'http://rambo.example.com:443/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json',
+              'http://rambo.example.com:443/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json'
+            ], [
+              'http://rambo.example.com:443/api/v1/map/0123456789/1/{z}/{x}/{y}.grid.json',
+              'http://rambo.example.com:443/api/v1/map/0123456789/1/{z}/{x}/{y}.grid.json',
+              'http://rambo.example.com:443/api/v1/map/0123456789/1/{z}/{x}/{y}.grid.json',
+              'http://rambo.example.com:443/api/v1/map/0123456789/1/{z}/{x}/{y}.grid.json'
+            ]
+          ]
+        });
+      });
+    });
+
+    describe('when using a CDN', function () {
+      it('should return the URLS for tiles and grids for https', function () {
+        var dashboard = new WindshaftDashboardInstance({
+          'layergroupid': '0123456789',
+          'urlTemplate': 'https://{user}.example.com:443',
+          'userName': 'rambo',
+          'cdn_url': {
+            http: 'cdn.http.example.com',
+            https: 'cdn.https.example.com'
+          },
+          'metadata': {
+            'layers': [
+              {
+                'type': 'mapnik',
+                'meta': {}
+              },
+              {
+                'type': 'mapnik',
+                'meta': {}
+              }
+            ]
+          }
+        });
+        expect(dashboard.getTiles()).toEqual({
+          'tiles': [ 'https://cdn.https.example.com/rambo/api/v1/map/0123456789/0,1/{z}/{x}/{y}.png' ],
+          'grids': [
+            [ 'https://cdn.https.example.com/rambo/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json' ],
+            [ 'https://cdn.https.example.com/rambo/api/v1/map/0123456789/1/{z}/{x}/{y}.grid.json' ]
+          ]
+        });
+      });
+
+      it('should return the URLS for tiles and grids for http', function () {
+        var dashboard = new WindshaftDashboardInstance({
+          'layergroupid': '0123456789',
+          'urlTemplate': 'http://{user}.example.com:443',
+          'userName': 'rambo',
+          'cdn_url': {
+            http: 'cdn.http.example.com',
+            https: 'cdn.https.example.com'
+          },
+          'metadata': {
+            'layers': [
+              {
+                'type': 'mapnik',
+                'meta': {}
+              },
+              {
+                'type': 'mapnik',
+                'meta': {}
+              }
+            ]
+          }
+        });
+        expect(dashboard.getTiles()).toEqual({
+          'tiles': [
+            'http://0.cdn.http.example.com/rambo/api/v1/map/0123456789/0,1/{z}/{x}/{y}.png',
+            'http://1.cdn.http.example.com/rambo/api/v1/map/0123456789/0,1/{z}/{x}/{y}.png',
+            'http://2.cdn.http.example.com/rambo/api/v1/map/0123456789/0,1/{z}/{x}/{y}.png',
+            'http://3.cdn.http.example.com/rambo/api/v1/map/0123456789/0,1/{z}/{x}/{y}.png'
+          ],
+          'grids': [
+            [
+              'http://0.cdn.http.example.com/rambo/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json',
+              'http://1.cdn.http.example.com/rambo/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json',
+              'http://2.cdn.http.example.com/rambo/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json',
+              'http://3.cdn.http.example.com/rambo/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json'
+            ], [
+              'http://0.cdn.http.example.com/rambo/api/v1/map/0123456789/1/{z}/{x}/{y}.grid.json',
+              'http://1.cdn.http.example.com/rambo/api/v1/map/0123456789/1/{z}/{x}/{y}.grid.json',
+              'http://2.cdn.http.example.com/rambo/api/v1/map/0123456789/1/{z}/{x}/{y}.grid.json',
+              'http://3.cdn.http.example.com/rambo/api/v1/map/0123456789/1/{z}/{x}/{y}.grid.json'
+            ]
+          ]
+        });
+      });
+    });
+  });
+
+  describe('#getDataviewURL', function () {
+    it('should return undefined if dataview is not found', function () {
+      var dashboard = new WindshaftDashboardInstance({
+        'layergroupid': '0123456789',
+        'urlTemplate': 'https://{user}.example.com:443',
+        'userName': 'rambo',
+        'metadata': {
+          'layers': [
+            {
+              'type': 'mapnik',
+              'meta': {}
+            },
+            {
+              'type': 'torque',
+              'meta': {}
+            }
+          ]
+        }
+      });
+
+      var dataviewURL = dashboard.getDataviewURL({ dataviewId: 'whatever', protocol: 'http' });
+      expect(dataviewURL).toBeUndefined();
+
+      dashboard = new WindshaftDashboardInstance({
+        'layergroupid': '0123456789',
+        'urlTemplate': 'https://{user}.example.com:443',
+        'userName': 'rambo',
+        'metadata': {
+          'layers': [
+            {
+              'type': 'mapnik',
+              'meta': {},
+              'widgets': {
+                'category_widget_uuid': {
+                  'url': {
+                    'http': 'http://staging.cartocdn.com/pablo/api/v1/map/a5a4f259c7a6af8b56a182ad1b1635f7:1446650335533.2698/0/widget/category_widget_uuid',
+                    'https': 'https://cdb-staging-1.global.ssl.fastly.net/pablo/api/v1/map/a5a4f259c7a6af8b56a182ad1b1635f7:1446650335533.2698/0/widget/category_widget_uuid'
+                  }
+                }
+              }
+            },
+            {
+              'type': 'torque',
+              'meta': {}
+            }
+          ]
+        }
+      });
+
+      dataviewURL = dashboard.getDataviewURL({ dataviewId: 'whatever', protocol: 'http' });
+      expect(dataviewURL).toBeUndefined();
+    });
+
+    it('should return the URL for the given dataviewId and protocol', function () {
+      var dashboard = new WindshaftDashboardInstance({
+        'layergroupid': '0123456789',
+        'urlTemplate': 'https://{user}.example.com:443',
+        'userName': 'rambo',
+        'metadata': {
+          'layers': [
+            {
+              'type': 'mapnik',
+              'meta': {},
+              'widgets': {
+                'dataviewId': {
+                  'url': {
+                    'http': 'http://example.com',
+                    'https': 'https://example.com'
+                  }
+                }
+              }
+            },
+            {
+              'type': 'torque',
+              'meta': {}
+            }
+          ]
+        }
+      });
+
+      var dataviewURL = dashboard.getDataviewURL({ dataviewId: 'dataviewId', protocol: 'http' });
+      expect(dataviewURL).toEqual('http://example.com');
+
+      dataviewURL = dashboard.getDataviewURL({ dataviewId: 'dataviewId', protocol: 'https' });
+      expect(dataviewURL).toEqual('https://example.com');
+    });
+  });
+});

--- a/test/spec/windshaft/dashboard.spec.js
+++ b/test/spec/windshaft/dashboard.spec.js
@@ -1,0 +1,351 @@
+var $ = require('jquery');
+var _ = require('underscore');
+var Backbone = require('backbone');
+var Model = require('../../../src/core/model');
+var Map = require('../../../src/geo/map');
+var TorqueLayer = require('../../../src/geo/map/torque-layer');
+var CartoDBLayer = require('../../../src/geo/map/cartodb-layer');
+var HistogramDataviewModel = require('../../../src/dataviews/histogram-dataview-model');
+var WindshaftDashboard = require('../../../src/windshaft/dashboard');
+var WindshaftDashboardInstance = require('../../../src/windshaft/dashboard-instance');
+var CategoryFilter = require('../../../src/windshaft/filters/category');
+
+describe('windshaft/dashboard', function () {
+  beforeEach(function () {
+    jasmine.clock().install();
+
+    // Disable ajax and debounce for these tests
+    spyOn($, 'ajax').and.callFake(function () {});
+    spyOn(_, 'debounce').and.callFake(function (func) { return function () { func.apply(this, arguments); }; });
+
+    this.dashboardInstance = new WindshaftDashboardInstance({
+      metadata: {
+        layers: [
+          {
+            'type': 'mapnik',
+            'meta': {},
+            'widgets': {
+              'dataviewId': {
+                'url': {
+                  'http': 'http://example.com',
+                  'https': 'https://example.com'
+                }
+              }
+            }
+          }
+        ]
+      }
+    });
+    this.dataviews = new Backbone.Collection();
+
+    spyOn(this.dashboardInstance, 'getBaseURL').and.returnValue('baseURL');
+    spyOn(this.dashboardInstance, 'getTiles').and.callFake(function (type) {
+      if (type === 'torque') {
+        return 'torqueTileURLs';
+      }
+      return 'tileURLs';
+    });
+
+    this.client = {
+      instantiateMap: function (options) {
+        options.success(this.dashboardInstance);
+      }.bind(this)
+    };
+
+    this.configGenerator = {
+      generate: function () {}
+    };
+
+    this.map = new Map({
+      view_bounds_sw: [],
+      view_bounds_ne: []
+    });
+
+    this.cartoDBLayerGroup = new Model();
+    this.cartoDBLayer1 = new CartoDBLayer({ id: '12345-67890' });
+    this.cartoDBLayer2 = new CartoDBLayer({ id: '09876-54321' });
+    this.torqueLayer = new TorqueLayer();
+  });
+
+  afterEach(function () {
+    jasmine.clock().uninstall();
+  });
+
+  it('should create an instance of the dashboard and update the URLs of layers and dataviews', function () {
+    var dataview = new HistogramDataviewModel({
+      id: 'dataviewId',
+      type: 'list'
+    }, {
+      layer: this.cartoDBLayer1
+    });
+    this.dataviews.add(dataview);
+
+    new WindshaftDashboard({ // eslint-disable-line
+      client: this.client,
+      configGenerator: this.configGenerator,
+      statTag: 'stat_tag',
+      layerGroup: this.cartoDBLayerGroup,
+      layers: new Backbone.Collection([ this.cartoDBLayer1, this.cartoDBLayer2, this.torqueLayer ]),
+      dataviews: this.dataviews,
+      map: this.map
+    });
+    jasmine.clock().tick(100);
+
+    // urls of the layerGroup have been updated
+    expect(this.cartoDBLayerGroup.get('baseURL')).toEqual('baseURL');
+    expect(this.cartoDBLayerGroup.get('urls')).toEqual('tileURLs');
+
+    // urls of torque layers have been updated too!
+    expect(this.torqueLayer.get('urls')).toEqual('torqueTileURLs');
+
+    // url of dataview have been updated
+    expect(dataview.url()).toEqual('http://example.com');
+  });
+
+  it('should pass the filters of visible layers to create the instance', function () {
+    spyOn(this.client, 'instantiateMap');
+
+    var filter = new CategoryFilter({ layerIndex: 0 });
+    spyOn(filter, 'isEmpty').and.returnValue(false);
+    spyOn(filter, 'toJSON').and.returnValue({ something: 'else' });
+
+    var dataview = new HistogramDataviewModel({
+      id: 'dataviewId',
+      type: 'list'
+    }, {
+      layer: this.cartoDBLayer1,
+      filter: filter
+    });
+
+    this.dataviews.add(dataview);
+
+    new WindshaftDashboard({ // eslint-disable-line
+      client: this.client,
+      configGenerator: this.configGenerator,
+      statTag: 'stat_tag',
+      layerGroup: this.cartoDBLayerGroup,
+      layers: new Backbone.Collection([ this.cartoDBLayer1, this.cartoDBLayer2 ]),
+      dataviews: this.dataviews,
+      map: this.map
+    });
+    jasmine.clock().tick(100);
+
+    expect(this.client.instantiateMap.calls.mostRecent().args[0].filters).toEqual({
+      layers: [{
+        something: 'else'
+      }]
+    });
+
+    // Hide the layer
+    this.cartoDBLayer1.set('visible', false);
+
+    // client.instantiateMap has been called again, but this time no filters are passed
+    expect(this.client.instantiateMap.calls.mostRecent().args[0].filters).toEqual({});
+  });
+
+  it('should update the urls of dataviews when bounding box changes', function () {
+    this.client.instantiateMap = function (args) {
+      this.dashboardInstance.set({
+        layergroupid: 'dashboardId',
+        metadata: {
+          layers: [
+            {
+              'type': 'mapnik',
+              'meta': {},
+              'widgets': {
+                'dataviewId': {
+                  'url': {
+                    'http': 'http://example.com/dataviewId',
+                    'https': 'https://example.comdataviewId'
+                  }
+                }
+              }
+            }
+          ]
+        }
+      });
+      args.success(this.dashboardInstance);
+    }.bind(this);
+
+    var dataview = new HistogramDataviewModel({
+      id: 'dataviewId',
+      type: 'list'
+    }, {
+      layer: this.cartoDBLayer1
+    });
+    this.dataviews.add(dataview);
+
+    new WindshaftDashboard({ // eslint-disable-line
+      client: this.client,
+      configGenerator: this.configGenerator,
+      statTag: 'stat_tag',
+      layerGroup: this.cartoDBLayerGroup,
+      layers: new Backbone.Collection([ this.cartoDBLayer1 ]),
+      dataviews: this.dataviews,
+      map: this.map
+    });
+    jasmine.clock().tick(100);
+
+    // url of dataview have been updated
+    expect(dataview.url()).toEqual('http://example.com/dataviewId');
+
+    // This dataviews needs this attribute to be true in order to submit the bbox filter
+    dataview.set('submitBBox', true);
+
+    // Map bounds changes and event is triggered
+    this.map.setBounds([['s', 'w'], ['n', 'e']]);
+    this.map.trigger('change:center');
+
+    // dataview url has been updated and now includes the bounding box filter
+    expect(dataview.url()).toEqual('http://example.com/dataviewId?bbox=w,s,e,n');
+  });
+
+  it('should create a new instance when some attributes of a layer changes', function () {
+    spyOn(this.client, 'instantiateMap');
+
+    var dataview = new HistogramDataviewModel({
+      id: 'dataviewId',
+      type: 'list'
+    }, {
+      layer: this.cartoDBLayer1
+    });
+    this.dataviews.add(dataview);
+
+    new WindshaftDashboard({ // eslint-disable-line
+      client: this.client,
+      configGenerator: this.configGenerator,
+      statTag: 'stat_tag',
+      layerGroup: this.cartoDBLayerGroup,
+      layers: new Backbone.Collection([ this.cartoDBLayer1, this.cartoDBLayer2 ]),
+      dataviews: this.dataviews,
+      map: this.map
+    });
+    jasmine.clock().tick(100);
+
+    expect(this.client.instantiateMap.calls.count()).toEqual(1);
+
+    // Hide the layer
+    this.cartoDBLayer1.set('visible', false);
+
+    expect(this.client.instantiateMap.calls.count()).toEqual(2);
+  });
+
+  it('should create a new instance when the filter of a layer changes', function () {
+    spyOn(this.client, 'instantiateMap');
+
+    var filter = new CategoryFilter({ layerIndex: 0 });
+    spyOn(filter, 'isEmpty').and.returnValue(false);
+    spyOn(filter, 'toJSON').and.returnValue({ something: 'else' });
+
+    var dataview = new HistogramDataviewModel({
+      id: 'dataviewId',
+      type: 'list'
+    }, {
+      layer: this.cartoDBLayer1,
+      filter: filter
+    });
+    this.dataviews.add(dataview);
+
+    new WindshaftDashboard({ // eslint-disable-line
+      client: this.client,
+      configGenerator: this.configGenerator,
+      statTag: 'stat_tag',
+      layerGroup: this.cartoDBLayerGroup,
+      layers: new Backbone.Collection([ this.cartoDBLayer1, this.cartoDBLayer2 ]),
+      dataviews: this.dataviews,
+      map: this.map
+    });
+    jasmine.clock().tick(100);
+
+    expect(this.client.instantiateMap.calls.count()).toEqual(1);
+
+    // Filter has changed
+    dataview.trigger('change:filter', dataview);
+
+    expect(this.client.instantiateMap.calls.count()).toEqual(2);
+  });
+
+  it('should refresh the URLs of dataviews and only trigger a change event if the dataview belongs to the layer that changed', function () {
+    var i = 0;
+    this.client.instantiateMap = function (args) {
+      this.dashboardInstance.set('metadata', {
+        layers: [
+          {
+            'type': 'mapnik',
+            'meta': {},
+            'widgets': {
+              'dataviewId1': {
+                'url': {
+                  'http': 'http://example.com/dataviewId1/' + i,
+                  'https': 'https://example.com/dataviewId1/' + i
+                }
+              }
+            }
+          },
+          {
+            'type': 'mapnik',
+            'meta': {},
+            'widgets': {
+              'dataviewId2': {
+                'url': {
+                  'http': 'http://example.com/dataviewId2/' + i,
+                  'https': 'https://example.com/dataviewId2/' + i
+                }
+              }
+            }
+          }
+        ]
+      });
+
+      args.success(this.dashboardInstance);
+      i++;
+    }.bind(this);
+
+    var dataview1 = new HistogramDataviewModel({
+      id: 'dataviewId1',
+      type: 'list'
+    }, {
+      layer: this.cartoDBLayer1
+    });
+    this.dataviews.add(dataview1);
+
+    var dataview2 = new HistogramDataviewModel({
+      id: 'dataviewId2',
+      type: 'list'
+    }, {
+      layer: this.cartoDBLayer2
+    });
+    this.dataviews.add(dataview2);
+
+    new WindshaftDashboard({ // eslint-disable-line
+      client: this.client,
+      configGenerator: this.configGenerator,
+      statTag: 'stat_tag',
+      layerGroup: this.cartoDBLayerGroup,
+      layers: new Backbone.Collection([ this.cartoDBLayer1, this.cartoDBLayer2 ]),
+      dataviews: this.dataviews,
+      map: this.map
+    });
+    jasmine.clock().tick(100);
+
+    expect(dataview1.get('url')).toEqual('http://example.com/dataviewId1/0');
+    expect(dataview2.get('url')).toEqual('http://example.com/dataviewId2/0');
+
+    // Bind some callbacks to check which change:url events do dataviews trigger
+    var callback1 = jasmine.createSpy('callback1');
+    var callback2 = jasmine.createSpy('callback2');
+
+    dataview1.bind('change:url', callback1);
+    dataview2.bind('change:url', callback2);
+
+    // Filter has changed by cartoDBLayer1
+    dataview1.trigger('change:filter', dataview1);
+
+    expect(dataview1.get('url')).toEqual('http://example.com/dataviewId1/1');
+    expect(dataview2.get('url')).toEqual('http://example.com/dataviewId2/1');
+
+    // Layer1 was the one that triggered the change so only callback1 should have been called
+    expect(callback1).toHaveBeenCalled();
+    expect(callback2).not.toHaveBeenCalled();
+  });
+});

--- a/test/spec/windshaft/filters/category.spec.js
+++ b/test/spec/windshaft/filters/category.spec.js
@@ -1,0 +1,226 @@
+var WindshaftFiltersCategory = require('../../../../src/windshaft/filters/category');
+
+describe('windshaft/filters/category', function () {
+  var data;
+
+  beforeEach(function () {
+    this.filter = new WindshaftFiltersCategory({
+      dataviewId: 'category_dataview'
+    });
+
+    data = [];
+    for (var i = 0; i < 12; i++) {
+      data.push(i);
+    }
+  });
+
+  it('should generate two internal collections for adding rejected and accepted items', function () {
+    expect(this.filter.rejectedCategories).toBeDefined();
+    expect(this.filter.acceptedCategories).toBeDefined();
+  });
+
+  describe('isEmpty', function () {
+    it('should be empty when there is no rejected and accepted items', function () {
+      expect(this.filter.isEmpty()).toBeTruthy();
+    });
+    it('should not be empty when there is rejected items', function () {
+      this.filter.reject(1);
+      expect(this.filter.isEmpty()).toBeFalsy();
+    });
+    it('should not be empty when there is accepted items', function () {
+      this.filter.accept(1);
+      expect(this.filter.isEmpty()).toBeFalsy();
+    });
+    it('should not be empty when rejectAll is true', function () {
+      this.filter.set('rejectAll', true);
+      expect(this.filter.isEmpty()).toBeFalsy();
+    });
+  });
+
+  describe('accept', function () {
+    it('should accept an array or a string as an argument', function () {
+      var acceptedCats = this.filter.getAccepted();
+      this.filter.accept(1);
+      expect(acceptedCats.size()).toBe(1);
+      this.filter.accept(2);
+      expect(acceptedCats.size()).toBe(2);
+    });
+
+    it('should trigger change event when value is accepted', function () {
+      var callback = jasmine.createSpy('callback');
+      this.filter.bind('change', callback, this.filter);
+      this.filter.accept(1);
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should remove value from rejected if it is present when it is accepted', function () {
+      this.filter.reject(1);
+      var rejectedCats = this.filter.getRejected();
+      var acceptedCats = this.filter.getAccepted();
+      expect(rejectedCats.size()).toBe(1);
+      this.filter.accept(1);
+      expect(rejectedCats.size()).toBe(0);
+      expect(acceptedCats.size()).toBe(1);
+    });
+
+    it('should not accept a value if it is already present', function () {
+      this.filter.accept(1);
+      var acceptedCats = this.filter.getAccepted();
+      expect(acceptedCats.size()).toBe(1);
+      this.filter.accept(1);
+      expect(acceptedCats.size()).toBe(1);
+    });
+  });
+
+  it('should accept all cleaning accepted and rejected', function () {
+    this.filter.accept([1, 2, 3]);
+    this.filter.reject([4, 5, 6]);
+    this.filter.acceptAll();
+    expect(this.filter.getRejected().size()).toBe(0);
+    expect(this.filter.getAccepted().size()).toBe(0);
+  });
+
+  describe('reject', function () {
+    it('should reject an array or a string as an argument', function () {
+      var rejectedCats = this.filter.getRejected();
+      this.filter.reject([1]);
+      expect(rejectedCats.size()).toBe(1);
+      this.filter.reject(2);
+      expect(rejectedCats.size()).toBe(2);
+    });
+
+    it('should trigger change event when value is accepted', function () {
+      var callback = jasmine.createSpy('callback');
+      this.filter.bind('change', callback, this.filter);
+      this.filter.accept(1);
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should remove value from accepted if it is present when it is rejected', function () {
+      this.filter.accept([1, 2]);
+      var acceptedCats = this.filter.getAccepted();
+      var rejectedCats = this.filter.getRejected();
+      expect(acceptedCats.size()).toBe(2);
+      this.filter.reject(1);
+      expect(rejectedCats.size()).toBe(0);
+      expect(acceptedCats.size()).toBe(1);
+      this.filter.reject(2);
+      expect(rejectedCats.size()).toBe(0);
+      expect(acceptedCats.size()).toBe(0);
+      this.filter.reject(3);
+      expect(rejectedCats.size()).toBe(1);
+      expect(acceptedCats.size()).toBe(0);
+    });
+
+    it('should not reject a value if it is already present', function () {
+      this.filter.reject(1);
+      var rejectedCats = this.filter.getRejected();
+      expect(rejectedCats.size()).toBe(1);
+      this.filter.reject(1);
+      expect(rejectedCats.size()).toBe(1);
+    });
+  });
+
+  it('should reject all cleaning accepted and rejected, also changing rejectAll attribute', function () {
+    var callback = jasmine.createSpy('callback');
+    this.filter.bind('change', callback, this.filter);
+    this.filter.accept([1, 2, 3]);
+    this.filter.reject([4]);
+    this.filter.rejectAll();
+    expect(this.filter.getRejected().size()).toBe(0);
+    expect(this.filter.getAccepted().size()).toBe(0);
+    expect(this.filter.get('rejectAll')).toBeTruthy();
+    expect(callback).toHaveBeenCalled();
+  });
+
+  describe('isRejected', function () {
+    it('should be rejected it is included in reject collection', function () {
+      this.filter.reject(1);
+      expect(this.filter.isRejected(1)).toBeTruthy();
+    });
+
+    it('should be rejected it is not included in any of both (accept or reject) and there are accepted', function () {
+      this.filter.accept(4);
+      expect(this.filter.isRejected(1)).toBeTruthy();
+      this.filter.reject(2);
+      expect(this.filter.isRejected(1)).toBeTruthy();
+    });
+
+    it('should not be rejected if both collections are empty', function () {
+      expect(this.filter.isRejected(1)).toBeFalsy();
+    });
+
+    it('should not be rejected if it is present in accepted collection', function () {
+      this.filter.accept(1);
+      expect(this.filter.isRejected(1)).toBeFalsy();
+    });
+
+    it('should be rejected if rejectAll is enabled', function () {
+      this.filter.set('rejectAll', true);
+      expect(this.filter.isRejected(1)).toBeTruthy();
+    });
+  });
+
+  describe('toJSON', function () {
+    it('should generate an object with attributes when it is serialized', function () {
+      this.filter.reject([1, 2]);
+      var result = this.filter.toJSON();
+      expect(result['category_dataview']).toBeDefined();
+      expect(result['category_dataview']['reject']).toBeDefined();
+    });
+
+    it('should not generate any value when accept and reject are empty', function () {
+      var result = this.filter.toJSON();
+      expect(result['category_dataview']).toBeDefined();
+      expect(result['category_dataview']['reject']).not.toBeDefined();
+      expect(result['category_dataview']['accept']).not.toBeDefined();
+    });
+
+    it('should send accept when there is any accept, no matter rejects', function () {
+      this.filter.reject([1, 2]);
+      this.filter.accept(3);
+      var result = this.filter.toJSON();
+      expect(result['category_dataview']).toBeDefined();
+      expect(result['category_dataview']['reject']).not.toBeDefined();
+      expect(result['category_dataview']['accept']).toBeDefined();
+      var accept = result['category_dataview']['accept'];
+      expect(accept.length).toBe(1);
+      expect(accept[0]).toBe(3);
+    });
+
+    it('should send reject when accept is empty but reject', function () {
+      this.filter.reject([1, 2]);
+      var result = this.filter.toJSON();
+      expect(result['category_dataview']).toBeDefined();
+      expect(result['category_dataview']['reject']).toBeDefined();
+      expect(result['category_dataview']['accept']).not.toBeDefined();
+      var reject = result['category_dataview']['reject'];
+      expect(reject.length).toBe(2);
+      expect(reject[0]).toBe(1);
+      expect(reject[1]).toBe(2);
+    });
+
+    it('should send accept when both (accept and reject) are not empty', function () {
+      this.filter.reject([1, 2]);
+      this.filter.accept([3]);
+      var result = this.filter.toJSON();
+      expect(result['category_dataview']).toBeDefined();
+      expect(result['category_dataview']['reject']).not.toBeDefined();
+      expect(result['category_dataview']['accept']).toBeDefined();
+      var accept = result['category_dataview']['accept'];
+      expect(accept.length).toBe(1);
+      expect(accept[0]).toBe(3);
+    });
+
+    // TODO: change this spec when it is fixed in the API
+    it('should send a special character in accept when all categories are rejected', function () {
+      this.filter.rejectAll(data);
+      var result = this.filter.toJSON();
+      expect(result['category_dataview']).toBeDefined();
+      expect(result['category_dataview']['reject']).not.toBeDefined();
+      expect(result['category_dataview']['accept']).toBeDefined();
+      var accept = result['category_dataview']['accept'];
+      expect(accept.length).toBe(0);
+    });
+  });
+});

--- a/test/spec/windshaft/filters/range.spec.js
+++ b/test/spec/windshaft/filters/range.spec.js
@@ -1,0 +1,65 @@
+var RangeFilter = require('../../../../src/windshaft/filters/range');
+
+describe('windshaft/filters/range', function () {
+  beforeEach(function () {
+    this.dataviewId = 'range-filter-uuid';
+    this.filter = new RangeFilter({
+      dataviewId: this.dataviewId
+    });
+  });
+
+  it('should have a undefined range values by default', function () {
+    expect(this.filter.get('min')).toBeUndefined();
+    expect(this.filter.get('max')).toBeUndefined();
+  });
+
+  describe('.setRange', function () {
+    it('should set the range', function () {
+      this.filter.setRange(2, 4);
+      expect(this.filter.get('min')).toEqual(2);
+      expect(this.filter.get('max')).toEqual(4);
+    });
+  });
+
+  describe('.isEmpty', function () {
+    it('should return true if there are no range values set', function () {
+      expect(this.filter.isEmpty()).toBe(true);
+      this.filter.setRange(1, 2);
+      expect(this.filter.isEmpty()).toBe(false);
+    });
+  });
+
+  describe('.unsetRange', function () {
+    beforeEach(function () {
+      this.filter.setRange(2, 4);
+      this.changeSpy = jasmine.createSpy('change');
+      this.filter.bind('change', this.changeSpy);
+      this.filter.unsetRange();
+    });
+
+    it('should remove range', function () {
+      expect(this.filter.get('min')).toBeUndefined();
+      expect(this.filter.get('max')).toBeUndefined();
+    });
+
+    it('should only trigger change event once', function () {
+      expect(this.changeSpy).toHaveBeenCalled();
+      expect(this.changeSpy.calls.count()).toEqual(1);
+    });
+  });
+
+  describe('.toJSON', function () {
+    beforeEach(function () {
+      this.filter.setRange(2, 4);
+      this.res = this.filter.toJSON();
+    });
+
+    it('should return a JSON object', function () {
+      expect(this.res).toEqual(jasmine.any(Object));
+      var res = this.res[this.dataviewId];
+      expect(res).toEqual(jasmine.any(Object));
+      expect(res.min).toEqual(2);
+      expect(res.max).toEqual(4);
+    });
+  });
+});

--- a/test/spec/windshaft/layergroup-config.spec.js
+++ b/test/spec/windshaft/layergroup-config.spec.js
@@ -1,0 +1,122 @@
+var Backbone = require('backbone');
+var CartoDBLayer = require('../../../src/geo/map/cartodb-layer');
+var LayerGroupConfig = require('../../../src/windshaft/layergroup-config');
+var HistogramDataviewModel = require('../../../src/dataviews/histogram-dataview-model');
+
+describe('windshaft/layergroup-config', function () {
+  beforeEach(function () {
+    this.dataviews = new Backbone.Collection();
+
+    this.cartoDBLayer1 = new CartoDBLayer({
+      id: 'layer1',
+      sql: 'sql1',
+      cartocss: 'cartoCSS1',
+      cartocss_version: '2.0'
+    });
+    var dataview = new HistogramDataviewModel({
+      id: 'dataviewId',
+      column: 'column1',
+      bins: 10
+    }, {
+      layer: this.cartoDBLayer1
+    });
+    this.dataviews.add(dataview);
+
+    this.cartoDBLayer2 = new CartoDBLayer({
+      id: 'layer2',
+      sql: 'sql2',
+      cartocss: 'cartoCSS2',
+      cartocss_version: '2.0'
+    });
+    var dataview2 = new HistogramDataviewModel({
+      id: 'dataviewId2',
+      column: 'column2',
+      bins: 5
+    }, {
+      layer: this.cartoDBLayer2
+    });
+    this.dataviews.add(dataview2);
+  });
+
+  describe('.generate', function () {
+    it('should generate the config', function () {
+      var config = LayerGroupConfig.generate({
+        dataviews: this.dataviews,
+        layers: [ this.cartoDBLayer1, this.cartoDBLayer2 ]
+      });
+
+      expect(config).toEqual({
+        layers: [
+          {
+            type: 'cartodb',
+            options: {
+              sql: 'sql1',
+              cartocss: 'cartoCSS1',
+              cartocss_version: '2.0',
+              interactivity: [ 'cartodb_id' ],
+              widgets: {
+                dataviewId: {
+                  type: 'histogram',
+                  options: {
+                    column: 'column1',
+                    bins: 10
+                  }
+                }
+              }
+            }
+          },
+          {
+            type: 'cartodb',
+            options: {
+              sql: 'sql2',
+              cartocss: 'cartoCSS2',
+              cartocss_version: '2.0',
+              interactivity: [ 'cartodb_id' ],
+              widgets: {
+                dataviewId2: {
+                  type: 'histogram',
+                  options: {
+                    column: 'column2',
+                    bins: 5
+                  }
+                }
+              }
+            }
+          }
+        ]
+      });
+    });
+
+    it('should not include hidden layers', function () {
+      this.cartoDBLayer1.set('visible', false);
+
+      var config = LayerGroupConfig.generate({
+        dataviews: this.dataviews,
+        layers: [ this.cartoDBLayer1, this.cartoDBLayer2 ]
+      });
+
+      expect(config).toEqual({
+        layers: [
+          {
+            type: 'cartodb',
+            options: {
+              sql: 'sql2',
+              cartocss: 'cartoCSS2',
+              cartocss_version: '2.0',
+              interactivity: [ 'cartodb_id' ],
+              widgets: {
+                dataviewId2: {
+                  type: 'histogram',
+                  options: {
+                    column: 'column2',
+                    bins: 5
+                  }
+                }
+              }
+            }
+          }
+        ]
+      });
+    });
+  });
+});

--- a/test/spec/windshaft/namedmap-config.spec.js
+++ b/test/spec/windshaft/namedmap-config.spec.js
@@ -1,0 +1,36 @@
+var CartoDBLayer = require('../../../src/geo/map/cartodb-layer');
+var NamedMapConfig = require('../../../src/windshaft/namedmap-config');
+
+describe('windshaft/namedmap-config', function () {
+  beforeEach(function () {
+    this.cartoDBLayer1 = new CartoDBLayer({
+      id: 'layer1',
+      sql: 'sql1',
+      cartocss: 'cartoCSS1',
+      cartocss_version: '2.0'
+    });
+    this.cartoDBLayer2 = new CartoDBLayer({
+      id: 'layer2',
+      sql: 'sql2',
+      cartocss: 'cartoCSS2',
+      cartocss_version: '2.0'
+    });
+    this.cartoDBLayer3 = new CartoDBLayer({
+      id: 'layer2',
+      sql: 'sql2',
+      cartocss: 'cartoCSS2',
+      cartocss_version: '2.0',
+      visible: false
+    });
+  });
+
+  describe('.generate', function () {
+    it('should generate the config', function () {
+      var config = NamedMapConfig.generate({
+        layers: [ this.cartoDBLayer1, this.cartoDBLayer2, this.cartoDBLayer3 ]
+      });
+
+      expect(config).toEqual({ layer0: 1, layer1: 1, layer2: 0 });
+    });
+  });
+});


### PR DESCRIPTION
Migrated code out from deep-insights to here. Retrofit in this case more specifically means:
- Adding the new dataviews concepts
- Update the exsting `src/windshaft/*` code to take into account `dataviews` (previously widgets) and `filters`
- `vis` object is accommodated to take into account the new concepts
- Mostly moved code as it were implemented in deep-insights

In terms of dataviews, instead of exposing the raw models, and taking into account these concepts only makes sense in the context of a vis/map they're only exposed through a factory:
```js
var dataview = vis.dataviewFactory.createHistogramDataview(layer, { … });
```
Internally this wires up the windshaft client and such to take into account this dataview and it's underlying filter. Also, this way we just need to document the public-facing methods, props, and events, the underlying implementation can be changed as we see fit.

@alonsogarciapablo can you review? cc @CartoDB/frontend FYI