### PR TITLE
Clarify dataview models' default attrs names

### DIFF
--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -10,8 +10,8 @@ module.exports = Model.extend({
     url: '',
     data: [],
     columns: [],
-    syncData: true,
-    syncBoundingBox: true,
+    sync_on_source_change: true,
+    sync_on_bbox_change: true,
     enabled: true
   },
 
@@ -133,11 +133,11 @@ module.exports = Model.extend({
   },
 
   _shouldFetchOnURLChange: function () {
-    return this.get('syncData') && this.get('enabled');
+    return this.get('sync_on_source_change') && this.get('enabled');
   },
 
   _shouldFetchOnBoundingBoxChange: function () {
-    return this.get('enabled') && this.get('syncBoundingBox');
+    return this.get('enabled') && this.get('sync_on_bbox_change');
   },
 
   _fetch: function (callback) {

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -10,7 +10,7 @@ module.exports = Model.extend({
     url: '',
     data: [],
     columns: [],
-    sync_on_source_change: true,
+    sync_on_data_change: true,
     sync_on_bbox_change: true,
     enabled: true
   },
@@ -133,7 +133,7 @@ module.exports = Model.extend({
   },
 
   _shouldFetchOnURLChange: function () {
-    return this.get('sync_on_source_change') && this.get('enabled');
+    return this.get('sync_on_data_change') && this.get('enabled');
   },
 
   _shouldFetchOnBoundingBoxChange: function () {

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -54,8 +54,8 @@ describe('dataviews/dataview-model-base', function () {
       this.model.set('url', 'newurl');
     });
 
-    it('should not fetch new data when url changes and sync_on_source_change is disabled', function () {
-      this.model.set('sync_on_source_change', false);
+    it('should not fetch new data when url changes and sync_on_data_change is disabled', function () {
+      this.model.set('sync_on_data_change', false);
       spyOn(this.model, 'fetch');
       this.model.trigger('change:url', this.model);
       expect(this.model.fetch).not.toHaveBeenCalled();

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -54,8 +54,8 @@ describe('dataviews/dataview-model-base', function () {
       this.model.set('url', 'newurl');
     });
 
-    it('should not fetch new data when url changes and syncData is disabled', function () {
-      this.model.set('syncData', false);
+    it('should not fetch new data when url changes and sync_on_source_change is disabled', function () {
+      this.model.set('sync_on_source_change', false);
       spyOn(this.model, 'fetch');
       this.model.trigger('change:url', this.model);
       expect(this.model.fetch).not.toHaveBeenCalled();
@@ -69,7 +69,7 @@ describe('dataviews/dataview-model-base', function () {
     });
 
     it('should not fetch new data when bbox changes and bbox is disabled', function () {
-      this.model.set('syncBoundingBox', false);
+      this.model.set('sync_on_bbox_change', false);
       spyOn(this.model, 'fetch');
       this.model.trigger('change:boundingBox', this.model);
       expect(this.model.fetch).not.toHaveBeenCalled();


### PR DESCRIPTION
Changed the until-now-private attrs to snake_case, and changed names to make intentions clearer.
I tried to put names that are semantic to the "outside world", since we'll need to expose/pass these attrs (+`enabled`) from the editor.

@alonsogarciapablo  can you review?