### PR TITLE
Fixes infowindows and tooltips

### DIFF
--- a/src/vis/infowindow-manager.js
+++ b/src/vis/infowindow-manager.js
@@ -55,9 +55,7 @@ InfowindowManager.prototype._bindFeatureClickEvent = function (layerView, layerM
     }
     var cartoDBId = data.cartodb_id;
 
-debugger;
     layerView.model.fetchAttributes(layerIndex, cartoDBId, function (attributes) {
-debugger;
       // Old viz.json doesn't contain width and maxHeight properties
       // and we have to get the default values if there are not defined.
       var extra = _.defaults(

--- a/src/vis/infowindow-manager.js
+++ b/src/vis/infowindow-manager.js
@@ -92,8 +92,8 @@ InfowindowManager.prototype._bindFeatureClickEvent = function (layerView, layerM
       .setLoading()
       .showInfowindow();
 
-    if (layerView.tooltip) {
-      layerView.tooltip.setFilter(function (feature) {
+    if (layerView.tooltipView) {
+      layerView.tooltipView.setFilter(function (feature) {
         return feature.cartodb_id !== cartoDBId;
       }).hide();
     }

--- a/src/vis/infowindow-manager.js
+++ b/src/vis/infowindow-manager.js
@@ -1,0 +1,100 @@
+var _ = require('underscore');
+var Overlay = require('./vis/overlay');
+var InfowindowModel = require('../geo/ui/infowindow-model');
+
+/**
+ * Manages the infowindows for a map. It listens to changes on the collection
+ * of layers and binds a new infowindow view/model to CartoDB.js whenever the
+ * collection of layers changes
+ */
+var InfowindowManager = function (options) {
+  this._vis = options.vis;
+  this._map = options.map;
+  this._mapView = options.mapView;
+
+  this._map.layers.bind('reset', function (layers) {
+    layers.each(this._addInfowindowForLayer, this);
+  }, this);
+  this._map.layers.bind('add', this._addInfowindowForLayer, this);
+};
+
+InfowindowManager.prototype._addInfowindowForLayer = function (layerModel) {
+  if (layerModel.getInfowindowData && layerModel.getInfowindowData()) {
+    var layerView = this._mapView.getLayerViewByLayerCid(layerModel.cid);
+
+    this._addInfowindowOverlay(layerView, layerModel);
+    this._bindFeatureClickEvent(layerView, layerModel);
+
+    layerView.bind('mouseover', function () {
+      this._mapView.setCursor('pointer');
+    }, this);
+
+    layerView.bind('mouseout', function (m, layer) {
+      this._mapView.setCursor('auto');
+    }, this);
+  }
+};
+
+InfowindowManager.prototype._addInfowindowOverlay = function (layerView, layerModel) {
+  var infowindowView = layerView.infowindowView;
+  if (!infowindowView) {
+    layerView.infowindowView = infowindowView = Overlay.create('infowindow', this._vis, layerModel.getInfowindowData());
+    this._mapView.addInfowindow(infowindowView);
+  }
+};
+
+InfowindowManager.prototype._bindFeatureClickEvent = function (layerView, layerModel) {
+  var infowindowView = layerView.infowindowView;
+  layerView.bind('featureClick', function (e, latlng, pos, data, layerIndex) {
+    var infowindowFields = layerModel.getInfowindowData();
+    if (!infowindowFields) {
+      return;
+    }
+    var cartoDBId = data.cartodb_id;
+
+    layerView.model.fetchAttributes(layerIndex, cartoDBId, function (attributes) {
+      // Old viz.json doesn't contain width and maxHeight properties
+      // and we have to get the default values if there are not defined.
+      var extra = _.defaults(
+        {
+          offset: infowindowFields.offset,
+          width: infowindowFields.width,
+          maxHeight: infowindowFields.maxHeight
+        },
+        InfowindowModel.prototype.defaults
+      );
+
+      infowindowView.model.set({
+        'fields': infowindowFields.fields,
+        'template': infowindowFields.template,
+        'template_type': infowindowFields.template_type,
+        'alternative_names': infowindowFields.alternative_names,
+        'sanitizeTemplate': infowindowFields.sanitizeTemplate,
+        'offset': extra.offset,
+        'width': extra.width,
+        'maxHeight': extra.maxHeight
+      });
+
+      if (attributes) {
+        infowindowView.model.updateContent(attributes);
+        infowindowView.adjustPan();
+      } else {
+        infowindowView.setError();
+      }
+    });
+
+    // Show infowindow with loading state
+    infowindowView
+      .setLatLng(latlng)
+      .setLoading()
+      .showInfowindow();
+
+    if (layerView.tooltip) {
+      layerView.tooltip.setFilter(function (feature) {
+        return feature.cartodb_id !== cartoDBId;
+      }).hide();
+    }
+  });
+};
+
+module.exports = InfowindowManager;

--- a/src/vis/infowindow-manager.js
+++ b/src/vis/infowindow-manager.js
@@ -7,10 +7,13 @@ var InfowindowModel = require('../geo/ui/infowindow-model');
  * of layers and binds a new infowindow view/model to CartoDB.js whenever the
  * collection of layers changes
  */
-var InfowindowManager = function (options) {
-  this._vis = options.vis;
-  this._map = options.map;
-  this._mapView = options.mapView;
+var InfowindowManager = function (vis) {
+  this._vis = vis;
+};
+
+InfowindowManager.prototype.manage = function (mapView, map) {
+  this._mapView = mapView;
+  this._map = map;
 
   this._map.layers.bind('reset', function (layers) {
     layers.each(this._addInfowindowForLayer, this);
@@ -52,7 +55,9 @@ InfowindowManager.prototype._bindFeatureClickEvent = function (layerView, layerM
     }
     var cartoDBId = data.cartodb_id;
 
+debugger;
     layerView.model.fetchAttributes(layerIndex, cartoDBId, function (attributes) {
+debugger;
       // Old viz.json doesn't contain width and maxHeight properties
       // and we have to get the default values if there are not defined.
       var extra = _.defaults(

--- a/src/vis/tooltip-manager.js
+++ b/src/vis/tooltip-manager.js
@@ -1,0 +1,61 @@
+var Tooltip = require('../geo/ui/tooltip');
+
+var TooltipManager = function (options) {
+  this._vis = options.vis;
+  this._map = options.map;
+  this._mapView = options.mapView;
+
+  this._map.layers.bind('reset', function (layers) {
+    layers.each(this._addTooltipForLayer, this);
+  }, this);
+  this._map.layers.bind('add', this._addTooltipForLayer, this);
+};
+
+TooltipManager.prototype._addTooltipForLayer = function (layerModel) {
+  if (layerModel.getTooltipData && layerModel.getTooltipData()) {
+    var layerView = this._mapView.getLayerViewByLayerCid(layerModel.cid);
+
+    this._addTooltipOverlay(layerView, layerModel);
+    this._bindFeatureOverEvent(layerView, layerModel);
+  }
+};
+
+TooltipManager.prototype._addTooltipOverlay = function (layerView, layerModel) {
+  var tooltipView = layerView.tooltipView;
+  if (!tooltipView) {
+    var tooltipData = layerModel.getTooltipData();
+    layerView.tooltipView = tooltipView = new Tooltip({
+      mapView: this._mapView,
+      layer: layerView,
+      template: tooltipData.template,
+      position: 'bottom|right',
+      vertical_offset: 10,
+      horizontal_offset: 4,
+      fields: tooltipData.fields,
+      omit_columns: ['cartodb_id']
+    });
+    this._mapView.addOverlay(tooltipView);
+
+    // TODO: Test this
+    layerView.bind('remove', function () {
+      tooltipView.clean();
+    });
+  }
+};
+
+TooltipManager.prototype._bindFeatureOverEvent = function (layerView, layerModel) {
+  var tooltipView = layerView.tooltipView;
+  layerView.bind('featureOver', function (e, latlng, pos, data, layer) {
+    var tooltipData = layerModel.getTooltipData();
+    if (tooltipData) {
+      tooltipView.setTemplate(tooltipData.template);
+      tooltipView.setFields(tooltipData.fields);
+      tooltipView.setAlternativeNames(tooltipData.alternative_names);
+      tooltipView.enable();
+    } else {
+      tooltipView.disable();
+    }
+  });
+};
+
+module.exports = TooltipManager;

--- a/src/vis/tooltip-manager.js
+++ b/src/vis/tooltip-manager.js
@@ -1,9 +1,17 @@
 var Tooltip = require('../geo/ui/tooltip');
 
-var TooltipManager = function (options) {
-  this._vis = options.vis;
-  this._map = options.map;
-  this._mapView = options.mapView;
+/**
+ * Manages the tooltips for a map. It listens to changes on the collection
+ * of layers and binds a new tooltip view/model to CartoDB.js whenever the
+ * collection of layers changes
+ */
+var TooltipManager = function (vis) {
+  this._vis = vis;
+};
+
+TooltipManager.prototype.manage = function (mapView, map) {
+  this._mapView = mapView;
+  this._map = map;
 
   this._map.layers.bind('reset', function (layers) {
     layers.each(this._addTooltipForLayer, this);

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -13,7 +13,6 @@ var MapViewFactory = require('../geo/map-view-factory');
 var LegendModel = require('../geo/ui/legend-model');
 var Legend = require('../geo/ui/legend');
 var SQL = require('../api/sql');
-var Tooltip = require('../geo/ui/tooltip');
 var InfowindowModel = require('../geo/ui/infowindow-model');
 var Infowindow = require('../geo/ui/infowindow');
 var Template = require('../core/template');
@@ -27,6 +26,9 @@ var WindshaftClient = require('../windshaft/client');
 var WindshaftLayerGroupConfig = require('../windshaft/layergroup-config');
 var WindshaftNamedMapConfig = require('../windshaft/namedmap-config');
 var WindshaftMap = require('../windshaft/windshaft-map');
+
+var InfowindowManager = require('./infowindow-manager');
+var TooltipManager = require('./tooltip-manager');
 
 /**
  * Visualization creation
@@ -382,16 +384,21 @@ var Vis = View.extend({
 
     this.mapView.bind('newLayerView', this._addLoading, this);
 
-    if (this.infowindow) {
-      this.mapView.bind('newLayerView', this.addInfowindow, this);
-    }
-
-    if (this.tooltip) {
-      this.mapView.bind('newLayerView', this.addTooltip, this);
-    }
-
     // Create the Layer Models and set them on hte map
     var layerModels = this._newLayerModels(data, this.map);
+    
+    new InfowindowManager({
+      vis: this,
+      map: this.map,
+      mapView: this.mapView
+    });
+
+    new TooltipManager({
+      vis: this,
+      map: this.map,
+      mapView: this.mapView
+    });
+
     this.map.layers.reset(layerModels);
 
     // Create the collection of Overlays
@@ -775,158 +782,6 @@ var Vis = View.extend({
     });
 
     return sql;
-  },
-
-  addTooltip: function (layerView) {
-    var layers = layerView.model && layerView.model.layers || [];
-
-    for (var i = 0; i < layers.length; ++i) {
-      var layerModel = layers.at(i);
-      var t = layerModel.getTooltipData();
-      if (t) {
-        if (!layerView.tooltip) {
-          var tooltip = new Tooltip({
-            mapView: this.mapView,
-            layer: layerView,
-            template: t.template,
-            position: 'bottom|right',
-            vertical_offset: 10,
-            horizontal_offset: 4,
-            fields: t.fields,
-            omit_columns: ['cartodb_id']
-          });
-          layerView.tooltip = tooltip;
-          this.mapView.addOverlay(tooltip);
-          layerView.bind('remove', function () {
-            this.tooltip.clean();
-          });
-        }
-      }
-    }
-
-    if (layerView.tooltip) {
-      layerView.bind('featureOver', function (e, latlng, pos, data, layer) {
-        var t = layers.at(layer).getTooltipData();
-        if (t) {
-          layerView.tooltip.setTemplate(t.template);
-          layerView.tooltip.setFields(t.fields);
-          layerView.tooltip.setAlternativeNames(t.alternative_names);
-          layerView.tooltip.enable();
-        } else {
-          layerView.tooltip.disable();
-        }
-      });
-    }
-  },
-
-  addInfowindow: function (layerView) {
-    var mapView = this.mapView;
-    var infowindow = null;
-    var layers = [];
-    // TODO: this should be managed at a different level so each layer knows if
-    // the infowindow needs to be added
-    if (layerView.model) {
-      if (layerView.model.layers) {
-        layers = layerView.model.layers;
-      } else {
-        if (layerView.model.getInfowindowData) {
-          layers = new Backbone.Collection([layerView.model]);
-        }
-      }
-    }
-
-    for (var i = 0; i < layers.length; ++i) {
-      var layerModel = layers.at(i);
-      if (layerModel.getInfowindowData()) {
-        if (!infowindow) {
-          infowindow = Overlay.create('infowindow', this, layerModel.getInfowindowData(), true);
-          mapView.addInfowindow(infowindow);
-        }
-      }
-    }
-
-    if (!infowindow) {
-      return;
-    }
-
-    infowindow.bind('close', function () {
-      // TODO: create a test checking this behaviour.
-      // when infowindow is closed remove all the filters
-      // for tooltips
-      layers.each(function(layerView) {
-        var layerTooltip = layerView.tooltip;
-        if (layerTooltip) {
-          layerTooltip.setFilter(null);
-        }
-      });
-    });
-
-    infowindow.model.bind('domready', function () {
-      layerView.trigger('infowindow_ready', infowindow, this);
-    }, this);
-
-    // if the layer has no infowindow just pass the interaction
-    // data to the infowindow
-    layerView.bind('featureClick', function (e, latlng, pos, data, layer) {
-      var infowindowFields = layers.at(layer).getInfowindowData();
-      if (!infowindowFields) return;
-      var cartodb_id = data.cartodb_id;
-
-      layerView.model.fetchAttributes(layer, cartodb_id, function (attributes) {
-        // Old viz.json doesn't contain width and maxHeight properties
-        // and we have to get the default values if there are not defined.
-        var extra = _.defaults(
-          {
-            offset: infowindowFields.offset,
-            width: infowindowFields.width,
-            maxHeight: infowindowFields.maxHeight
-          },
-          InfowindowModel.prototype.defaults
-        );
-
-        infowindow.model.set({
-          'fields': infowindowFields.fields,
-          'template': infowindowFields.template,
-          'template_type': infowindowFields.template_type,
-          'alternative_names': infowindowFields.alternative_names,
-          'sanitizeTemplate': infowindowFields.sanitizeTemplate,
-          'offset': extra.offset,
-          'width': extra.width,
-          'maxHeight': extra.maxHeight
-        });
-
-        if (attributes) {
-          infowindow.model.updateContent(attributes);
-          infowindow.adjustPan();
-        } else {
-          infowindow.setError();
-        }
-      });
-
-      // Show infowindow with loading state
-      infowindow
-        .setLatLng(latlng)
-        .setLoading()
-        .showInfowindow();
-
-      if (layerView.tooltip) {
-        layerView.tooltip.setFilter(function (feature) {
-          return feature.cartodb_id !== cartodb_id;
-        }).hide();
-      }
-    });
-
-    var hovers = [];
-
-    layerView.bind('mouseover', function () {
-      mapView.setCursor('pointer');
-    });
-
-    layerView.bind('mouseout', function (m, layer) {
-      mapView.setCursor('auto');
-    });
-
-    layerView.infowindow = infowindow.model;
   },
 
   _addLoading: function (layerView) {

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -386,23 +386,14 @@ var Vis = View.extend({
 
     // Create the Layer Models and set them on hte map
     var layerModels = this._newLayerModels(data, this.map);
-    
-    new InfowindowManager({
-      vis: this,
-      map: this.map,
-      mapView: this.mapView
-    });
 
-    new TooltipManager({
-      vis: this,
-      map: this.map,
-      mapView: this.mapView
-    });
+    var infowindowManager = new InfowindowManager(this);
+    infowindowManager.manage(this.mapView, this.map);
 
-    this.map.layers.reset(layerModels);
+    var tooltipManager = new TooltipManager(this);
+    tooltipManager.manage(this.mapView, this.map);
 
     // Create the collection of Overlays
-
     var overlaysCollection = new Backbone.Collection();
     overlaysCollection.bind('reset', function (overlays) {
       this._addOverlays(overlays, data, options);
@@ -410,7 +401,6 @@ var Vis = View.extend({
     overlaysCollection.reset(data.overlays);
 
     // Create the public Dataview Factory
-
     this.dataviews = new DataviewsFactory(null, {
       dataviewsCollection: this._dataviewsCollection,
       layersCollection: this.map.layers,
@@ -421,6 +411,9 @@ var Vis = View.extend({
     if (!options.skipMapInstantiation) {
       this.instantiateMap();
     }
+
+    // Lastly: reset the layer models on the map
+    this.map.layers.reset(layerModels);
 
     return this;
   },

--- a/test/spec/vis/infowindow-manager-spec.js
+++ b/test/spec/vis/infowindow-manager-spec.js
@@ -227,5 +227,4 @@ describe('src/vis/infowindow-manager.js', function () {
     expect(filterFunction({ cartodb_id: 10 })).toBeFalsy();
     expect(filterFunction({ cartodb_id: 0 })).toBeTruthy();
   });
-
 });

--- a/test/spec/vis/infowindow-manager-spec.js
+++ b/test/spec/vis/infowindow-manager-spec.js
@@ -1,0 +1,187 @@
+var Backbone = require('backbone');
+var MapView = require('../../../src/geo/map-view');
+var Map = require('../../../src/geo/map');
+var CartoDBLayer = require('../../../src/geo/map/cartodb-layer');
+var InfowindowManager = require('../../../src/vis/infowindow-manager');
+
+describe('src/vis/infowindow-manager.js', function () {
+  beforeEach(function () {
+    var windshaftMap = new Backbone.Model({});
+    windshaftMap.isNamedMap = function () { return false; };
+    this.map = new Map({}, {
+      windshaftMap: windshaftMap
+    });
+    this.layerView = new Backbone.Model();
+    var layerViewFactory = jasmine.createSpyObj('layerViewFactory', ['createLayerView']);
+    layerViewFactory.createLayerView.and.returnValue(this.layerView);
+
+    this.mapView = new MapView({
+      map: this.map,
+      layerViewFactory: layerViewFactory
+    });
+    this.mapView.getNativeMap = function () {};
+    this.mapView._addLayerToMap = function () {};
+    this.mapView.latLonToPixel = function () { return { x: 0, y: 0 }; };
+    this.mapView.getSize = function () { return { x: 1000, y: 1000 }; };
+
+    this.vis = {
+      mapView: this.mapView
+    };
+  });
+
+  it('should add a new infowindow view to the map view when new layers are reseted', function () {
+    spyOn(this.mapView, 'addInfowindow');
+
+    var layer = new CartoDBLayer({
+      infowindow: {
+        fields: [{
+          'name': 'name',
+          'title': true,
+          'position': 1
+        }]
+      }
+    });
+
+    var infowindowManager = new InfowindowManager(this.vis);
+    infowindowManager.manage(this.mapView, this.map);
+
+    this.map.layers.reset([ layer ]);
+    expect(this.mapView.addInfowindow).toHaveBeenCalled();
+  });
+
+  it('should add a new infowindow view to the map view when new layers are added', function () {
+    spyOn(this.mapView, 'addInfowindow');
+
+    var layer = new CartoDBLayer({
+      infowindow: {
+        fields: [{
+          'name': 'name',
+          'title': true,
+          'position': 1
+        }]
+      }
+    });
+
+    var infowindowManager = new InfowindowManager(this.vis);
+    infowindowManager.manage(this.mapView, this.map);
+
+    this.map.layers.reset([ layer ]);
+    expect(this.mapView.addInfowindow).toHaveBeenCalled();
+  });
+
+  it('should NOT add a new infowindow view to the map view when new layers share the same layerView', function () {
+    spyOn(this.mapView, 'addInfowindow');
+
+    var layer1 = new CartoDBLayer({
+      infowindow: {
+        fields: [{
+          'name': 'name',
+          'title': true,
+          'position': 1
+        }]
+      }
+    });
+
+    var layer2 = new CartoDBLayer({
+      infowindow: {
+        fields: [{
+          'name': 'description',
+          'title': true,
+          'position': 1
+        }]
+      }
+    });
+
+    var infowindowManager = new InfowindowManager(this.vis);
+    infowindowManager.manage(this.mapView, this.map);
+
+    this.map.layers.reset([ layer1, layer2 ]);
+    expect(this.mapView.addInfowindow).toHaveBeenCalled();
+    expect(this.mapView.addInfowindow.calls.count()).toEqual(1);
+  });
+
+  it('should NOT add a new infowindow view to the map view when new layers are added if layer doesn\'t have infowindow fields', function () {
+    spyOn(this.mapView, 'addInfowindow');
+
+    var layer = new CartoDBLayer({
+      infowindow: {
+        fields: []
+      }
+    });
+
+    var infowindowManager = new InfowindowManager(this.vis);
+    infowindowManager.manage(this.mapView, this.map);
+
+    this.map.layers.reset([ layer ]);
+    expect(this.mapView.addInfowindow).not.toHaveBeenCalled();
+  });
+
+  it('should correctly bind the featureClick event to the corresponding layerView', function () {
+    spyOn(this.mapView, 'addInfowindow');
+
+    var layer = new CartoDBLayer({
+      infowindow: {
+        template: 'template',
+        template_type: 'underscore',
+        fields: [{
+          'name': 'name',
+          'title': true,
+          'position': 1
+        }]
+      }
+    });
+
+    var infowindowManager = new InfowindowManager(this.vis);
+    infowindowManager.manage(this.mapView, this.map);
+
+    this.map.layers.reset([ layer ]);
+    var infowindowView = this.mapView.addInfowindow.calls.mostRecent().args[0];
+    var infowindowModel = infowindowView.model;
+
+    this.layerView.model = {
+      fetchAttributes: jasmine.createSpy('fetchAttributes').and.returnValue({ name: 'Juan' })
+    };
+    spyOn(infowindowView, 'adjustPan');
+
+    // Simulate the featureClick event
+    this.layerView.trigger('featureClick', {}, [100, 200], undefined, { cartodb_id: 10 }, 1);
+
+    // A request to fetch the attributes for the right cartodb_id and layerIndex has been triggered
+    expect(this.layerView.model.fetchAttributes).toHaveBeenCalledWith(1, 10, jasmine.any(Function));
+
+    // InfowindowModel has been updated
+    expect(infowindowModel.attributes).toEqual({
+      'template': 'template',
+      'template_type': 'underscore',
+      'alternative_names': {},
+      'fields': [
+        {
+          'name': 'name',
+          'title': true,
+          'position': 1
+        }
+      ],
+      'template_name': 'infowindow_light',
+      'latlng': [
+        100,
+        200
+      ],
+      'offset': [
+        28,
+        0
+      ],
+      'maxHeight': 180,
+      'autoPan': true,
+      'content': {
+        'fields': [
+          {
+            'type': 'loading',
+            'title': 'loading',
+            'value': '…'
+          }
+        ]
+      },
+      'visibility': true
+    });
+  });
+});

--- a/test/spec/vis/infowindow-manager-spec.js
+++ b/test/spec/vis/infowindow-manager-spec.js
@@ -127,7 +127,8 @@ describe('src/vis/infowindow-manager.js', function () {
           'name': 'name',
           'title': true,
           'position': 1
-        }]
+        }],
+        alternative_names: 'alternative_names'
       }
     });
 
@@ -153,7 +154,7 @@ describe('src/vis/infowindow-manager.js', function () {
     expect(infowindowModel.attributes).toEqual({
       'template': 'template',
       'template_type': 'underscore',
-      'alternative_names': {},
+      'alternative_names': 'alternative_names',
       'fields': [
         {
           'name': 'name',

--- a/test/spec/vis/tooltip-manager-spec.js
+++ b/test/spec/vis/tooltip-manager-spec.js
@@ -1,0 +1,161 @@
+var Backbone = require('backbone');
+var MapView = require('../../../src/geo/map-view');
+var Map = require('../../../src/geo/map');
+var CartoDBLayer = require('../../../src/geo/map/cartodb-layer');
+var TooltipManager = require('../../../src/vis/tooltip-manager');
+
+describe('src/vis/tooltip-manager.js', function () {
+  beforeEach(function () {
+    var windshaftMap = new Backbone.Model({});
+    windshaftMap.isNamedMap = function () { return false; };
+    this.map = new Map({}, {
+      windshaftMap: windshaftMap
+    });
+    this.layerView = new Backbone.Model();
+    var layerViewFactory = jasmine.createSpyObj('layerViewFactory', ['createLayerView']);
+    layerViewFactory.createLayerView.and.returnValue(this.layerView);
+
+    this.mapView = new MapView({
+      map: this.map,
+      layerViewFactory: layerViewFactory
+    });
+    this.mapView.getNativeMap = function () {};
+    this.mapView._addLayerToMap = function () {};
+    this.mapView.latLonToPixel = function () { return { x: 0, y: 0 }; };
+    this.mapView.getSize = function () { return { x: 1000, y: 1000 }; };
+
+    this.vis = {
+      mapView: this.mapView
+    };
+  });
+
+  it('should add a new tooltip view to the map view when new layers are reseted', function () {
+    spyOn(this.mapView, 'addOverlay');
+
+    var layer = new CartoDBLayer({
+      tooltip: {
+        fields: [{
+          'name': 'name',
+          'title': true,
+          'position': 1
+        }]
+      }
+    });
+
+    var tooltipManager = new TooltipManager(this.vis);
+    tooltipManager.manage(this.mapView, this.map);
+
+    this.map.layers.reset([ layer ]);
+    expect(this.mapView.addOverlay).toHaveBeenCalled();
+  });
+
+  it('should add a new tooltip view to the map view when new layers are added', function () {
+    spyOn(this.mapView, 'addOverlay');
+
+    var layer = new CartoDBLayer({
+      tooltip: {
+        fields: [{
+          'name': 'name',
+          'title': true,
+          'position': 1
+        }]
+      }
+    });
+
+    var tooltipManager = new TooltipManager(this.vis);
+    tooltipManager.manage(this.mapView, this.map);
+
+    this.map.layers.reset([ layer ]);
+    expect(this.mapView.addOverlay).toHaveBeenCalled();
+  });
+
+  it('should NOT add a new infowindow view to the map view when new layers share the same layerView', function () {
+    spyOn(this.mapView, 'addOverlay');
+
+    var layer1 = new CartoDBLayer({
+      tooltip: {
+        fields: [{
+          'name': 'name',
+          'title': true,
+          'position': 1
+        }]
+      }
+    });
+
+    var layer2 = new CartoDBLayer({
+      tooltip: {
+        fields: [{
+          'name': 'description',
+          'title': true,
+          'position': 1
+        }]
+      }
+    });
+
+    var tooltipManager = new TooltipManager(this.vis);
+    tooltipManager.manage(this.mapView, this.map);
+
+    this.map.layers.reset([ layer1, layer2 ]);
+
+    expect(this.mapView.addOverlay).toHaveBeenCalled();
+    expect(this.mapView.addOverlay.calls.count()).toEqual(1);
+  });
+
+  it('should NOT add a new infowindow view to the map view when new layers are added if layer doesn\'t have infowindow fields', function () {
+    spyOn(this.mapView, 'addOverlay');
+
+    var layer = new CartoDBLayer({
+      tooltip: {
+        fields: []
+      }
+    });
+
+    var tooltipManager = new TooltipManager(this.vis);
+    tooltipManager.manage(this.mapView, this.map);
+
+    this.map.layers.reset([ layer ]);
+    expect(this.mapView.addOverlay).not.toHaveBeenCalled();
+  });
+
+  it('should correctly bind the featureOver event to the corresponding layerView', function () {
+    spyOn(this.mapView, 'addOverlay');
+
+    var layer = new CartoDBLayer({
+      tooltip: {
+        template: 'template',
+        template_type: 'underscore',
+        fields: [{
+          'name': 'name',
+          'title': true,
+          'position': 1
+        }],
+        alternative_names: 'alternative_names'
+      }
+    });
+
+    var tooltipManager = new TooltipManager(this.vis);
+    tooltipManager.manage(this.mapView, this.map);
+
+    this.map.layers.reset([ layer ]);
+
+    expect(this.mapView.addOverlay).toHaveBeenCalled();
+    var tooltipView = this.mapView.addOverlay.calls.mostRecent().args[0];
+
+    spyOn(tooltipView, 'setTemplate');
+    spyOn(tooltipView, 'setFields');
+    spyOn(tooltipView, 'setAlternativeNames');
+    spyOn(tooltipView, 'enable');
+
+    // Simulate the featureOver event
+    this.layerView.trigger('featureOver', {}, [100, 200], undefined, { cartodb_id: 10 }, 1);
+
+    expect(tooltipView.setTemplate).toHaveBeenCalledWith('template');
+    expect(tooltipView.setFields).toHaveBeenCalledWith([{
+      'name': 'name',
+      'title': true,
+      'position': 1
+    }]);
+    expect(tooltipView.setAlternativeNames).toHaveBeenCalledWith('alternative_names');
+    expect(tooltipView.enable).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
In this PR I changed how we're creating new infowindows and tooltips right now. Instead of listening to the "newLayerView" event and adding infowindows/tooltips when a new layerview is added, we now work directly with the array of layerModels.

In an attempt to make things a bit more simpler and clean up the vis#load method, I've extracted the logic to manage infowindows and tooltips to what I've called an InfowindowManager and a TooltipManager. I'm open to better names.

@javisantana could you please tell me what you think about this approach? Thanks!