### PR TITLE
Fixes wrong attribute name ownFilter -> enableFilter

### DIFF
--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -210,7 +210,7 @@ module.exports = DataviewModelBase.extend({
       });
     }, this);
 
-    if (this.get('ownFilter')) {
+    if (this.get('enableFilter')) {
       // Add accepted items that are not present in the categories data
       this.filter.acceptedCategories.each(function (mdl) {
         var category = mdl.get('name');

--- a/test/spec/dataviews/category-dataview-model.spec.js
+++ b/test/spec/dataviews/category-dataview-model.spec.js
@@ -199,6 +199,47 @@ describe('dataviews/category-dataview-model', function () {
       });
       expect(areNamesString).toBeTruthy();
     });
+
+    describe('when enableFilter is enabled', function () {
+      it('should add categories that are accepted when they are not present in the new categories', function () {
+        this.model.filter.accept('Madrid');
+
+        // Enable `enableFilter`
+        this.model.set('enableFilter', true);
+
+        _parseData(this.model, _.map(['Barcelona'], function (v) {
+          return {
+            category: v,
+            value: 1
+          };
+        }));
+
+        var categories = this.model.get('data');
+        expect(categories.length).toEqual(2);
+        expect(categories[0].name).toEqual('Barcelona');
+        expect(categories[1].name).toEqual('Madrid');
+      });
+    });
+
+    describe('when enableFilter is disabled', function () {
+      it('should NOT add categories that are accepted when they are not present in the new categories', function () {
+        this.model.filter.accept('Madrid');
+
+        // Disable `enableFilter`
+        this.model.set('enableFilter', false);
+
+        _parseData(this.model, _.map(['Barcelona'], function (v) {
+          return {
+            category: v,
+            value: 1
+          };
+        }));
+
+        var categories = this.model.get('data');
+        expect(categories.length).toEqual(1);
+        expect(categories[0].name).toEqual('Barcelona');
+      });
+    });
   });
 });
 


### PR DESCRIPTION
[This commit](https://github.com/CartoDB/cartodb.js/commit/ff3960e3ec6f93500f454da4b6cd6f3b1b8f1cfc) renamed `ownFilter` to `enableFilter`, but I think we forgot to replace one usage of the attribute. This PR fixes that and adds a couple of tests to test that behaviour.

@viddo can you please review? thx!