### PR TITLE
Removed duplicated binding

### DIFF
--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -69,19 +69,6 @@ module.exports = DataviewModelBase.extend({
       });
     }, this);
 
-    this.bind('change:enabled', function (mdl, isEnabled) {
-      if (isEnabled) {
-        if (mdl.changedAttributes(this._previousAttrs)) {
-          this._fetch();
-        }
-      } else {
-        this._previousAttrs = {
-          url: this.get('url'),
-          boundingBox: this.get('boundingBox')
-        };
-      }
-    }, this);
-
     this._rangeModel.bind('change:totalCount change:categoriesCount', function () {
       this.set({
         totalCount: this._rangeModel.get('totalCount'),


### PR DESCRIPTION
The exact same code that is being removed on this PR is present in [the "super" method](https://github.com/CartoDB/cartodb.js/blob/remove-duplicated-binding/src/dataviews/dataview-model-base.js#L121-L133) so this object was being bound to the "change:enabled" event twice. This was causing the dataview to fetch it's data twice when the dataview was re-enabled.

@viddo it's pretty trivial, but just in case I'm missing something... PTAL. thanks!