### PR TITLE
Di 164 hide layers

### DIFF
--- a/src/windshaft/filters/collection.js
+++ b/src/windshaft/filters/collection.js
@@ -2,14 +2,36 @@ var _ = require('underscore');
 var Backbone = require('backbone');
 
 module.exports = Backbone.Collection.extend({
+  initialize: function (filters, layers) {
+    this.layers = layers;
+    Backbone.Collection.prototype.initialize.apply(this, filters);
+  },
+
   toJSON: function () {
     var json = {};
     var activeFilters = this.getActiveFilters();
     if (activeFilters.length) {
       json.layers = [];
       _.each(activeFilters, function (filter) {
-        json.layers.push(filter.toJSON());
+        var index = filter.get('layerIndex');
+        if (index >= 0) {
+          if (json.layers[index]) {
+            _.extend(json.layers[index], filter.toJSON());
+          } else {
+            json.layers[index] = filter.toJSON();
+          }
+        } else {
+          throw new Error('layerIndex missing for filter ' + JSON.stringify(filter.toJSON()));
+        }
       });
+      // fill the holes only if layer is visible, otherwise remove the hole.
+      for (var i = 0; i < json.layers.length; ++i) {
+        if (this.layers[i].isVisible()) {
+          json.layers[i] = json.layers[i] || {};
+        } else {
+          json.layers.splice(i, 1);
+        }
+      }
     }
 
     return json;

--- a/src/windshaft/filters/collection.js
+++ b/src/windshaft/filters/collection.js
@@ -8,17 +8,15 @@ module.exports = Backbone.Collection.extend({
     if (activeFilters.length) {
       json.layers = [];
       _.each(activeFilters, function (filter) {
-        if (!filter.isEmpty()) {
-          var index = filter.get('layerIndex');
-          if (index >= 0) {
-            if (json.layers[index]) {
-              _.extend(json.layers[index], filter.toJSON());
-            } else {
-              json.layers[index] = filter.toJSON();
-            }
+        var index = filter.get('layerIndex');
+        if (index >= 0) {
+          if (json.layers[index]) {
+            _.extend(json.layers[index], filter.toJSON());
           } else {
-            throw new Error('layerIndex missing for filter ' + JSON.stringify(filter.toJSON()));
+            json.layers[index] = filter.toJSON();
           }
+        } else {
+          throw new Error('layerIndex missing for filter ' + JSON.stringify(filter.toJSON()));
         }
       });
       // fill the holes

--- a/src/windshaft/filters/collection.js
+++ b/src/windshaft/filters/collection.js
@@ -8,21 +8,8 @@ module.exports = Backbone.Collection.extend({
     if (activeFilters.length) {
       json.layers = [];
       _.each(activeFilters, function (filter) {
-        var index = filter.get('layerIndex');
-        if (index >= 0) {
-          if (json.layers[index]) {
-            _.extend(json.layers[index], filter.toJSON());
-          } else {
-            json.layers[index] = filter.toJSON();
-          }
-        } else {
-          throw new Error('layerIndex missing for filter ' + JSON.stringify(filter.toJSON()));
-        }
+        json.layers.push(filter.toJSON());
       });
-      // fill the holes
-      for (var i = 0; i < json.layers.length; ++i) {
-        json.layers[i] = json.layers[i] || {};
-      }
     }
 
     return json;

--- a/src/windshaft/windshaft-map.js
+++ b/src/windshaft/windshaft-map.js
@@ -48,13 +48,17 @@ var WindshaftMap = Backbone.Model.extend({
     var filtersFromVisibleLayers = [];
     if (dataviews) {
       filtersFromVisibleLayers = dataviews.chain()
-        .filter(function (dataview) { return dataview.layer.isVisible(); })
-        .map(function (dataview) { return dataview.filter; })
+        .filter(function (dataview) {
+          return dataview.layer.isVisible();
+        })
+        .map(function (dataview) {
+          return dataview.filter;
+        })
         .compact() // not all dataviews have filters
         .value();
     }
 
-    var filters = new WindshaftFiltersCollection(filtersFromVisibleLayers);
+    var filters = new WindshaftFiltersCollection(filtersFromVisibleLayers, layers);
 
     this.client.instantiateMap({
       mapDefinition: mapConfig,


### PR DESCRIPTION
CR @alonsogarciapablo 

close https://github.com/CartoDB/deep-insights.js/issues/169 (from DI).

Please Pable review this PR. It solves a problem when there are two layers with widgets and you hide one of them. The widgets are hidden and the second layer widgets works until you make some filter.

Check if my reasoning is correct.
I realize we have generating an array of filters for winshaft map with the filters in the same position as the layer index and holes of no layer of filter is empty.

Supposing we have two layer and we hide one, new info is send to server with only one layer (not two). Later if you filter on a widget of the second layer an array with two positions is sent, the first empty (hole) for filters of the first layer and the second for filter in the layer two), generating an error on server `{"errors":["Cannot read property 'amount-spent-histogram-layer2' of undefined"]}`.