### PR TITLE
Reload map on prefix+suffix change on category dataview

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var jasmineCfg = require('./grunt/tasks/jasmine');
 
 /**
  *  Grunfile runner file for CartoDB.js
@@ -61,7 +62,7 @@ module.exports = function(grunt) {
     cssmin: require('./grunt/tasks/cssmin').task(),
     imagemin: require('./grunt/tasks/imagemin').task(),
     jshint: require('./grunt/tasks/jshint').task(),
-    jasmine: require('./grunt/tasks/jasmine').task()
+    jasmine: jasmineCfg
   });
 
   grunt.registerTask('release', [
@@ -140,6 +141,14 @@ module.exports = function(grunt) {
     grunt.config('config.doWatchify', true); // required for browserify to use watch files instead
   });
 
+  grunt.registerTask('build-jasmine-specrunners', _
+    .chain(jasmineCfg)
+    .keys()
+    .map(function (name) {
+      return ['jasmine', name, 'build'].join(':');
+    })
+    .value());
+
   // Define tasks order for each step as if run in isolation,
   // when registering the actual tasks _.uniq is used to discard duplicate tasks from begin run
   var allDeps = [
@@ -158,6 +167,7 @@ module.exports = function(grunt) {
   var js = allDeps
     .concat([
       'browserify',
+      'build-jasmine-specrunners'
     ]);
   var buildJS = allDeps
     .concat(js)

--- a/grunt/tasks/jasmine.js
+++ b/grunt/tasks/jasmine.js
@@ -25,59 +25,54 @@ var requiredVendorForModuleLoad = [
  * Load order: vendor, helpers, source, specs,
  */
 module.exports = {
-  task: function() {
-    return {
+  cartodb: {
+    src: [
+      'dist/cartodb.uncompressed.js'
+    ],
+    options: _.defaults({
+      outfile: 'test/SpecRunner-cartodb.html',
+      specs: '<%= config.tmp %>/cartodb-specs.js'
+    }, defaultOptions)
+  },
+  'cartodb-src': {
+    src: [], // actual src files are require'd in the *.spec.js files
+    options: _.defaults({
+      outfile: 'test/SpecRunner-src.html',
+      specs: '<%= config.tmp %>/src-specs.js',
+      vendor: defaultOptions.vendor
+        .concat([
+          'http://maps.googleapis.com/maps/api/js?sensor=false&v=3.12'
+        ])
+        .concat(requiredVendorForModuleLoad)
+    }, defaultOptions)
+  },
 
-      cartodb: {
-        src: [
-          'dist/cartodb.uncompressed.js'
-        ],
-        options: _.defaults({
-          outfile: 'test/SpecRunner-cartodb.html',
-          specs: '<%= config.tmp %>/cartodb-specs.js'
-        }, defaultOptions)
-      },
-      'cartodb-src': {
-        src: [], // actual src files are require'd in the *.spec.js files
-        options: _.defaults({
-          outfile: 'test/SpecRunner-src.html',
-          specs: '<%= config.tmp %>/src-specs.js',
-          vendor: defaultOptions.vendor
-            .concat([
-              'http://maps.googleapis.com/maps/api/js?sensor=false&v=3.12'
-            ])
-            .concat(requiredVendorForModuleLoad)
-        }, defaultOptions)
-      },
-
-      'cartodb.mod.torque': {
-        src: [], // actual src files are require'd in the *.spec.js files
-        options: _.defaults({
-          outfile: 'test/SpecRunner-cartodb.mod.torque.html',
-          specs: '<%= config.tmp %>/cartodb.mod.torque-specs.js',
-          vendor: defaultOptions.vendor
-            .concat([
-              'http://maps.googleapis.com/maps/api/js?sensor=false&v=3.12',
-              'dist/cartodb.uncompressed.js',
-              'dist/cartodb.mod.torque.uncompressed.js'
-            ])
-            .concat(requiredVendorForModuleLoad)
-        }, defaultOptions)
-      },
-      'cartodb.mod.torque-srcSpecs': {
-        src: [], // actual src files are require'd in the *.spec.js files
-        options: _.defaults({
-          outfile: 'test/SpecRunner-cartodb.mod.torque-src.html',
-          specs: '<%= config.tmp %>/cartodb.mod.torque-srcSpecs.js',
-          vendor: defaultOptions.vendor
-            .concat([
-              'http://maps.googleapis.com/maps/api/js?sensor=false&v=3.12',
-              'dist/cartodb.uncompressed.js',
-              'dist/cartodb.mod.torque.uncompressed.js'
-            ])
-            .concat(requiredVendorForModuleLoad)
-        }, defaultOptions)
-      }
-    }
+  'cartodb.mod.torque': {
+    src: [], // actual src files are require'd in the *.spec.js files
+    options: _.defaults({
+      outfile: 'test/SpecRunner-cartodb.mod.torque.html',
+      specs: '<%= config.tmp %>/cartodb.mod.torque-specs.js',
+      vendor: defaultOptions.vendor
+        .concat([
+          'http://maps.googleapis.com/maps/api/js?sensor=false&v=3.12',
+          'dist/cartodb.uncompressed.js',
+          'dist/cartodb.mod.torque.uncompressed.js'
+        ])
+        .concat(requiredVendorForModuleLoad)
+    }, defaultOptions)
+  },
+  'cartodb.mod.torque-srcSpecs': {
+    src: [], // actual src files are require'd in the *.spec.js files
+    options: _.defaults({
+      outfile: 'test/SpecRunner-cartodb.mod.torque-src.html',
+      specs: '<%= config.tmp %>/cartodb.mod.torque-srcSpecs.js',
+      vendor: defaultOptions.vendor
+        .concat([
+          'http://maps.googleapis.com/maps/api/js?sensor=false&v=3.12',
+          'dist/cartodb.uncompressed.js',
+          'dist/cartodb.mod.torque.uncompressed.js'
+        ])
+        .concat(requiredVendorForModuleLoad)
+    }, defaultOptions)
   }
 }

--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -15,6 +15,7 @@ module.exports = DataviewModelBase.extend({
 
   defaults: _.extend(
     {
+      type: 'aggregation',
       enableFilter: true,
       allCategoryNames: [], // all (new + previously accepted), updated on data fetch (see parse)
       prefix: '',
@@ -258,5 +259,16 @@ module.exports = DataviewModelBase.extend({
       }
     };
   }
+},
 
-});
+  // Class props
+  {
+    ATTRS_NAMES: DataviewModelBase.ATTRS_NAMES.concat([
+      'column',
+      'aggregation',
+      'aggregation_column',
+      'prefix',
+      'suffix'
+    ])
+  }
+);

