### PR TITLE
Changed how windshaft map gets some dependencies

### DIFF
--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -288,8 +288,36 @@ var Map = Model.extend({
     }
 
     return zoom - 1;
-  }
+  },
 
+  getLayerGroup: function () {
+    return this.layers.find(function (layer) {
+      return layer.get('type') === 'layergroup' || layer.get('type') === 'namedmap';
+    });
+  },
+
+  getInteractiveLayers: function () {
+    if (!this._interactiveLayers) {
+      this._interactiveLayers = new Backbone.Collection();
+    }
+
+    var interactiveLayers = [];
+
+    // TODO: We'd also need to do this every time a layer is added/removed to the collection of layers
+    // to keep this collection in sync with map.layer
+    this.layers.each(function (layer) {
+      if (layer.get('type') === 'layergroup' || layer.get('type') === 'namedmap') {
+        layer.layers.each(function (cartoDBlayer) {
+          interactiveLayers.push(cartoDBlayer);
+        });
+      } else if (layer.get('type') === 'torque') {
+        interactiveLayers.push(layer);
+      }
+    });
+    this._interactiveLayers.reset(interactiveLayers);
+
+    return this._interactiveLayers;
+  }
 }, {
   latlngToMercator: function(latlng, zoom) {
     var ll = new L.LatLng(latlng[0], latlng[1]);

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -339,7 +339,6 @@ var Vis = View.extend({
     }
 
     var cartoDBLayers;
-    var cartoDBLayerGroup;
     var layers = [];
 
     // This attribute is public (used by deep-insights)
@@ -357,11 +356,10 @@ var Vis = View.extend({
         }
         cartoDBLayers = _.map(layersData, function (layerData) {
           var cartoDBLayer = Layers.create('cartodb', self, layerData);
-          self.interactiveLayers.add(cartoDBLayer);
           return cartoDBLayer;
         });
 
-        cartoDBLayerGroup = new layerGroupClass(null, {
+        var cartoDBLayerGroup = new layerGroupClass(null, {
           layers: cartoDBLayers
         });
         layers.push(cartoDBLayerGroup);
@@ -369,14 +367,14 @@ var Vis = View.extend({
         // Treat differently since this kind of layer is rendered client-side (and not through the tiler)
         var layer = Layers.create(layerData.type, self, layerData);
         layers.push(layer);
-        if (layerData.type === 'torque') {
-          self.interactiveLayers.add(layer);
-        }
       }
     });
 
     // Map layers are resetted and the mapView adds the layers to the map
     this.map.layers.reset(layers);
+
+    // This is a public attribute (used by deep-insights.js).
+    this.interactiveLayers = this.map.getInteractiveLayers();
 
     this._dataviewsCollection = new DataviewCollection();
     this.dataviews = new DataviewsFactory(null, {
@@ -387,43 +385,33 @@ var Vis = View.extend({
     // TODO: rethink this
     this._dataviewsCollection.on('add reset remove', _.debounce(this._invalidateSizeOnDataviewsChanges, 10), this);
 
-    // TODO: This method is creating an instance of the layer group
-    // and setting the tiles and grid urls on the layerGroup model, which
-    // cause the layergroup view to fetch and render the tiles. This needs
-    // to happen everytime a layer that belongs to the layerGroup changes
-    // (eg: when the layer is hidden or it's SQL is changed)
-    if (cartoDBLayerGroup) {
-      var endpoint;
-      var configGenerator;
-      var datasource = data.datasource;
+    var endpoint;
+    var configGenerator;
+    var datasource = data.datasource;
 
-      // TODO: We can use something else to differentiate types of "datasource"s
-      if (datasource.template_name) {
-        endpoint = [WindshaftConfig.MAPS_API_BASE_URL, 'named', datasource.template_name].join('/');
-        configGenerator = WindshaftNamedMapConfig;
-      } else {
-        endpoint = WindshaftConfig.MAPS_API_BASE_URL;
-        configGenerator = WindshaftLayerGroupConfig;
-      }
-
-      var windshaftClient = new WindshaftClient({
-        endpoint: endpoint,
-        urlTemplate: datasource.maps_api_template,
-        userName: datasource.user_name,
-        forceCors: datasource.force_cors || true
-      });
-
-      new WindshaftMap({ // eslint-disable-line
-        client: windshaftClient,
-        configGenerator: configGenerator,
-        statTag: datasource.stat_tag,
-        // TODO: assuming here all viz.json has a layergroup and that may not be true
-        layerGroup: cartoDBLayerGroup,
-        layers: this.interactiveLayers,
-        dataviews: this._dataviewsCollection,
-        map: this.map
-      });
+    // TODO: We can use something else to differentiate types of "datasource"s
+    if (datasource.template_name) {
+      endpoint = [WindshaftConfig.MAPS_API_BASE_URL, 'named', datasource.template_name].join('/');
+      configGenerator = WindshaftNamedMapConfig;
+    } else {
+      endpoint = WindshaftConfig.MAPS_API_BASE_URL;
+      configGenerator = WindshaftLayerGroupConfig;
     }
+
+    var windshaftClient = new WindshaftClient({
+      endpoint: endpoint,
+      urlTemplate: datasource.maps_api_template,
+      userName: datasource.user_name,
+      forceCors: datasource.force_cors || true
+    });
+
+    new WindshaftMap({ // eslint-disable-line
+      client: windshaftClient,
+      configGenerator: configGenerator,
+      statTag: datasource.stat_tag,
+      dataviews: this._dataviewsCollection,
+      map: this.map
+    });
 
     // if there are no sublayer_options fill it
     if (!options.sublayer_options) {

--- a/src/windshaft/windshaft-map.js
+++ b/src/windshaft/windshaft-map.js
@@ -16,7 +16,6 @@ var WindshaftMap = function (options) {
 
   this.map = options.map;
   this.layers = this.map.getInteractiveLayers();
-  this.layerGroup = this.map.getLayerGroup();
   this.dataviews = options.dataviews;
   this.client = options.client;
 
@@ -66,7 +65,8 @@ WindshaftMap.prototype._createInstance = function (options) {
       this.instance.set(mapInstance.toJSON());
 
       // TODO: Extract this.
-      this.layerGroup && this.layerGroup.set({
+      var layerGroup = this.map.getLayerGroup();
+      layerGroup && layerGroup.set({
         baseURL: mapInstance.getBaseURL(),
         urls: mapInstance.getTiles('mapnik')
       });

--- a/src/windshaft/windshaft-map.js
+++ b/src/windshaft/windshaft-map.js
@@ -14,11 +14,13 @@ var WindshaftMapInstance = require('./windshaft-map-instance');
 var WindshaftMap = function (options) {
   var BOUNDING_BOX_FILTER_WAIT = 500;
 
-  this.layerGroup = options.layerGroup;
-  this.layers = options.layers;
-  this.dataviews = options.dataviews;
   this.map = options.map;
+  this.layers = this.map.getInteractiveLayers();
+  this.layerGroup = this.map.getLayerGroup();
+  this.dataviews = options.dataviews;
   this.client = options.client;
+
+  // TODO: This could probably be a property of the map object
   this.statTag = options.statTag;
   this.configGenerator = options.configGenerator;
   this.instance = new WindshaftMapInstance();

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -1,7 +1,10 @@
 var config = require('cdb.config');
 var PlainLayer = require('../../../src/geo/map/plain-layer');
-var CartoDBLayer = require('../../../src/geo/map/cartodb-layer');
 var Map = require('../../../src/geo/map');
+var CartoDBLayer = require('../../../src/geo/map/cartodb-layer');
+var TorqueLayer = require('../../../src/geo/map/torque-layer');
+var CartoDBLayerGroupAnonymous = require('../../../src/geo/map/cartodb-layer-group-anonymous');
+var CartoDBLayerGroupNamed = require('../../../src/geo/map/cartodb-layer-group-named');
 
 describe('core/geo/map', function() {
   var map;
@@ -121,4 +124,96 @@ describe('core/geo/map', function() {
       "CartoDB <a href=\"http://cartodb.com/attributions\" target=\"_blank\">attribution</a>",
     ]);
   })
+
+  describe('.getInteractiveLayers', function () {
+    it('should return layers inside of a layergroup layer model', function () {
+      map = new Map();
+      var cartodbLayer1 = new CartoDBLayer();
+      var cartodbLayer2 = new CartoDBLayer();
+
+      var layerGroup = new CartoDBLayerGroupAnonymous(null, {
+        layers: [cartodbLayer1, cartodbLayer2]
+      });
+
+      map.layers.reset([layerGroup]);
+
+      var interactiveLayers = map.getInteractiveLayers();
+      expect(interactiveLayers.size()).toEqual(2);
+      expect(interactiveLayers.at(0)).toEqual(cartodbLayer1);
+      expect(interactiveLayers.at(1)).toEqual(cartodbLayer2);
+    });
+
+    it('should return layers inside of a namedmap layer model', function () {
+      map = new Map();
+      var cartodbLayer1 = new CartoDBLayer();
+      var cartodbLayer2 = new CartoDBLayer();
+
+      var layerGroup = new CartoDBLayerGroupNamed(null, {
+        layers: [cartodbLayer1, cartodbLayer2]
+      });
+
+      map.layers.reset([layerGroup]);
+
+      var interactiveLayers = map.getInteractiveLayers();
+      expect(interactiveLayers.size()).toEqual(2);
+      expect(interactiveLayers.at(0)).toEqual(cartodbLayer1);
+      expect(interactiveLayers.at(1)).toEqual(cartodbLayer2);
+    });
+
+    it('should return torque layers', function () {
+      map = new Map();
+      var torqueLayer = new TorqueLayer();
+
+      var layerGroup = new CartoDBLayerGroupNamed(null, {
+        layers: [torqueLayer]
+      });
+
+      map.layers.reset([layerGroup]);
+
+      var interactiveLayers = map.getInteractiveLayers();
+      expect(interactiveLayers.size()).toEqual(1);
+      expect(interactiveLayers.at(0)).toEqual(torqueLayer);
+    });
+  });
+
+  describe('.getLayerGroup', function () {
+    it('should NOT return the layer group', function () {
+      map = new Map();
+
+      expect(map.getLayerGroup()).toBeUndefined();
+
+      var torqueLayer = new TorqueLayer();
+      map.layers.reset([torqueLayer]);
+
+      expect(map.getLayerGroup()).toBeUndefined();
+    });
+
+    it('should return a CartoDBLayerGroupAnonymous layergroup', function () {
+      map = new Map();
+      var cartodbLayer1 = new CartoDBLayer();
+      var cartodbLayer2 = new CartoDBLayer();
+
+      var layerGroup = new CartoDBLayerGroupAnonymous(null, {
+        layers: [cartodbLayer1, cartodbLayer2]
+      });
+
+      map.layers.reset([layerGroup]);
+
+      expect(map.getLayerGroup()).toEqual(layerGroup);
+    });
+
+    it('should return a CartoDBLayerGroupNamed layergroup', function () {
+      map = new Map();
+      var cartodbLayer1 = new CartoDBLayer();
+      var cartodbLayer2 = new CartoDBLayer();
+
+      var layerGroup = new CartoDBLayerGroupNamed(null, {
+        layers: [cartodbLayer1, cartodbLayer2]
+      });
+
+      map.layers.reset([layerGroup]);
+
+      expect(map.getLayerGroup()).toEqual(layerGroup);
+    });
+  });
 });

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -164,11 +164,7 @@ describe('core/geo/map', function() {
       map = new Map();
       var torqueLayer = new TorqueLayer();
 
-      var layerGroup = new CartoDBLayerGroupNamed(null, {
-        layers: [torqueLayer]
-      });
-
-      map.layers.reset([layerGroup]);
+      map.layers.reset([torqueLayer]);
 
       var interactiveLayers = map.getInteractiveLayers();
       expect(interactiveLayers.size()).toEqual(1);

--- a/test/spec/windshaft/windshaft-map.spec.js
+++ b/test/spec/windshaft/windshaft-map.spec.js
@@ -61,10 +61,13 @@ describe('windshaft/map', function () {
       view_bounds_ne: []
     });
 
-    this.cartoDBLayerGroup = new Model();
     this.cartoDBLayer1 = new CartoDBLayer({ id: '12345-67890' });
     this.cartoDBLayer2 = new CartoDBLayer({ id: '09876-54321' });
-    this.torqueLayer = new TorqueLayer();
+    this.cartoDBLayerGroup = new Model({
+      type: 'layergroup'
+    });
+    this.cartoDBLayerGroup.layers = new Backbone.Collection([this.cartoDBLayer1, this.cartoDBLayer2]);
+    this.map.layers.reset([this.cartoDBLayerGroup]);
   });
 
   afterEach(function () {
@@ -72,6 +75,9 @@ describe('windshaft/map', function () {
   });
 
   it('should create an instance of the windshaft map and update the URLs of layers and dataviews', function () {
+    var torqueLayer = new TorqueLayer();
+    this.map.layers.reset([this.cartoDBLayerGroup, torqueLayer]);
+
     var dataview = new HistogramDataviewModel({
       id: 'dataviewId',
       type: 'list'
@@ -84,8 +90,6 @@ describe('windshaft/map', function () {
       client: this.client,
       configGenerator: this.configGenerator,
       statTag: 'stat_tag',
-      layerGroup: this.cartoDBLayerGroup,
-      layers: new Backbone.Collection([ this.cartoDBLayer1, this.cartoDBLayer2, this.torqueLayer ]),
       dataviews: this.dataviews,
       map: this.map
     });
@@ -96,7 +100,7 @@ describe('windshaft/map', function () {
     expect(this.cartoDBLayerGroup.get('urls')).toEqual('tileURLs');
 
     // urls of torque layers have been updated too!
-    expect(this.torqueLayer.get('urls')).toEqual('torqueTileURLs');
+    expect(torqueLayer.get('urls')).toEqual('torqueTileURLs');
 
     // url of dataview have been updated
     expect(dataview.url()).toEqual('http://example.com');


### PR DESCRIPTION
Changed the way windshaft-map gets the collection of "interactive" layers and the layergroup so that it's a bit more dynamic. We'd need to keep `map.layers` and `map._interactiveLayers` in sync, but this is a first step.

@viddo what do you think?