### PR TITLE
Fix problem with category filter when accepts a category where it was rejected

### DIFF
--- a/src/windshaft/filters/category.js
+++ b/src/windshaft/filters/category.js
@@ -39,8 +39,7 @@ module.exports = WindshaftFilterBase.extend({
       var acceptedMdls = this.acceptedCategories.where(d);
       if (rejectedMdls.length > 0) {
         this.rejectedCategories.remove(rejectedMdls);
-      }
-      if (!acceptedMdls.length) {
+      } else if (!acceptedMdls.length) {
         this.acceptedCategories.add(d);
       }
     }, this);

--- a/test/spec/windshaft/filters/category.spec.js
+++ b/test/spec/windshaft/filters/category.spec.js
@@ -60,7 +60,7 @@ describe('windshaft/filters/category', function () {
       expect(rejectedCats.size()).toBe(1);
       this.filter.accept(1);
       expect(rejectedCats.size()).toBe(0);
-      expect(acceptedCats.size()).toBe(1);
+      expect(acceptedCats.size()).toBe(0);
     });
 
     it('should not accept a value if it is already present', function () {


### PR DESCRIPTION
If a category was rejected, when it is accepted, we shouldn't include it in the acceptedCategories "array", it should be removed from the rejectedCategories, and that's it :dancer:.

CR: @alonsogarciapablo 