### PR TITLE
Fixed `enableFilter` flag on the category dataview model

### DIFF
--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -16,7 +16,7 @@ module.exports = DataviewModelBase.extend({
   defaults: _.extend(
     {
       type: 'category',
-      enableFilter: true,
+      filterEnabled: false,
       allCategoryNames: [] // all (new + previously accepted), updated on data fetch (see parse)
     },
     DataviewModelBase.prototype.defaults
@@ -28,7 +28,7 @@ module.exports = DataviewModelBase.extend({
       params.push('bbox=' + this.get('boundingBox'));
     }
 
-    params.push('own_filter=' + (this.get('enableFilter') ? 0 : 1));
+    params.push('own_filter=' + (this.get('filterEnabled') ? 1 : 0));
 
     return this.get('url') + '?' + params.join('&');
   },
@@ -96,11 +96,11 @@ module.exports = DataviewModelBase.extend({
   },
 
   enableFilter: function () {
-    this.set('enableFilter', true);
+    this.set('filterEnabled', true);
   },
 
   disableFilter: function () {
-    this.set('enableFilter', false);
+    this.set('filterEnabled', false);
   },
 
   // Search model helper methods //
@@ -196,8 +196,8 @@ module.exports = DataviewModelBase.extend({
       });
     }, this);
 
-    // Only accepted categories should appear when enableFilter is false
-    if (!this.get('enableFilter')) {
+    // Only accepted categories should appear when filterEnabled is true
+    if (this.get('filterEnabled')) {
       // Add accepted items that are not present in the categories data
       this.filter.acceptedCategories.each(function (mdl) {
         var category = mdl.get('name');

--- a/test/spec/dataviews/category-dataview-model.spec.js
+++ b/test/spec/dataviews/category-dataview-model.spec.js
@@ -146,7 +146,7 @@ describe('dataviews/category-dataview-model', function () {
     expect(this.model._fetch.calls.count()).toEqual(1);
   });
 
-  fdescribe('.parse', function () {
+  describe('.parse', function () {
     it('should change internal data collection when parse is called', function () {
       var resetSpy = jasmine.createSpy('reset');
       this.model._data.bind('reset', resetSpy);

--- a/test/spec/dataviews/category-dataview-model.spec.js
+++ b/test/spec/dataviews/category-dataview-model.spec.js
@@ -146,7 +146,7 @@ describe('dataviews/category-dataview-model', function () {
     expect(this.model._fetch.calls.count()).toEqual(1);
   });
 
-  describe('.parse', function () {
+  fdescribe('.parse', function () {
     it('should change internal data collection when parse is called', function () {
       var resetSpy = jasmine.createSpy('reset');
       this.model._data.bind('reset', resetSpy);
@@ -168,12 +168,11 @@ describe('dataviews/category-dataview-model', function () {
       expect(areNamesString).toBeTruthy();
     });
 
-    describe('when enableFilter is enabled', function () {
+    describe('when filter is disabled', function () {
       it('should NOT add categories that are accepted when they are not present in the new categories', function () {
         this.model.filter.accept('Madrid');
 
-        // Enable `enableFilter`
-        this.model.set('enableFilter', true);
+        this.model.disableFilter();
 
         _parseData(this.model, _.map(['Barcelona'], function (v) {
           return {
@@ -188,12 +187,11 @@ describe('dataviews/category-dataview-model', function () {
       });
     });
 
-    describe('when enableFilter is disabled', function () {
+    describe('when filter is enabled', function () {
       it('should add categories that are accepted when they are not present in the new categories', function () {
         this.model.filter.accept('Madrid');
 
-        // Disable `enableFilter`
-        this.model.set('enableFilter', false);
+        this.model.enableFilter();
 
         _parseData(this.model, _.map(['Barcelona'], function (v) {
           return {


### PR DESCRIPTION
This "flag" was being used incorrectly so I fixed it. Since `enableFilter` and `disableFilter` are being used from deep-insights.js, I will open a PR on that repo to fix it there too.

@xavijam what do you think?