### PR TITLE
Filters has a reference to the Layer instead a `layerIndex` property

### DIFF
--- a/src/dataviews/dataviews-factory.js
+++ b/src/dataviews/dataviews-factory.js
@@ -28,8 +28,7 @@ module.exports = Model.extend({
   createCategoryModel: function (layerModel, attrs) {
     _checkProperties(attrs, ['column']);
     var categoryFilter = new CategoryFilter({
-      // TODO Setting layer-index on filters here is not good, if order change the filters won't work on the expected layer anymore!
-      layerIndex: this._indexOf(layerModel)
+      layer: layerModel
     });
 
     attrs = _.pick(attrs, CategorDataviewModel.ATTRS_NAMES);
@@ -63,8 +62,7 @@ module.exports = Model.extend({
     _checkProperties(attrs, ['column']);
 
     var rangeFilter = new RangeFilter({
-      // TODO Setting layer-index on filters here is not good, if order change the filters won't work on the expected layer anymore!
-      layerIndex: this._indexOf(layerModel)
+      layer: layerModel
     });
 
     attrs = _.pick(attrs, HistogramDataviewModel.ATTRS_NAMES);

--- a/src/windshaft/filters/collection.js
+++ b/src/windshaft/filters/collection.js
@@ -14,24 +14,32 @@ module.exports = Backbone.Collection.extend({
   },
 
   toJSON: function () {
-    var json = {
-      layers: []
-    };
-    var l, f, filters, filtersJson;
-    for (l = 0; l < this.layers.length; l++) {
-      var layer = this.layers[l];
-      if (layer.isVisible()) {
-        filters = this.getActiveFiltersForLayer(layer);
-        filtersJson = {};
-        if (filters.length) {
-          for (f = 0; f < filters.length; f++) {
-            _.extend(filtersJson, filters[f].toJSON());
+    var json = {};
+    var activeFilters = this.getActiveFilters();
+    if (activeFilters.length) {
+      json.layers = [];
+      var l, f, filters, filtersJson;
+      for (l = 0; l < this.layers.length; l++) {
+        var layer = this.layers[l];
+        if (layer.isVisible()) {
+          filters = this.getActiveFiltersForLayer(layer);
+          filtersJson = {};
+          if (filters.length) {
+            for (f = 0; f < filters.length; f++) {
+              _.extend(filtersJson, filters[f].toJSON());
+            }
           }
+          json.layers.push(filtersJson);
         }
-        json.layers.push(filtersJson);
       }
     }
     return json;
+  },
+
+  getActiveFilters: function () {
+    return this.filter(function (filter) {
+      return !filter.isEmpty();
+    });
   },
 
   getActiveFiltersForLayer: function (layer) {

--- a/src/windshaft/filters/collection.js
+++ b/src/windshaft/filters/collection.js
@@ -23,8 +23,10 @@ module.exports = Backbone.Collection.extend({
       if (layer.isVisible()) {
         filters = this.getActiveFiltersForLayer(layer);
         filtersJson = {};
-        for (f = 0; f < filters.length; f++) {
-          _.extend(filtersJson, filters[f].toJSON());
+        if (filters.length) {
+          for (f = 0; f < filters.length; f++) {
+            _.extend(filtersJson, filters[f].toJSON());
+          }
         }
         json.layers.push(filtersJson);
       }

--- a/src/windshaft/filters/collection.js
+++ b/src/windshaft/filters/collection.js
@@ -2,44 +2,39 @@ var _ = require('underscore');
 var Backbone = require('backbone');
 
 module.exports = Backbone.Collection.extend({
+
+  /**
+   * @param  {Array.<Filter>} filters Array with the filters to add to the collection.
+   * @param  {Array.<LayerModel>} layers  Array of LayerModel in the same order passed to the WindshaftMap.
+   * @returns {WindshaftFilterCollection}
+   */
   initialize: function (filters, layers) {
     this.layers = layers;
     Backbone.Collection.prototype.initialize.apply(this, filters);
   },
 
   toJSON: function () {
-    var json = {};
-    var activeFilters = this.getActiveFilters();
-    if (activeFilters.length) {
-      json.layers = [];
-      _.each(activeFilters, function (filter) {
-        var index = filter.get('layerIndex');
-        if (index >= 0) {
-          if (json.layers[index]) {
-            _.extend(json.layers[index], filter.toJSON());
-          } else {
-            json.layers[index] = filter.toJSON();
-          }
-        } else {
-          throw new Error('layerIndex missing for filter ' + JSON.stringify(filter.toJSON()));
+    var json = {
+      layers: []
+    };
+    var l, f, filters, filtersJson;
+    for (l = 0; l < this.layers.length; l++) {
+      var layer = this.layers[l];
+      if (layer.isVisible()) {
+        filters = this.getActiveFiltersForLayer(layer);
+        filtersJson = {};
+        for (f = 0; f < filters.length; f++) {
+          _.extend(filtersJson, filters[f].toJSON());
         }
-      });
-      // fill the holes only if layer is visible, otherwise remove the hole.
-      for (var i = 0; i < json.layers.length; ++i) {
-        if (this.layers[i].isVisible()) {
-          json.layers[i] = json.layers[i] || {};
-        } else {
-          json.layers.splice(i, 1);
-        }
+        json.layers.push(filtersJson);
       }
     }
-
     return json;
   },
 
-  getActiveFilters: function () {
+  getActiveFiltersForLayer: function (layer) {
     return this.filter(function (filter) {
-      return !filter.isEmpty();
+      return !filter.isEmpty() && filter.get('layer') === layer;
     });
   }
 });

--- a/test/spec/windshaft/windshaft-map.spec.js
+++ b/test/spec/windshaft/windshaft-map.spec.js
@@ -75,7 +75,9 @@ describe('windshaft/map', function () {
         statTag: 'stat_tag'
       });
 
-      var filter = new CategoryFilter({ layerIndex: 0 });
+      var filter = new CategoryFilter({
+        layer: this.cartoDBLayer1
+      });
       spyOn(filter, 'isEmpty').and.returnValue(false);
       spyOn(filter, 'toJSON').and.returnValue({ accept: 'category' });
 
@@ -104,7 +106,7 @@ describe('windshaft/map', function () {
       var args = this.client.instantiateMap.calls.mostRecent().args[0];
       expect(args.mapDefinition).toEqual({ foo: 'bar' });
       expect(args.statTag).toEqual('stat_tag');
-      expect(args.filters).toEqual({ layers: [{ accept: 'category' }] });
+      expect(args.filters).toEqual({ layers: [{ accept: 'category' }, {}, {}] });
     });
 
     it('should not send filters linked to hidden layers', function () {
@@ -118,7 +120,7 @@ describe('windshaft/map', function () {
       });
 
       var args = this.client.instantiateMap.calls.mostRecent().args[0];
-      expect(args.filters).toEqual({ });
+      expect(args.filters).toEqual({ layers: [{}, {}] });
     });
 
     it('should trigger an event when the instance is created', function () {

--- a/test/spec/windshaft/windshaft-map.spec.js
+++ b/test/spec/windshaft/windshaft-map.spec.js
@@ -120,7 +120,7 @@ describe('windshaft/map', function () {
       });
 
       var args = this.client.instantiateMap.calls.mostRecent().args[0];
-      expect(args.filters).toEqual({ layers: [{}, {}] });
+      expect(args.filters).toEqual({ });
     });
 
     it('should trigger an event when the instance is created', function () {


### PR DESCRIPTION
CR @alonsogarciapablo 

close #1020 

- Filters has a reference to the Layer instead had a `layerIndex` property.
- WindshaftMap and WindshaftFilterCollection are updated to compute the list of filters grouped by layer.
