### PR TITLE
Several d3+category fixes

### DIFF
--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -166,7 +166,7 @@ module.exports = DataviewModelBase.extend({
   },
 
   getCount: function () {
-    return this.get('categoriesCount');
+    return this.get('allCategoryNames').length;
   },
 
   isOtherAvailable: function () {

--- a/src/geo/data-providers/geojson/geojson-data-provider.js
+++ b/src/geo/data-providers/geojson/geojson-data-provider.js
@@ -17,16 +17,19 @@ GeoJSONDataProvider.prototype._dataGeneratorsForDataviews = {
   category: function (features, options) {
     var columnName = options.column;
     var numberOfCategories = 5;
-
-    // TODO: There's probably a more efficient way of doing this
-    var groups = _.groupBy(features, function (feature) { return feature.properties[columnName]; });
-    var groupCounts = _.map(Object.keys(groups), function (key) { return [key, groups[key].length]; });
-    var sortedGroups = _.sortBy(groupCounts, function (group) { return group[1]; }).reverse();
+    var sortedGroups = this.filter.getColumnValues(columnName);
+    var lastCat = {
+      category: 'Other',
+      value: sortedGroups.slice(6).reduce(function (p, c) {
+        return p+c.value
+      }, 0),
+      agg: true
+    }
 
     // TODO: Calculate harcoded values
     var data = {
       categories: [],
-      categoriesCount: 3,
+      categoriesCount: sortedGroups.length,
       count: 7446,
       max: 4580,
       min: 106,
@@ -36,12 +39,12 @@ GeoJSONDataProvider.prototype._dataGeneratorsForDataviews = {
 
     _.each(sortedGroups.slice(0, numberOfCategories), function (category) {
       data.categories.push({
-        category: category[0],
-        value: category[1],
+        category: category.key,
+        value: category.value,
         agg: false
       });
     });
-
+    data.categories.push(lastCat)
     return data;
   },
 

--- a/src/geo/data-providers/geojson/geojson-data-provider.js
+++ b/src/geo/data-providers/geojson/geojson-data-provider.js
@@ -20,7 +20,7 @@ GeoJSONDataProvider.prototype._dataGeneratorsForDataviews = {
     var sortedGroups = this.filter.getColumnValues(columnName);
     var lastCat = {
       category: 'Other',
-      value: sortedGroups.slice(6).reduce(function (p, c) {
+      value: sortedGroups.slice(numberOfCategories).reduce(function (p, c) {
         return p + c.value
       }, 0),
       agg: true

--- a/src/geo/data-providers/geojson/geojson-data-provider.js
+++ b/src/geo/data-providers/geojson/geojson-data-provider.js
@@ -78,7 +78,7 @@ GeoJSONDataProvider.prototype._dataGeneratorsForDataviews = {
 };
 
 GeoJSONDataProvider.prototype.generateDataForDataview = function (dataview, features) {
-  var generateData = this._dataGeneratorsForDataviews[dataview.get('type')];
+  var generateData = this._dataGeneratorsForDataviews[dataview.get('type')].bind(this._vectorLayerView.renderers[this._layerIndex]);
   if (!generateData) {
     throw new Error("Couldn't generate data for dataview of type: " + dataview.get('type'));
   }

--- a/src/geo/data-providers/geojson/geojson-data-provider.js
+++ b/src/geo/data-providers/geojson/geojson-data-provider.js
@@ -21,18 +21,18 @@ GeoJSONDataProvider.prototype._dataGeneratorsForDataviews = {
     var lastCat = {
       category: 'Other',
       value: sortedGroups.slice(6).reduce(function (p, c) {
-        return p+c.value
+        return p + c.value
       }, 0),
       agg: true
-    }
+    };
 
     // TODO: Calculate harcoded values
     var data = {
       categories: [],
       categoriesCount: sortedGroups.length,
-      count: 7446,
-      max: 4580,
-      min: 106,
+      count: this.filter.dimensions[columnName].groupAll().value(),
+      max: sortedGroups[0].value,
+      min: sortedGroups[sortedGroups.length - 1].value,
       nulls: 0,
       type: 'aggregation'
     };


### PR DESCRIPTION
* Uses grouping methods from crossfilter
* Fills in max, min and count values that were previously hardcoded
* Adds **Other** trailing category

Requires merge of https://github.com/CartoDB/d3.cartodb/pull/94
@alonsogarciapablo 
![cat](https://cloud.githubusercontent.com/assets/3707222/12888777/e4e9edb2-ce7b-11e5-966f-e6e4c045deb5.gif)
