### PR TITLE
Returning suffix and prefix values for Formula and Category dataviews models

### DIFF
--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -16,7 +16,9 @@ module.exports = DataviewModelBase.extend({
   defaults: _.extend(
     {
       enableFilter: true,
-      allCategoryNames: [] // all (new + previously accepted), updated on data fetch (see parse)
+      allCategoryNames: [], // all (new + previously accepted), updated on data fetch (see parse)
+      suffix: '',
+      prefix: ''
     },
     DataviewModelBase.prototype.defaults
   ),
@@ -244,7 +246,9 @@ module.exports = DataviewModelBase.extend({
       options: {
         column: this.get('column'),
         aggregation: this.get('aggregation'),
-        aggregationColumn: this.get('aggregationColumn')
+        aggregationColumn: this.get('aggregationColumn'),
+        suffix: this.get('suffix'),
+        prefix: this.get('prefix')
       }
     };
   }

--- a/src/dataviews/formula-dataview-model.js
+++ b/src/dataviews/formula-dataview-model.js
@@ -19,7 +19,7 @@ module.exports = DataviewModelBase.extend({
     };
   },
 
-  toJSON: function (d) {
+  toJSON: function () {
     return {
       type: 'formula',
       options: {

--- a/src/dataviews/formula-dataview-model.js
+++ b/src/dataviews/formula-dataview-model.js
@@ -24,7 +24,9 @@ module.exports = DataviewModelBase.extend({
       type: 'formula',
       options: {
         column: this.get('column'),
-        operation: this.get('operation')
+        operation: this.get('operation'),
+        suffix: this.get('suffix'),
+        prefix: this.get('prefix')
       }
     };
   }

--- a/test/spec/dataviews/category-dataview-model.spec.js
+++ b/test/spec/dataviews/category-dataview-model.spec.js
@@ -132,6 +132,14 @@ describe('dataviews/category-dataview-model', function () {
     expect(this.model._fetch.calls.count()).toEqual(1);
   });
 
+  describe('toJSON', function () {
+    it('should return suffix and prefix values', function () {
+      var data = this.model.toJSON();
+      expect(data.suffix).toBeDefined();
+      expect(data.prefix).toBeDefined();
+    });
+  });
+
   describe('parseData', function () {
     it('should provide data as an object', function () {
       _parseData(this.model, _generateData(10));

--- a/test/spec/dataviews/category-dataview-model.spec.js
+++ b/test/spec/dataviews/category-dataview-model.spec.js
@@ -134,9 +134,10 @@ describe('dataviews/category-dataview-model', function () {
 
   describe('toJSON', function () {
     it('should return suffix and prefix values', function () {
+      this.model.set('suffix', '$');
       var data = this.model.toJSON();
-      expect(data.suffix).toBeDefined();
-      expect(data.prefix).toBeDefined();
+      expect(data.options.suffix).toBe('$');
+      expect(data.options.prefix).toBeDefined();
     });
   });
 


### PR DESCRIPTION
Trying to fix https://github.com/CartoDB/deep-insights.js/issues/105, @javierarce and I realized that dataviewModel(s) are not returning ```suffix``` and ```prefix``` attributes when ```toJSON``` is called.

CR: @javierarce
cc @viddo @alonsogarciapablo 