### PR TITLE
Map instantiation bug

### DIFF
--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -1,6 +1,7 @@
 var _ = require('underscore');
 var Model = require('../core/model');
 var WindshaftFiltersBoundingBoxFilter = require('../windshaft/filters/bounding-box');
+var BOUNDING_BOX_FILTER_WAIT = 500;
 
 /**
  * Default dataview model
@@ -118,7 +119,6 @@ module.exports = Model.extend({
   },
 
   _onChangeBinds: function () {
-    var BOUNDING_BOX_FILTER_WAIT = 500;
     this.listenTo(this._map, 'change:center change:zoom', _.debounce(this._onMapBoundsChanged.bind(this), BOUNDING_BOX_FILTER_WAIT));
 
     this.on('change:url', function () {

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -28,8 +28,6 @@ var Map = Model.extend({
 
     this._windshaftMap = options.windshaftMap;
     this._dataviewsCollection = options.dataviewsCollection;
-
-    this._initBinds();
   },
 
   _initBinds: function () {
@@ -47,10 +45,14 @@ var Map = Model.extend({
     this.layers.bind('change:attribution', this._updateAttributions, this);
 
     if (this._dataviewsCollection) {
-
       // When new dataviews are defined, a new instance of the map needs to be created
       this.listenTo(this._dataviewsCollection, 'add', _.debounce(this._onDataviewAdded.bind(this), 10));
     }
+  },
+
+  instantiateMap: function () {
+    this._initBinds();
+    this.reload();
   },
 
   _onLayersResetted: function () {

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -262,7 +262,6 @@ var Vis = View.extend({
     this._applyOptionsToVizJSON(data, options);
 
     this._dataviewsCollection = new DataviewCollection();
-    this._dataviewsCollection.on('add reset remove', _.debounce(this._invalidateSizeOnDataviewsChanges, 10), this);
 
     // Create the WindhaftClient
 
@@ -424,12 +423,24 @@ var Vis = View.extend({
     });
 
     // Trigger 'done' event
-
     _.defer(function () {
       self.trigger('done', self, self.map.layers);
     });
 
+    if (!options.skipMapInstantiation) {
+      this.instantiateMap();
+    }
+
     return this;
+  },
+
+  instantiateMap: function () {
+    this._dataviewsCollection.on('add reset remove', _.debounce(this._invalidateSizeOnDataviewsChanges, 10), this);
+    this.map.instantiateMap();
+    var self = this;
+    setTimeout(function () {
+      self.mapView.invalidateSize();
+    }, 10);
   },
 
   _newLayerModels: function (vizjson, map) {

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -434,13 +434,13 @@ var Vis = View.extend({
     return this;
   },
 
-  instantiateMap: function () {
+  instantiateMap: function (invalidateMapSize) {
     this._dataviewsCollection.on('add reset remove', _.debounce(this._invalidateSizeOnDataviewsChanges, 10), this);
     this.map.instantiateMap();
-    var self = this;
-    setTimeout(function () {
-      self.mapView.invalidateSize();
-    }, 10);
+
+    if (invalidateMapSize) {
+      this.mapView.invalidateSize();
+    }
   },
 
   _newLayerModels: function (vizjson, map) {

--- a/test/spec/geo/leaflet/leaflet-map-view.spec.js
+++ b/test/spec/geo/leaflet/leaflet-map-view.spec.js
@@ -33,6 +33,7 @@ describe('geo/leaflet/leaflet-map-view', function () {
     map = new Map(null, {
       windshaftMap: fakeWindshaftMap
     });
+    map.instantiateMap();
 
     mapView = new LeafletMapView({
       el: container,

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -8,6 +8,7 @@ describe('core/geo/map', function() {
 
   beforeEach(function() {
     map = new Map();
+    map.instantiateMap();
   });
 
   it("should raise only one change event on setBounds", function() {
@@ -59,6 +60,7 @@ describe('core/geo/map', function() {
 
   it('should update the attributions of the map when layers are reset/added/removed', function() {
     map = new Map();
+    map.instantiateMap();
 
     // Map has the default CartoDB attribution
     expect(map.get('attribution')).toEqual([

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -391,7 +391,7 @@ describe('vis/vis', function () {
       this.vis.instantiateMap();
       expect(this.vis.mapView.invalidateSize).not.toHaveBeenCalled();
       this.vis.instantiateMap(true);
-      expect(this.vis.mapView.invalidateSize).not.toHaveBeenCalled();
+      expect(this.vis.mapView.invalidateSize).toHaveBeenCalled();
     });
   });
 

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -373,24 +373,22 @@ describe('vis/vis', function () {
 
   describe('.instantiateMap', function () {
     it('should instantiate map when skip is false', function () {
-      spyOn(this.vis, 'instantiateMap');
+      spyOn(this.vis, '_instantiateMap');
       this.vis.load(this.mapConfig, {});
-      expect(this.vis.instantiateMap).toHaveBeenCalled();
+      expect(this.vis._instantiateMap).toHaveBeenCalled();
     });
 
     it('should not instantiate map when skip is true', function () {
-      spyOn(this.vis, 'instantiateMap');
+      spyOn(this.vis, '_instantiateMap');
       this.vis.load(this.mapConfig, {
         skipMapInstantiation: true
       });
-      expect(this.vis.instantiateMap).not.toHaveBeenCalled();
+      expect(this.vis._instantiateMap).not.toHaveBeenCalled();
     });
 
-    it('should not invalidate map size if option is not added', function () {
+    it('should not invalidate map size if uses the public method', function () {
       spyOn(this.vis.mapView, 'invalidateSize');
       this.vis.instantiateMap();
-      expect(this.vis.mapView.invalidateSize).not.toHaveBeenCalled();
-      this.vis.instantiateMap(true);
       expect(this.vis.mapView.invalidateSize).toHaveBeenCalled();
     });
   });

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -385,6 +385,14 @@ describe('vis/vis', function () {
       });
       expect(this.vis.instantiateMap).not.toHaveBeenCalled();
     });
+
+    it('should not invalidate map size if option is not added', function () {
+      spyOn(this.vis.mapView, 'invalidateSize');
+      this.vis.instantiateMap();
+      expect(this.vis.mapView.invalidateSize).not.toHaveBeenCalled();
+      this.vis.instantiateMap(true);
+      expect(this.vis.mapView.invalidateSize).not.toHaveBeenCalled();
+    });
   });
 
   describe('dragging option', function () {

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -371,6 +371,22 @@ describe('vis/vis', function () {
     expect(this.vis.map.layers.at(0).get('type')).toEqual('GMapsBase');
   });
 
+  describe('.instantiateMap', function () {
+    it('should instantiate map when skip is false', function () {
+      spyOn(this.vis, 'instantiateMap');
+      this.vis.load(this.mapConfig, {});
+      expect(this.vis.instantiateMap).toHaveBeenCalled();
+    });
+
+    it('should not instantiate map when skip is true', function () {
+      spyOn(this.vis, 'instantiateMap');
+      this.vis.load(this.mapConfig, {
+        skipMapInstantiation: true
+      });
+      expect(this.vis.instantiateMap).not.toHaveBeenCalled();
+    });
+  });
+
   describe('dragging option', function () {
     beforeEach(function () {
       this.mapConfig = {


### PR DESCRIPTION
There used to be several map instantiations when widget dataviews are added to the dataviewsCollection. It generated problems in the map rendering, more requests to the API than expected, etc.

So, from now on, when a dashboard (deep-insights) is created, it will skip the map instantiation until dataviews collection is generated (@viddo idea's, and totally makes sense).

CR: @viddo
cc @javisantana @alonsogarciapablo @javierarce @acanimal 

Deep-insights [PR](https://github.com/CartoDB/deep-insights.js/pull/196).