### PR TITLE
Cancel old requests that comes from dataviewModels

### DIFF
--- a/grunt/tasks/_browserify-bundles.js
+++ b/grunt/tasks/_browserify-bundles.js
@@ -22,6 +22,7 @@ module.exports = {
       'test/spec/api/**/*',
       'test/spec/core/**/*',
       'test/spec/dataviews/**/*',
+      'test/spec/util/**/*',
       'test/spec/geo/**/*',
       'test/spec/ui/**/*',
       'test/spec/vis/**/*',

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -1,5 +1,6 @@
 var _ = require('underscore');
 var Model = require('../core/model');
+var BackboneCancelSync = require('../util/backbone-abort-sync');
 var WindshaftFiltersBoundingBoxFilter = require('../windshaft/filters/bounding-box');
 var BOUNDING_BOX_FILTER_WAIT = 500;
 
@@ -41,6 +42,8 @@ module.exports = Model.extend({
     this.layer = opts.layer;
     this._map = opts.map;
     this._windshaftMap = opts.windshaftMap;
+
+    this.sync = BackboneCancelSync.bind(this);
 
     // filter is optional, so have to guard before using it
     this.filter = opts.filter;
@@ -169,19 +172,6 @@ module.exports = Model.extend({
 
   getPreviousData: function () {
     return this.previous('data');
-  },
-
-  sync: function (method, model, options) {
-    var self = arguments[1];
-
-    if (this._xhr) {
-      this._xhr.abort();
-    }
-    this._xhr = Model.prototype.sync.apply(this, arguments);
-    this._xhr.always(function () {
-      self._xhr = null;
-    });
-    return this._xhr;
   },
 
   fetch: function (opts) {

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -173,6 +173,7 @@ module.exports = Model.extend({
 
   sync: function (method, model, options) {
     var self = arguments[1];
+
     if (this._xhr) {
       this._xhr.abort();
     }
@@ -186,7 +187,7 @@ module.exports = Model.extend({
   fetch: function (opts) {
     opts = opts || {};
 
-    this.trigger('loading');
+    this.trigger('loading', this);
 
     if (opts.success) {
       var successCallback = opts && opts.success;
@@ -195,11 +196,11 @@ module.exports = Model.extend({
     return Model.prototype.fetch.call(this, _.extend(opts, {
       success: function () {
         successCallback && successCallback(arguments);
-        this.trigger('loaded');
+        this.trigger('loaded', this);
       }.bind(this),
       error: function (mdl, err) {
         if (!err || (err && err.statusText !== 'abort')) {
-          this.trigger('error');
+          this.trigger('error', mdl, err);
         }
       }.bind(this)
     }));

--- a/src/util/backbone-abort-sync.js
+++ b/src/util/backbone-abort-sync.js
@@ -1,0 +1,17 @@
+var Backbone = require('backbone');
+
+/**
+ * Abort ongoing request if it exists
+ */
+module.exports = function (method, model, options) {
+  var self = arguments[1];
+
+  if (this._xhr) {
+    this._xhr.abort();
+  }
+  this._xhr = Backbone.sync.apply(this, arguments);
+  this._xhr.always(function () {
+    self._xhr = null;
+  });
+  return this._xhr;
+};

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -206,13 +206,4 @@ describe('dataviews/dataview-model-base', function () {
       });
     });
   });
-
-  describe('.sync', function () {
-    it('should abort old ongoing request', function () {
-      var oldXHR = jasmine.createSpyObj('XHR', ['abort', 'always']);
-      this.model._xhr = oldXHR;
-      this.model.fetch();
-      expect(oldXHR.abort).toHaveBeenCalled();
-    });
-  });
 });

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -206,4 +206,13 @@ describe('dataviews/dataview-model-base', function () {
       });
     });
   });
+
+  describe('.sync', function () {
+    it('should abort old ongoing request', function () {
+      var oldXHR = jasmine.createSpyObj('XHR', ['abort', 'always']);
+      this.model._xhr = oldXHR;
+      this.model.fetch();
+      expect(oldXHR.abort).toHaveBeenCalled();
+    });
+  });
 });

--- a/test/spec/util/backbone-abort-sync.spec.js
+++ b/test/spec/util/backbone-abort-sync.spec.js
@@ -1,0 +1,17 @@
+var Model = require('../../../src/core/model');
+var BackboneAbortSync = require('../../../src/util/backbone-abort-sync');
+
+describe('util/backbone-abort-sync', function () {
+  beforeEach(function () {
+    this.model = new Model();
+    this.model.url = 'url';
+    this.model.sync = BackboneAbortSync.bind(this.model);
+  });
+
+  it('should abort old ongoing request', function () {
+    var oldXHR = jasmine.createSpyObj('XHR', ['abort', 'always']);
+    this.model._xhr = oldXHR;
+    this.model.fetch();
+    expect(oldXHR.abort).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes part of https://github.com/CartoDB/deep-insights.js/issues/236.
No sure if it could break something from D3 integration.

CR: @javisantana
@viddo @alonsogarciapablo @fdansv @rochoa

PS: Deep insights PR also coming.