### PR TITLE
Change type to category again

### DIFF
--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -15,7 +15,7 @@ module.exports = DataviewModelBase.extend({
 
   defaults: _.extend(
     {
-      type: 'aggregation',
+      type: 'category',
       enableFilter: true,
       allCategoryNames: [] // all (new + previously accepted), updated on data fetch (see parse)
     },


### PR DESCRIPTION
Was faulty changed in
https://github.com/CartoDB/cartodb.js/commit/2e9b0ea39440d8bca812c0665b76e114a3e54e17#diff-51a09ea5f3b9485ac7865588bdfa1082R18

it was given as `category` from DI: https://github.com/CartoDB/deep-insights.js/pull/138/files#diff-eb62919dbc9c6c8e66ffed48ee679a92L39,
although in the `toJSON` we have the hardcoded `aggregation` value: 
https://github.com/CartoDB/cartodb.js/blob/2e9b0ea39440d8bca812c0665b76e114a3e54e17/src/dataviews/category-dataview-model.js#L249

It should be category as type still since some code depends on it.

@alonsogarciapablo 