### PR TITLE
Using current window protocol for widget fetch url

### DIFF
--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -90,7 +90,7 @@ module.exports = Model.extend({
   _onNewWindshaftMapInstance: function (windshaftMapInstance, sourceLayerId) {
     var url = windshaftMapInstance.getDataviewURL({
       dataviewId: this.get('id'),
-      protocol: 'http'
+      protocol: window.location.protocol === 'https:' ? 'https' : 'http'
     });
 
     if (url) {


### PR DESCRIPTION
Spotted while we were testing widgets with namedmaps, where all widgets requests were under `http`.

Do I forget something? Good solution?

@alonsogarciapablo @viddo 
cc @juanignaciosl 