### PR TITLE
Fixing problem with loader in category search

### DIFF
--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -78,7 +78,7 @@ module.exports = DataviewModelBase.extend({
     this._searchModel.bind('loading', function () {
       this.trigger('loading', this);
     }, this);
-    this._searchModel.bind('sync', function () {
+    this._searchModel.bind('loaded', function () {
       this.trigger('loaded', this);
     }, this);
     this._searchModel.bind('error', function (e) {

--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -79,7 +79,7 @@ module.exports = DataviewModelBase.extend({
       this.trigger('loading', this);
     }, this);
     this._searchModel.bind('sync', function () {
-      this.trigger('sync', this);
+      this.trigger('loaded', this);
     }, this);
     this._searchModel.bind('error', function (e) {
       if (!e || (e && e.statusText !== 'abort')) {

--- a/src/dataviews/category-dataview/search-model.js
+++ b/src/dataviews/category-dataview/search-model.js
@@ -92,7 +92,24 @@ module.exports = Model.extend({
   },
 
   fetch: function (opts) {
+    opts = opts || {};
+
     this.trigger('loading', this);
-    return Model.prototype.fetch.call(this, opts);
+
+    if (opts.success) {
+      var successCallback = opts && opts.success;
+    }
+
+    return Model.prototype.fetch.call(this, _.extend(opts, {
+      success: function () {
+        successCallback && successCallback(arguments);
+        this.trigger('loaded', this);
+      }.bind(this),
+      error: function (mdl, err) {
+        if (!err || (err && err.statusText !== 'abort')) {
+          this.trigger('error', mdl, err);
+        }
+      }.bind(this)
+    }));
   }
 });

--- a/src/dataviews/category-dataview/search-model.js
+++ b/src/dataviews/category-dataview/search-model.js
@@ -1,5 +1,6 @@
 var _ = require('underscore');
 var Model = require('../../core/model');
+var BackboneAbortSync = require('../../util/backbone-abort-sync');
 var CategoriesCollection = require('./categories-collection');
 
 /**
@@ -18,6 +19,7 @@ module.exports = Model.extend({
 
   initialize: function (attrs, opts) {
     this._data = new CategoriesCollection();
+    this.sync = BackboneAbortSync.bind(this);
     this._initBinds();
   },
 
@@ -91,19 +93,6 @@ module.exports = Model.extend({
 
   fetch: function (opts) {
     this.trigger('loading', this);
-    return cdb.core.Model.prototype.fetch.call(this, opts);
-  },
-
-  sync: function () {
-    var self = arguments[1];
-    if (this._xhr) {
-      this._xhr.abort();
-    }
-    this._xhr = cdb.core.Model.prototype.sync.apply(this, arguments);
-    this._xhr.always(function () {
-      self._xhr = null;
-    });
-    return this._xhr;
+    return Model.prototype.fetch.call(this, opts);
   }
-
 });

--- a/test/spec/dataviews/category-dataview-model.spec.js
+++ b/test/spec/dataviews/category-dataview-model.spec.js
@@ -78,7 +78,7 @@ describe('dataviews/category-dataview-model', function () {
 
     describe('search events dispatcher', function () {
       it('should trigger search related events', function () {
-        var eventNames = ['loading', 'sync', 'error'];
+        var eventNames = ['loading', 'loaded', 'error'];
         _.each(eventNames, function (eventName) {
           _.bind(eventDispatcher, this)(this.model._searchModel, eventName);
         }, this);


### PR DESCRIPTION
After a category search is done, event was wrong because it was change to 'loaded'. Also using new `backbone-abort-sync` thing.

cc @javisantana 