### PR TITLE
Changes to the histogram dataview model

### DIFF
--- a/src/dataviews/histogram-dataview-model.js
+++ b/src/dataviews/histogram-dataview-model.js
@@ -18,17 +18,18 @@ module.exports = DataviewModelBase.extend({
     if (this.get('column_type')) {
       params.push('column_type=' + this.get('column_type'));
     }
-    if (_.isNumber(this.get('start'))) {
-      params.push('start=' + this.get('start'));
-    }
-    if (_.isNumber(this.get('end'))) {
-      params.push('end=' + this.get('end'));
-    }
-    if (_.isNumber(this.get('bins'))) {
-      params.push('bins=' + this.get('bins'));
-    }
     if (_.isNumber(this.get('own_filter'))) {
       params.push('own_filter=' + this.get('own_filter'));
+    } else {
+      if (_.isNumber(this.get('start'))) {
+        params.push('start=' + this.get('start'));
+      }
+      if (_.isNumber(this.get('end'))) {
+        params.push('end=' + this.get('end'));
+      }
+      if (_.isNumber(this.get('bins'))) {
+        params.push('bins=' + this.get('bins'));
+      }
     }
     if (this.get('boundingBox') && this.get('submitBBox')) {
       params.push('bbox=' + this.get('boundingBox'));
@@ -48,10 +49,27 @@ module.exports = DataviewModelBase.extend({
     // BBox should only be included until after the first fetch, since we want to get the range of the full dataset
     this.once('change:data', function () {
       this.set('submitBBox', true);
+
+      var data = this.getData();
+      if (data && data.length > 0) {
+        this.set({
+          start: data[0].start,
+          end: data[data.length - 1].end,
+          bins: data.length
+        }, { silent: true });
+      }
     }, this);
     this.listenTo(this.layer, 'change:meta', this._onChangeLayerMeta);
     this.on('change:column', this._reloadMap, this);
     this.on('change:bins', this.refresh, this);
+  },
+
+  enableFilter: function () {
+    this.set('own_filter', 1);
+  },
+
+  disableFilter: function () {
+    this.unset('own_filter');
   },
 
   getData: function () {

--- a/test/spec/dataviews/histogram-dataview-model.spec.js
+++ b/test/spec/dataviews/histogram-dataview-model.spec.js
@@ -129,4 +129,44 @@ describe('dataviews/histogram-dataview-model', function () {
       expect(this.model.filter.get('column_type')).toEqual('date');
     });
   });
+
+  describe('.url', function () {
+    it('should generate a URL by default', function () {
+      this.model.set('url', 'http://example.com');
+      expect(this.model.url()).toEqual('http://example.com?bins=10');
+    });
+
+    it('should include start, end and bins when own_filter is enabled', function () {
+      this.model.set({
+        'url': 'http://example.com',
+        'start': 0,
+        'end': 10,
+        'bins': 25
+      });
+      expect(this.model.url()).toEqual('http://example.com?start=0&end=10&bins=25');
+
+      this.model.enableFilter();
+
+      expect(this.model.url()).toEqual('http://example.com?own_filter=1');
+    });
+  });
+
+  describe('.enableFilter', function () {
+    it('should set the own_filter attribute', function () {
+      expect(this.model.get('own_filter')).toBeUndefined();
+
+      this.model.enableFilter();
+
+      expect(this.model.get('own_filter')).toEqual(1);
+    });
+  });
+
+  describe('.disabeFilter', function () {
+    it('should unset the own_filter attribute', function () {
+      this.model.enableFilter();
+      this.model.disableFilter();
+
+      expect(this.model.get('own_filter')).toBeUndefined();
+    });
+  });
 });

--- a/test/spec/dataviews/histogram-dataview-model.spec.js
+++ b/test/spec/dataviews/histogram-dataview-model.spec.js
@@ -46,6 +46,28 @@ describe('dataviews/histogram-dataview-model', function () {
     expect(this.model.url()).toEqual('http://example.com?bins=10&bbox=fakeBoundingBox');
   });
 
+  it('should calculate start, end and bins after the first fetch', function () {
+    var histogramData = {
+      'bin_width': 10,
+      'bins_count': 3,
+      'bins_start': 1,
+      'nulls': 0
+    };
+
+    spyOn(this.model, 'sync').and.callFake(function (method, model, options) {
+      options.success(histogramData);
+    });
+
+    expect(this.model.get('start')).toBeUndefined();
+    expect(this.model.get('end')).toBeUndefined();
+
+    this.model.fetch();
+
+    expect(this.model.get('start')).toEqual(1);
+    expect(this.model.get('end')).toEqual(31);
+    expect(this.model.get('bins')).toEqual(3);
+  });
+
   it('should parse the bins', function () {
     var data = {
       bin_width: 14490.25,


### PR DESCRIPTION
- Adds two public methods: enableFilter and disableFilter, that will be used by deep-insights. This is consistent with the category-dataview-model.
- Histrogram Dataview models now sets the `start`, `end` and `bins` properties after the first fetch.
- `.url` method only includes `start`, `end` and `bins` when `own_filter` is 1.

This is my second attempt to fix #1069 in a nicer way :) :) :). Checkout CartoDB/deep-insights.js#220 to checkout the changes in deep-insights.js.

@javisantana since you suggested following a different approach... what do you think? thanks!