### PR TITLE
Implement dataview.remove

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -140,26 +140,6 @@ module.exports = function(grunt) {
     grunt.config('config.doWatchify', true); // required for browserify to use watch files instead
   });
 
-  grunt.event.once('connect.server.listening', function(host, port) {
-    grunt.log.writeln('Styleguide:');
-    grunt.log.writeln(' - http://' + host + ':' + port + '/themes/styleguide');
-    grunt.log.writeln('');
-
-    grunt.log.writeln('Examples:');
-    grunt.log.writeln(' - http://' + host + ':' + port + '/examples');
-    grunt.log.writeln('');
-
-    // Needs webserver for source-map-support install to work in a non-headless browserify,
-    // Unfortunately can't get source-maps when spec-runner is opened using file://
-    grunt.log.writeln('Jasmine specs available at (one per bundle):');
-    var jasmineConfig = grunt.config('jasmine');
-    for (var name in jasmineConfig) {
-      var specRunnerFilepath = jasmineConfig[name].options.outfile;
-      grunt.task.run('jasmine:' + name + ':build');
-      grunt.log.writeln(' - http://' + host + ':' + port + '/' + specRunnerFilepath);
-    }
-  });
-
   // Define tasks order for each step as if run in isolation,
   // when registering the actual tasks _.uniq is used to discard duplicate tasks from begin run
   var allDeps = [

--- a/grunt/tasks/watch.js
+++ b/grunt/tasks/watch.js
@@ -10,7 +10,7 @@ module.exports = {
         tasks: ['sass', 'concat:themes', 'cssmin:themes'],
         options: {
           spawn: false,
-          livereload: true
+          livereload: 35730
         }
       },
       livereload: {

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -44,7 +44,6 @@ module.exports = Model.extend({
       this.filter.set('dataviewId', this.id);
     }
 
-    this._updateBoundingBox();
     this._initBinds();
   },
 

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -49,18 +49,15 @@ module.exports = Model.extend({
   },
 
   _initBinds: function () {
-    this._windshaftMap.bind('instanceCreated', this._onNewWindshaftMapInstance, this);
+    this.listenTo(this._windshaftMap, 'instanceCreated', this._onNewWindshaftMapInstance);
 
-    this.once('change:url', function () {
-      var self = this;
-      this._fetch(function () {
-        self._onChangeBinds();
-      });
-    }, this);
+    this.listenToOnce(this, 'change:url', function () {
+      this._fetch(this._onChangeBinds.bind(this));
+    });
 
     // Retrigger an event when the filter changes
     if (this.filter) {
-      this.filter.bind('change', this._onFilterChanged, this);
+      this.listenTo(this.filter, 'change', this._onFilterChanged);
     }
   },
 
@@ -89,20 +86,20 @@ module.exports = Model.extend({
 
   _onChangeBinds: function () {
     var BOUNDING_BOX_FILTER_WAIT = 500;
-    this._map.bind('change:center change:zoom', _.debounce(this._onMapBoundsChanged.bind(this), BOUNDING_BOX_FILTER_WAIT));
+    this.listenTo(this._map, 'change:center change:zoom', _.debounce(this._onMapBoundsChanged.bind(this), BOUNDING_BOX_FILTER_WAIT));
 
-    this.bind('change:url', function () {
+    this.listenTo(this, 'change:url', function () {
       if (this._shouldFetchOnURLChange()) {
         this._fetch();
       }
-    }, this);
-    this.bind('change:boundingBox', function () {
+    });
+    this.listenTo(this, 'change:boundingBox', function () {
       if (this._shouldFetchOnBoundingBoxChange()) {
         this._fetch();
       }
-    }, this);
+    });
 
-    this.bind('change:enabled', function (mdl, isEnabled) {
+    this.listenTo(this, 'change:enabled', function (mdl, isEnabled) {
       if (isEnabled) {
         if (mdl.changedAttributes(this._previousAttrs)) {
           this._fetch();
@@ -113,7 +110,7 @@ module.exports = Model.extend({
           boundingBox: this.get('boundingBox')
         };
       }
-    }, this);
+    });
   },
 
   _shouldFetchOnURLChange: function () {
@@ -159,5 +156,13 @@ module.exports = Model.extend({
 
   toJSON: function () {
     throw new Error('toJSON should be defined for each dataview');
+  },
+
+  remove: function () {
+    if (this.filter) {
+      this.filter.remove();
+    }
+    this.trigger('destroy', this);
+    this.stopListening();
   }
 });

--- a/src/dataviews/dataviews-factory.js
+++ b/src/dataviews/dataviews-factory.js
@@ -25,7 +25,7 @@ module.exports = Model.extend({
     this._layersCollection = opts.layersCollection;
   },
 
-  createCategoryDataview: function (layerModel, attrs) {
+  createCategoryModel: function (layerModel, attrs) {
     var categoryFilter = new CategoryFilter({
       // TODO Setting layer-index on filters here is not good, if order change the filters won't work on the expected layer anymore!
       layerIndex: this._indexOf(layerModel)
@@ -40,7 +40,7 @@ module.exports = Model.extend({
     );
   },
 
-  createFormulaDataview: function (layerModel, attrs) {
+  createFormulaModel: function (layerModel, attrs) {
     return this._newModel(
       new FormulaDataviewModel(attrs, {
         map: this._map,
@@ -50,7 +50,7 @@ module.exports = Model.extend({
     );
   },
 
-  createHistogramDataview: function (layerModel, attrs) {
+  createHistogramModel: function (layerModel, attrs) {
     var rangeFilter = new RangeFilter({
       // TODO Setting layer-index on filters here is not good, if order change the filters won't work on the expected layer anymore!
       layerIndex: this._indexOf(layerModel)
@@ -65,7 +65,7 @@ module.exports = Model.extend({
     );
   },
 
-  createListDataview: function (layerModel, attrs) {
+  createListModel: function (layerModel, attrs) {
     return this._newModel(
       new ListDataviewModel(attrs, {
         map: this._map,

--- a/src/windshaft/filters/base.js
+++ b/src/windshaft/filters/base.js
@@ -1,11 +1,17 @@
 var Model = require('../../core/model');
 
 module.exports = Model.extend({
+
   isEmpty: function () {
     throw new Error('Filters must implement the .isEmpty method');
   },
 
   toJSON: function () {
     throw new Error('Filters must implement the .toJSON method');
+  },
+
+  remove: function () {
+    this.trigger('destroy', this);
+    this.stopListening();
   }
 });

--- a/src/windshaft/filters/category.js
+++ b/src/windshaft/filters/category.js
@@ -3,10 +3,10 @@ var Backbone = require('backbone');
 var WindshaftFilterBase = require('./base');
 
 /**
- *  Filter used by the category dataview
- *
+ * Filter used by the category dataview
  */
 module.exports = WindshaftFilterBase.extend({
+
   defaults: {
     rejectAll: false
   },
@@ -18,12 +18,12 @@ module.exports = WindshaftFilterBase.extend({
   },
 
   _initBinds: function () {
-    this.rejectedCategories.bind('add remove', function () {
+    this.listenTo(this.rejectedCategories, 'add remove', function () {
       this.set('rejectAll', false);
-    }, this);
-    this.acceptedCategories.bind('add remove', function () {
+    });
+    this.listenTo(this.acceptedCategories, 'add remove', function () {
       this.set('rejectAll', false);
-    }, this);
+    });
   },
 
   isEmpty: function () {

--- a/src/windshaft/filters/range.js
+++ b/src/windshaft/filters/range.js
@@ -2,6 +2,7 @@ var _ = require('underscore');
 var WindshaftFilterBase = require('./base');
 
 module.exports = WindshaftFilterBase.extend({
+
   isEmpty: function () {
     return _.isUndefined(this.get('min')) && _.isUndefined(this.get('max'));
   },

--- a/test/spec/dataviews/category-dataview-model.spec.js
+++ b/test/spec/dataviews/category-dataview-model.spec.js
@@ -50,7 +50,6 @@ describe('dataviews/category-dataview-model', function () {
 
     describe('boundingBox', function () {
       it('should set search boundingBox when it changes', function () {
-        expect(this.model._searchModel.get('boundingBox')).toBe('2,1,4,3');
         this.model.set('boundingBox', 'hey');
         expect(this.model._searchModel.get('boundingBox')).toBe('hey');
       });

--- a/test/spec/dataviews/dataviews-collection.spec.js
+++ b/test/spec/dataviews/dataviews-collection.spec.js
@@ -1,0 +1,22 @@
+var DataviewsCollection = require('../../../src/dataviews/dataviews-collection');
+var DataviewModel = require('../../../src/dataviews/dataview-model-base');
+
+describe('dataviews/dataview-collection', function () {
+  beforeEach(function () {
+    this.collection = new DataviewsCollection();
+  });
+
+  it('should remove item when removed', function () {
+    var map = jasmine.createSpyObj('map', ['getViewBounds', 'off']);
+    map.getViewBounds.and.returnValue([[0, 0], [0, 0]]);
+    var windshaftMap = jasmine.createSpyObj('WindshaftMap', ['off']);
+    var dataviewModel = new DataviewModel(null, {
+      map: map,
+      windshaftMap: windshaftMap
+    });
+    this.collection.add(dataviewModel);
+    expect(this.collection.length).toEqual(1);
+    this.collection.first().remove();
+    expect(this.collection.length).toEqual(0);
+  });
+});

--- a/test/spec/dataviews/dataviews-factory.spec.js
+++ b/test/spec/dataviews/dataviews-factory.spec.js
@@ -15,9 +15,9 @@ describe('dataviews/dataviews-factory', function () {
 
   it('should create the factory as expected', function () {
     expect(this.factory).toBeDefined();
-    expect(this.factory.createCategoryDataview).toEqual(jasmine.any(Function));
-    expect(this.factory.createFormulaDataview).toEqual(jasmine.any(Function));
-    expect(this.factory.createHistogramDataview).toEqual(jasmine.any(Function));
-    expect(this.factory.createListDataview).toEqual(jasmine.any(Function));
+    expect(this.factory.createCategoryModel).toEqual(jasmine.any(Function));
+    expect(this.factory.createFormulaModel).toEqual(jasmine.any(Function));
+    expect(this.factory.createHistogramModel).toEqual(jasmine.any(Function));
+    expect(this.factory.createListModel).toEqual(jasmine.any(Function));
   });
 });

--- a/test/spec/windshaft/filters/base.spec.js
+++ b/test/spec/windshaft/filters/base.spec.js
@@ -1,0 +1,26 @@
+var FilterBase = require('../../../../src/windshaft/filters/base');
+
+describe('windshaft/filters/base', function () {
+  beforeEach(function () {
+    this.filter = new FilterBase();
+    this.filter.toJSON = jasmine.createSpy('toJSON').and.returnValue({});
+    this.filter.isEmpty = jasmine.createSpy('isEmpty').and.returnValue(false);
+  });
+
+  describe('.remove', function () {
+    beforeEach(function () {
+      this.removeSpy = jasmine.createSpy('remove');
+      this.filter.on('destroy', this.removeSpy);
+      spyOn(this.filter, 'stopListening');
+      this.filter.remove();
+    });
+
+    it('should trigger a destroy event', function () {
+      expect(this.removeSpy).toHaveBeenCalledWith(this.filter);
+    });
+
+    it('should stop listening to events', function () {
+      expect(this.filter.stopListening).toHaveBeenCalled();
+    });
+  });
+});

--- a/test/spec/windshaft/filters/collection.spec.js
+++ b/test/spec/windshaft/filters/collection.spec.js
@@ -1,0 +1,15 @@
+var FiltersCollection = require('../../../../src/windshaft/filters/collection');
+var BaseFilter = require('../../../../src/windshaft/filters/base');
+
+describe('windshaft/filters/collection', function () {
+  beforeEach(function () {
+    this.collection = new FiltersCollection();
+  });
+
+  it('should remove item when removed', function () {
+    this.collection.add(new BaseFilter());
+    expect(this.collection.length).toEqual(1);
+    this.collection.first().remove();
+    expect(this.collection.length).toEqual(0);
+  });
+});


### PR DESCRIPTION
Resolves #1024 

Noteworthy:
- Changed to `listenTo` instead, since that allows to remove _all_ event listeners from the own object (even on other objects), upon calling `stopListening`, which comes handy to cleanup after itself.
- Use `destroy` event (in lieu of a `remove event for example) because it removes the model from the parent collection too w/o any additional code.
- Renamed `dataviews.createFoobarDataview` to `dataview.createFoobarModel` to clarify what's returned
- Some cleanup of build stuff (skip console output that's included in the index file)

@alonsogarciapablo can you review? Also, I'm probably missing things… should a removal need updates in other parts of the code base? E.g. Should the WindshaftMap be re-instantiated?