--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -17,9 +17,7 @@ module.exports = DataviewModelBase.extend({
     {
       type: 'aggregation',
       enableFilter: true,
-      allCategoryNames: [], // all (new + previously accepted), updated on data fetch (see parse)
-      prefix: '',
-      suffix: ''
+      allCategoryNames: [] // all (new + previously accepted), updated on data fetch (see parse)
     },
     DataviewModelBase.prototype.defaults
   ),
@@ -45,7 +43,6 @@ module.exports = DataviewModelBase.extend({
     this._searchModel = new SearchModel();
 
     this.on('change:column change:aggregation change:aggregation_column', this._reloadMap, this);
-    this.on('change:prefix change:suffix', this._reloadMap, this);
   },
 
   // Set any needed parameter when they have changed in this model
@@ -252,10 +249,7 @@ module.exports = DataviewModelBase.extend({
         aggregation: this.get('aggregation'),
 
         // TODO server-side is using camelCased attr name, update once fixed
-        aggregationColumn: this.get('aggregation_column'),
-
-        prefix: this.get('prefix'),
-        suffix: this.get('suffix')
+        aggregationColumn: this.get('aggregation_column')
       }
     };
   }
@@ -266,9 +260,7 @@ module.exports = DataviewModelBase.extend({
     ATTRS_NAMES: DataviewModelBase.ATTRS_NAMES.concat([
       'column',
       'aggregation',
-      'aggregation_column',
-      'prefix',
-      'suffix'
+      'aggregation_column'
     ])
   }
 );

--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -17,8 +17,8 @@ module.exports = DataviewModelBase.extend({
     {
       enableFilter: true,
       allCategoryNames: [], // all (new + previously accepted), updated on data fetch (see parse)
-      suffix: '',
-      prefix: ''
+      prefix: '',
+      suffix: ''
     },
     DataviewModelBase.prototype.defaults
   ),
@@ -44,6 +44,7 @@ module.exports = DataviewModelBase.extend({
     this._searchModel = new SearchModel();
 
     this.on('change:column change:aggregation change:aggregation_column', this._reloadMap, this);
+    this.on('change:prefix change:suffix', this._reloadMap, this);
   },
 
   // Set any needed parameter when they have changed in this model
@@ -248,9 +249,12 @@ module.exports = DataviewModelBase.extend({
       options: {
         column: this.get('column'),
         aggregation: this.get('aggregation'),
-        aggregation_column: this.get('aggregation_column'),
-        suffix: this.get('suffix'),
-        prefix: this.get('prefix')
+
+        // TODO server-side is using camelCased attr name, update once fixed
+        aggregationColumn: this.get('aggregation_column'),
+
+        prefix: this.get('prefix'),
+        suffix: this.get('suffix')
       }
     };
   }

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -9,7 +9,6 @@ module.exports = Model.extend({
   defaults: {
     url: '',
     data: [],
-    columns: [],
     sync_on_data_change: true,
     sync_on_bbox_change: true,
     enabled: true
@@ -178,4 +177,14 @@ module.exports = Model.extend({
     this.trigger('destroy', this);
     this.stopListening();
   }
-});
+},
+
+  // Class props
+  {
+    ATTRS_NAMES: [
+      'sync_on_data_change',
+      'sync_on_bbox_change',
+      'enabled'
+    ]
+  }
+);

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -153,6 +153,11 @@ module.exports = Model.extend({
     this._fetch();
   },
 
+  update: function (attrs) {
+    attrs = _.pick(attrs, this.constructor.ATTRS_NAMES);
+    this.set(attrs);
+  },
+
   getData: function () {
     return this.get('data');
   },

--- a/src/dataviews/dataviews-factory.js
+++ b/src/dataviews/dataviews-factory.js
@@ -1,5 +1,5 @@
+var _ = require('underscore');
 var Model = require('../core/model');
-// var DataviewsCollection = require('./dataviews-collection');
 var CategoryFilter = require('../windshaft/filters/category');
 var RangeFilter = require('../windshaft/filters/range');
 var CategorDataviewModel = require('./category-dataview-model');
@@ -26,10 +26,16 @@ module.exports = Model.extend({
   },
 
   createCategoryModel: function (layerModel, attrs) {
+    _checkProperties(attrs, ['column']);
     var categoryFilter = new CategoryFilter({
       // TODO Setting layer-index on filters here is not good, if order change the filters won't work on the expected layer anymore!
       layerIndex: this._indexOf(layerModel)
     });
+
+    attrs = _.pick(attrs, CategorDataviewModel.ATTRS_NAMES);
+    attrs.aggregation = attrs.aggregation || 'count';
+    attrs.aggregation_column = attrs.aggregation_column || attrs.column;
+
     return this._newModel(
       new CategorDataviewModel(attrs, {
         map: this._map,
@@ -41,6 +47,9 @@ module.exports = Model.extend({
   },
 
   createFormulaModel: function (layerModel, attrs) {
+    _checkProperties(attrs, ['column', 'operation']);
+    attrs = _.pick(attrs, FormulaDataviewModel.ATTRS_NAMES);
+
     return this._newModel(
       new FormulaDataviewModel(attrs, {
         map: this._map,
@@ -51,10 +60,15 @@ module.exports = Model.extend({
   },
 
   createHistogramModel: function (layerModel, attrs) {
+    _checkProperties(attrs, ['column']);
+
     var rangeFilter = new RangeFilter({
       // TODO Setting layer-index on filters here is not good, if order change the filters won't work on the expected layer anymore!
       layerIndex: this._indexOf(layerModel)
     });
+
+    attrs = _.pick(attrs, HistogramDataviewModel.ATTRS_NAMES);
+
     return this._newModel(
       new HistogramDataviewModel(attrs, {
         map: this._map,
@@ -66,6 +80,9 @@ module.exports = Model.extend({
   },
 
   createListModel: function (layerModel, attrs) {
+    _checkProperties(attrs, ['columns']);
+    attrs = _.pick(attrs, ListDataviewModel.ATTRS_NAMES);
+
     return this._newModel(
       new ListDataviewModel(attrs, {
         map: this._map,
@@ -95,3 +112,11 @@ module.exports = Model.extend({
     }
   }
 });
+
+function _checkProperties (obj, propertiesArray) {
+  _.each(propertiesArray, function (prop) {
+    if (obj[prop] === undefined) {
+      throw new Error(prop + ' is required');
+    }
+  });
+}

--- a/src/dataviews/formula-dataview-model.js
+++ b/src/dataviews/formula-dataview-model.js
@@ -5,16 +5,14 @@ module.exports = DataviewModelBase.extend({
   defaults: _.extend(
     {
       type: 'formula',
-      data: '',
-      suffix: '',
-      prefix: ''
+      data: ''
     },
     DataviewModelBase.prototype.defaults
   ),
 
   initialize: function () {
     DataviewModelBase.prototype.initialize.apply(this, arguments);
-    this.on('change:column change:operation change:prefix change:suffix', this._reloadMap, this);
+    this.on('change:column change:operation', this._reloadMap, this);
   },
 
   parse: function (r) {
@@ -29,9 +27,7 @@ module.exports = DataviewModelBase.extend({
       type: 'formula',
       options: {
         column: this.get('column'),
-        operation: this.get('operation'),
-        suffix: this.get('suffix'),
-        prefix: this.get('prefix')
+        operation: this.get('operation')
       }
     };
   }
@@ -41,9 +37,7 @@ module.exports = DataviewModelBase.extend({
   {
     ATTRS_NAMES: DataviewModelBase.ATTRS_NAMES.concat([
       'column',
-      'operation',
-      'prefix',
-      'suffix'
+      'operation'
     ])
   }
 );

--- a/src/dataviews/formula-dataview-model.js
+++ b/src/dataviews/formula-dataview-model.js
@@ -4,6 +4,7 @@ var DataviewModelBase = require('./dataview-model-base');
 module.exports = DataviewModelBase.extend({
   defaults: _.extend(
     {
+      type: 'formula',
       data: '',
       suffix: '',
       prefix: ''
@@ -34,5 +35,15 @@ module.exports = DataviewModelBase.extend({
       }
     };
   }
+},
 
-});
+  // Class props
+  {
+    ATTRS_NAMES: DataviewModelBase.ATTRS_NAMES.concat([
+      'column',
+      'operation',
+      'prefix',
+      'suffix'
+    ])
+  }
+);

--- a/src/dataviews/histogram-dataview-model.js
+++ b/src/dataviews/histogram-dataview-model.js
@@ -3,6 +3,15 @@ var Backbone = require('backbone');
 var DataviewModelBase = require('./dataview-model-base');
 
 module.exports = DataviewModelBase.extend({
+
+  defaults: _.extend(
+    {
+      type: 'histogram',
+      bins: 10
+    },
+    DataviewModelBase.prototype.defaults
+  ),
+
   url: function () {
     var params = [];
 
@@ -100,4 +109,16 @@ module.exports = DataviewModelBase.extend({
       }
     }, this);
   }
-});
+},
+
+  // Class props
+  {
+    ATTRS_NAMES: DataviewModelBase.ATTRS_NAMES.concat([
+      'column',
+      'column_type',
+      'bins',
+      'start',
+      'end'
+    ])
+  }
+);

--- a/src/dataviews/list-dataview-model.js
+++ b/src/dataviews/list-dataview-model.js
@@ -1,11 +1,16 @@
+var _ = require('underscore');
 var Backbone = require('backbone');
 var DataviewModelBase = require('./dataview-model-base');
 
 module.exports = DataviewModelBase.extend({
-  options: {
-    page: 0,
-    per_page: 100
-  },
+
+  defaults: _.extend(
+    {
+      type: 'list',
+      columns: []
+    },
+    DataviewModelBase.prototype.defaults
+  ),
 
   initialize: function (attrs, opts) {
     DataviewModelBase.prototype.initialize.call(this, attrs, opts);
@@ -37,4 +42,12 @@ module.exports = DataviewModelBase.extend({
       }
     };
   }
-});
+},
+
+  // Class props
+  {
+    ATTRS_NAMES: DataviewModelBase.ATTRS_NAMES.concat([
+      'columns'
+    ])
+  }
+);

--- a/test/spec/dataviews/category-dataview-model.spec.js
+++ b/test/spec/dataviews/category-dataview-model.spec.js
@@ -208,6 +208,25 @@ describe('dataviews/category-dataview-model', function () {
       expect(areNamesString).toBeTruthy();
     });
   });
+
+  describe('.update', function () {
+    beforeEach(function () {
+      expect(this.model.get('foo')).toBeUndefined();
+      expect(this.model.get('sync_on_bbox_change')).toBe(true);
+      expect(this.model.get('aggregation')).not.toEqual('sum');
+      this.model.update({
+        sync_on_bbox_change: false,
+        aggregation: 'sum',
+        foo: 'bar'
+      });
+    });
+
+    it('should allow to set attrs but only the defined ones', function () {
+      expect(this.model.get('sync_on_bbox_change')).toBe(false);
+      expect(this.model.get('aggregation')).toEqual('sum');
+      expect(this.model.get('foo')).toBeUndefined();
+    });
+  });
 });
 
 function eventDispatcher (originModel, eventName, triggerName) {

--- a/test/spec/dataviews/category-dataview-model.spec.js
+++ b/test/spec/dataviews/category-dataview-model.spec.js
@@ -146,29 +146,6 @@ describe('dataviews/category-dataview-model', function () {
     expect(this.model._fetch.calls.count()).toEqual(1);
   });
 
-  describe('parseData', function () {
-    it('should provide data as an object', function () {
-      _parseData(this.model, _generateData(10));
-      var data = this.model.get('data');
-      expect(data).toBeDefined();
-      expect(data.length).toBe(10);
-    });
-
-    it('should complete data with accepted items (if they are not present already) when has ownFilter set', function () {
-      this.model.set('ownFilter', true);
-      this.model.filter.accept(['9', '10', '11']);
-      _parseData(this.model, _generateData(8));
-      var data = this.model.get('data');
-      expect(data.length).toBe(11);
-
-      this.model.filter.accept(['2']);
-      // The '2' should not be repeated in the data array
-      _parseData(this.model, _generateData(8));
-      data = this.model.get('data');
-      expect(data.length).toBe(11);
-    });
-  });
-
   describe('.parse', function () {
     it('should change internal data collection when parse is called', function () {
       var resetSpy = jasmine.createSpy('reset');

--- a/test/spec/dataviews/category-dataview-model.spec.js
+++ b/test/spec/dataviews/category-dataview-model.spec.js
@@ -27,6 +27,14 @@ describe('dataviews/category-dataview-model', function () {
     this.map.reload.calls.reset();
     this.model.set('aggregation_column', 'other');
     expect(this.map.reload).toHaveBeenCalled();
+
+    this.map.reload.calls.reset();
+    this.model.set('prefix', '$');
+    expect(this.map.reload).toHaveBeenCalled();
+
+    this.map.reload.calls.reset();
+    this.model.set('suffix', 'k');
+    expect(this.map.reload).toHaveBeenCalled();
   });
 
   it('should define several internal models/collections', function () {

--- a/test/spec/dataviews/category-dataview-model.spec.js
+++ b/test/spec/dataviews/category-dataview-model.spec.js
@@ -27,14 +27,6 @@ describe('dataviews/category-dataview-model', function () {
     this.map.reload.calls.reset();
     this.model.set('aggregation_column', 'other');
     expect(this.map.reload).toHaveBeenCalled();
-
-    this.map.reload.calls.reset();
-    this.model.set('prefix', '$');
-    expect(this.map.reload).toHaveBeenCalled();
-
-    this.map.reload.calls.reset();
-    this.model.set('suffix', 'k');
-    expect(this.map.reload).toHaveBeenCalled();
   });
 
   it('should define several internal models/collections', function () {
@@ -152,15 +144,6 @@ describe('dataviews/category-dataview-model', function () {
     this.model.refresh();
     expect(this.model._searchModel.fetch).toHaveBeenCalled();
     expect(this.model._fetch.calls.count()).toEqual(1);
-  });
-
-  describe('toJSON', function () {
-    it('should return suffix and prefix values', function () {
-      this.model.set('suffix', '$');
-      var data = this.model.toJSON();
-      expect(data.options.suffix).toBe('$');
-      expect(data.options.prefix).toBeDefined();
-    });
   });
 
   describe('parseData', function () {

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -186,4 +186,20 @@ describe('dataviews/dataview-model-base', function () {
       expect(this.model.stopListening).toHaveBeenCalled();
     });
   });
+
+  describe('.update', function () {
+    it('should only update the attrs set on ATTRS_NAMES', function () {
+      this.model.update({ foo: 'bar' });
+      expect(this.model.changedAttributes()).toBe(false);
+
+      expect(this.model.get('sync_on_bbox_change')).toBe(true);
+      this.model.update({
+        sync_on_bbox_change: false,
+        foo: 'bar'
+      });
+      expect(this.model.changedAttributes()).toEqual({
+        sync_on_bbox_change: false
+      });
+    });
+  });
 });

--- a/test/spec/dataviews/formula-dataview-model.spec.js
+++ b/test/spec/dataviews/formula-dataview-model.spec.js
@@ -25,16 +25,4 @@ describe('dataviews/formula-dataview-model', function () {
     this.model.set('column', 'other_col');
     expect(this.map.reload).toHaveBeenCalled();
   });
-
-  it('should reload map on prefix change', function () {
-    this.map.reload.calls.reset();
-    this.model.set('prefix', '$');
-    expect(this.map.reload).toHaveBeenCalled();
-  });
-
-  it('should reload map on suffix change', function () {
-    this.map.reload.calls.reset();
-    this.model.set('suffix', '€');
-    expect(this.map.reload).toHaveBeenCalled();
-  });
 });

--- a/test/spec/dataviews/histogram-dataview-model.spec.js
+++ b/test/spec/dataviews/histogram-dataview-model.spec.js
@@ -28,10 +28,10 @@ describe('dataviews/histogram-dataview-model', function () {
 
   it('should submit the bbox if enabled', function () {
     this.model.set({ boundingBox: 1234 });
-    expect(this.model.url()).toBe('');
+    expect(this.model.url()).not.toContain('bbox=');
 
     this.model.set({ submitBBox: true });
-    expect(this.model.url()).toBe('?bbox=1234');
+    expect(this.model.url()).toContain('bbox=1234');
   });
 
   it('should parse the bins', function () {


### PR DESCRIPTION
Related to #1040, some things were missing in previous PRs

Also discovered that aggregation_column need to be translated to camelcased version when sent to Windshaft, added a todo for this for now so we can move fwd

Finally, moved attrs names definition here as well as some minimal validation (presence) of attrs when creating the dataview.

@alonsogarciapablo 
cc @xavijam 