### PR TITLE
Not adding leaflet layer each time map is instantiated

### DIFF
--- a/src/geo/leaflet/leaflet-cartodb-layer-group-view.js
+++ b/src/geo/leaflet/leaflet-cartodb-layer-group-view.js
@@ -211,6 +211,8 @@ var LeafletCartoDBLayerGroupView = L.TileLayer.extend({
     if (tilejson) {
       this.tilejson = tilejson;
       this.setUrl(this.tilejson.tiles[0]);
+      // TODO: Is this necessary?
+      this.ok && this.ok();
       // manage interaction
       this._reloadInteraction();
     } else {

--- a/src/geo/leaflet/leaflet-cartodb-layer-group-view.js
+++ b/src/geo/leaflet/leaflet-cartodb-layer-group-view.js
@@ -211,10 +211,10 @@ var LeafletCartoDBLayerGroupView = L.TileLayer.extend({
     if (tilejson) {
       this.tilejson = tilejson;
       this.setUrl(this.tilejson.tiles[0]);
-      // TODO: Is this necessary?
-      this.ok && this.ok();
       // manage interaction
       this._reloadInteraction();
+      // TODO: Is this necessary?
+      this.ok && this.ok();
     } else {
       this.error && this.error('URLs have not been fetched yet');
     }

--- a/src/geo/leaflet/leaflet-cartodb-layer-group-view.js
+++ b/src/geo/leaflet/leaflet-cartodb-layer-group-view.js
@@ -96,20 +96,7 @@ var LeafletCartoDBLayerGroupView = L.TileLayer.extend({
     this.fire = this.trigger;
 
     // Bind changes to the urls of the model
-    layerModel.bind('change:urls', function () {
-      self.__update(function () {
-        // if while the layer was processed in the server is removed
-        // it should not be added to the map
-        var id = L.stamp(self);
-        if (!leafletMap._layers[id]) {
-          return;
-        }
-
-        L.TileLayer.prototype.onAdd.call(self, leafletMap);
-        self.fire('added');
-        self.options.added = true;
-      });
-    });
+    layerModel.bind('change:urls', this.__update, this);
 
     this.addProfiling();
 
@@ -200,8 +187,9 @@ var LeafletCartoDBLayerGroupView = L.TileLayer.extend({
    * @params {map}
    */
   onAdd: function (map) {
-    var self = this;
     this.options.map = map;
+    this.options.added = true;
+    return L.TileLayer.prototype.onAdd.call(this, map);
   },
 
   /**
@@ -219,23 +207,15 @@ var LeafletCartoDBLayerGroupView = L.TileLayer.extend({
    * generates a new url for tiles and refresh leaflet layer
    * do not collide with leaflet _update
    */
-  __update: function (done) {
-    var self = this;
-    this.fire('updated');
-    this.fire('loading');
-    var map = this.options.map;
-
-    var tilejson = self.model.get('urls');
+  __update: function () {
+    var tilejson = this.model.get('urls');
     if (tilejson) {
-      self.tilejson = tilejson;
-      self.setUrl(self.tilejson.tiles[0]);
+      this.tilejson = tilejson;
+      this.setUrl(this.tilejson.tiles[0]);
       // manage interaction
-      self._reloadInteraction();
-      self.ok && self.ok();
-      done && done();
+      this._reloadInteraction();
     } else {
-      self.error && self.error('URLs have not been fetched yet');
-      done && done();
+      this.error && this.error('URLs have not been fetched yet');
     }
   },
 

--- a/src/geo/leaflet/leaflet-cartodb-layer-group-view.js
+++ b/src/geo/leaflet/leaflet-cartodb-layer-group-view.js
@@ -70,7 +70,6 @@ var LeafletCartoDBLayerGroupView = L.TileLayer.extend({
         self.trigger('layermouseover', e, latlon, pxPos, data, layer);
       }, 0);
       previousEvent = e.timeStamp;
-
     };
 
     opts.featureOut = function (m, layer) {
@@ -96,7 +95,7 @@ var LeafletCartoDBLayerGroupView = L.TileLayer.extend({
     this.fire = this.trigger;
 
     // Bind changes to the urls of the model
-    layerModel.bind('change:urls', this.__update, this);
+    layerModel.bind('change:urls', this._onTileJSONChange, this);
 
     this.addProfiling();
 
@@ -203,11 +202,11 @@ var LeafletCartoDBLayerGroupView = L.TileLayer.extend({
   },
 
   /**
-   * Update CartoDB layer
-   * generates a new url for tiles and refresh leaflet layer
+   * On tileJSON change,
+   * it generates a new url for tiles and refresh leaflet layer
    * do not collide with leaflet _update
    */
-  __update: function () {
+  _onTileJSONChange: function () {
     var tilejson = this.model.get('urls');
     if (tilejson) {
       this.tilejson = tilejson;


### PR DESCRIPTION
Seems like our very own [weird-zoom-bug](https://github.com/CartoDB/deep-insights.js/issues/249) is due to a problem of adding the same layer each time the map is instantiated. For example, when a filter is applied. Seems like @javisantana and I have cleaned a little bit the old code.

CR: @javisantana 
cc @alonsogarciapablo 

No more :scream: faces showing a Deep-Insights bug.