### PR TITLE
Fixed dataview naming

### DIFF
--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -186,7 +186,6 @@ module.exports = Model.extend({
   {
     ATTRS_NAMES: [
       'type',
-      'column',
       'sync_on_data_change',
       'sync_on_bbox_change',
       'enabled'

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -34,7 +34,7 @@ module.exports = Model.extend({
     }
 
     if (!attrs.id) {
-      this.set('id', attrs.type + '-' + this.cid);
+      this.set('id', this.defaults.type + '-' + this.cid);
     }
 
     this.layer = opts.layer;

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -185,7 +185,7 @@ module.exports = Model.extend({
   // Class props
   {
     ATTRS_NAMES: [
-      'type',
+      'id',
       'sync_on_data_change',
       'sync_on_bbox_change',
       'enabled'

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -185,6 +185,8 @@ module.exports = Model.extend({
   // Class props
   {
     ATTRS_NAMES: [
+      'type',
+      'column',
       'sync_on_data_change',
       'sync_on_bbox_change',
       'enabled'


### PR DESCRIPTION
CR @viddo cc @alonsogarciapablo 

close #1094 

Added `type` attribute to the allowed dataview properties, otherwise the `id` is now well defined and always is named `undefined-xxx`.