### PR TITLE
Close function parenthesis in code example

### DIFF
--- a/doc/core_api.md
+++ b/doc/core_api.md
@@ -52,7 +52,7 @@ cartodb.Tiles.getTiles(layerData, function(tilesUrl, error) {
     return;
   }
   console.log("url template is ", tilesUrl.tiles[0]);
-}
+});
 ```
 
 The `tilesUrl` object contains url template for tiles and interactivity grids:


### PR DESCRIPTION
Add closing parenthesis and semi-colon to make example code work

[Obvious fix]