### PR TITLE
Fixes google maps API dependency

### DIFF
--- a/grunt/tasks/jasmine.js
+++ b/grunt/tasks/jasmine.js
@@ -34,11 +34,7 @@ module.exports = {
         ],
         options: _.defaults({
           outfile: 'test/SpecRunner-cartodb.html',
-          specs: '<%= config.tmp %>/cartodb-specs.js',
-          vendor: defaultOptions.vendor
-            .concat([
-              'http://maps.googleapis.com/maps/api/js?sensor=false&v=3.12'
-            ])
+          specs: '<%= config.tmp %>/cartodb-specs.js'
         }, defaultOptions)
       },
       'cartodb-src': {

--- a/src/geo/gmaps/gmaps-layer-view-factory.js
+++ b/src/geo/gmaps/gmaps-layer-view-factory.js
@@ -1,7 +1,10 @@
+/* global google */
 var cdb = require('cdb');
 var log = require('cdb.log');
 
 var GMapsLayerViewFactory = function () {};
+
+var constructors = {};
 
 // Only "register" the layer view mappings if Google Maps library is present
 if (typeof (google) !== 'undefined' && typeof (google.maps) !== 'undefined') {
@@ -11,7 +14,7 @@ if (typeof (google) !== 'undefined' && typeof (google.maps) !== 'undefined') {
   var GMapsPlainLayerView = require('./gmaps-plain-layer-view');
   var GMapsCartoDBLayerGroupView = require('./gmaps-cartodb-layer-group-view');
 
-  GMapsLayerViewFactory.prototype._constructors = {
+  constructors = {
     'tiled': GMapsTiledLayerView,
     'wms': LeafletWMSLayerView,
     'plain': GMapsPlainLayerView,
@@ -28,6 +31,8 @@ if (typeof (google) !== 'undefined' && typeof (google.maps) !== 'undefined') {
     }
   };
 }
+
+GMapsLayerViewFactory.prototype._constructors = constructors;
 
 GMapsLayerViewFactory.prototype.createLayerView = function (layerModel, mapModel) {
   var layerType = layerModel.get('type').toLowerCase();

--- a/src/geo/gmaps/gmaps-layer-view-factory.js
+++ b/src/geo/gmaps/gmaps-layer-view-factory.js
@@ -1,29 +1,33 @@
 var cdb = require('cdb');
 var log = require('cdb.log');
-var GMapsBaseLayerView = require('./gmaps-base-layer-view');
-var GMapsTiledLayerView = require('./gmaps-tiled-layer-view');
-var LeafletWMSLayerView = require('../leaflet/leaflet-wms-layer-view');
-var GMapsPlainLayerView = require('./gmaps-plain-layer-view');
-var GMapsCartoDBLayerGroupView = require('./gmaps-cartodb-layer-group-view');
 
 var GMapsLayerViewFactory = function () {};
 
-GMapsLayerViewFactory.prototype._constructors = {
-  'tiled': GMapsTiledLayerView,
-  'wms': LeafletWMSLayerView,
-  'plain': GMapsPlainLayerView,
-  'gmapsbase': GMapsBaseLayerView,
-  'layergroup': GMapsCartoDBLayerGroupView,
-  'namedmap': GMapsCartoDBLayerGroupView,
-  'torque': function (layer, map) {
-    // TODO for now adding this error to be thrown if object is not present, since it's dependency
-    // is not included in the standard bundle
-    if (!cdb.geo.GMapsTorqueLayerView) {
-      throw new Error('torque library must have been loaded for a torque layer to work');
+// Only "register" the layer view mappings if Google Maps library is present
+if (typeof (google) !== 'undefined' && typeof (google.maps) !== 'undefined') {
+  var GMapsBaseLayerView = require('./gmaps-base-layer-view');
+  var GMapsTiledLayerView = require('./gmaps-tiled-layer-view');
+  var LeafletWMSLayerView = require('../leaflet/leaflet-wms-layer-view');
+  var GMapsPlainLayerView = require('./gmaps-plain-layer-view');
+  var GMapsCartoDBLayerGroupView = require('./gmaps-cartodb-layer-group-view');
+
+  GMapsLayerViewFactory.prototype._constructors = {
+    'tiled': GMapsTiledLayerView,
+    'wms': LeafletWMSLayerView,
+    'plain': GMapsPlainLayerView,
+    'gmapsbase': GMapsBaseLayerView,
+    'layergroup': GMapsCartoDBLayerGroupView,
+    'namedmap': GMapsCartoDBLayerGroupView,
+    'torque': function (layer, map) {
+      // TODO for now adding this error to be thrown if object is not present, since it's dependency
+      // is not included in the standard bundle
+      if (!cdb.geo.GMapsTorqueLayerView) {
+        throw new Error('torque library must have been loaded for a torque layer to work');
+      }
+      return new cdb.geo.GMapsTorqueLayerView(layer, map);
     }
-    return new cdb.geo.GMapsTorqueLayerView(layer, map);
-  }
-};
+  };
+}
 
 GMapsLayerViewFactory.prototype.createLayerView = function (layerModel, mapModel) {
   var layerType = layerModel.get('type').toLowerCase();


### PR DESCRIPTION
Some class definitions expected the global "google" object to be defined. This PR introduces a condition in the `gmaps-layer-view-factory` that prevents those files from being required when "google" is not present.

@viddo perhaps there's a better way to do this...