### PR TITLE
Enforce client-side rendering with "vector" attribute in the viz.json

### DIFF
--- a/examples/v4/leaflet-layergroup-vector.html
+++ b/examples/v4/leaflet-layergroup-vector.html
@@ -276,6 +276,7 @@
               "order": 3,
               "type": "tiled"
             }
+
           ],
           "overlays":[
             {

--- a/examples/v4/leaflet-layergroup.html
+++ b/examples/v4/leaflet-layergroup.html
@@ -30,7 +30,6 @@
           "description":null,
           "scrollwheel":true,
           "legends":true,
-          "vector":true,
           "url":null,
           "map_provider":"leaflet",
           "bounds":[

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -16,10 +16,7 @@ var Config = Backbone.Model.extend({
 
   //error track
   REPORT_ERROR_URL: '/api/v0/error',
-  ERROR_TRACK_ENABLED: false,
-
-  // Forces rendering in the client
-  FORCE_CLIENT_SIDE_RENDERING: true
+  ERROR_TRACK_ENABLED: false
 });
 
 module.exports = Config;

--- a/src/geo/leaflet/leaflet-layer-view-factory.js
+++ b/src/geo/leaflet/leaflet-layer-view-factory.js
@@ -5,13 +5,9 @@ var LeafletPlainLayerView = require('./leaflet-plain-layer-view');
 var LeafletGmapsTiledLayerView = require('./leaflet-gmaps-tiled-layer-view');
 var LeafletCartoDBLayerGroupView = require('./leaflet-cartodb-layer-group-view');
 var LeafletCartoDBVectorLayerGroupView = require('./leaflet-cartodb-vector-layer-group-view');
-var config = require('cdb.config');
 
-var LayerGroupViewConstructor = function (layerGroupModel, mapModel) {
-  // TODO: We will need to determine this dinamically.
-  // Setting it to `true` for now for testing purposes.
-  var vectorRendering = config.FORCE_CLIENT_SIDE_RENDERING;
-  if (vectorRendering) {
+var LayerGroupViewConstructor = function (layerGroupModel, mapModel, options) {
+  if (options.vector) {
     var layerView = new LeafletCartoDBVectorLayerGroupView(layerGroupModel, mapModel);
 
     return layerView;
@@ -19,7 +15,9 @@ var LayerGroupViewConstructor = function (layerGroupModel, mapModel) {
   return new LeafletCartoDBLayerGroupView(layerGroupModel, mapModel);
 };
 
-var LeafletLayerViewFactory = function () {};
+var LeafletLayerViewFactory = function (options) {
+  this._vector = options.vector;
+};
 
 LeafletLayerViewFactory.prototype._constructors = {
   'tiled': LeafletTiledLayerView,
@@ -44,7 +42,9 @@ LeafletLayerViewFactory.prototype.createLayerView = function (layerModel, mapMod
 
   if (LayerViewClass) {
     try {
-      return new LayerViewClass(layerModel, mapModel);
+      return new LayerViewClass(layerModel, mapModel, {
+        vector: this._vector
+      });
     } catch (e) {
       log.error("Error creating an instance of layer view for '" + layerType + "' layer -> " + e.message);
       throw e;

--- a/src/geo/leaflet/leaflet-layer-view-factory.js
+++ b/src/geo/leaflet/leaflet-layer-view-factory.js
@@ -16,6 +16,7 @@ var LayerGroupViewConstructor = function (layerGroupModel, mapModel, options) {
 };
 
 var LeafletLayerViewFactory = function (options) {
+  options = options || {};
   this._vector = options.vector;
 };
 

--- a/src/geo/map-view-factory.js
+++ b/src/geo/map-view-factory.js
@@ -4,6 +4,7 @@ var LeafletLayerViewFactory = require('./leaflet/leaflet-layer-view-factory');
 var GMapsLayerViewFactory = require('./gmaps/gmaps-layer-view-factory');
 
 var MapViewFactory = function (options) {
+  options = options || {};
   this._vector = options.vector;
 };
 

--- a/src/geo/map-view-factory.js
+++ b/src/geo/map-view-factory.js
@@ -3,7 +3,9 @@ var cdb = require('cdb');
 var LeafletLayerViewFactory = require('./leaflet/leaflet-layer-view-factory');
 var GMapsLayerViewFactory = require('./gmaps/gmaps-layer-view-factory');
 
-var MapViewFactory = function () {};
+var MapViewFactory = function (options) {
+  this._vector = options.vector;
+};
 
 MapViewFactory.prototype.createMapView = function (provider, mapModel, el) {
   var MapViewClass;
@@ -26,7 +28,9 @@ MapViewFactory.prototype.createMapView = function (provider, mapModel, el) {
   return new MapViewClass({
     el: el,
     map: mapModel,
-    layerViewFactory: new LayerViewFactoryClass()
+    layerViewFactory: new LayerViewFactoryClass({
+      vector: this._vector
+    })
   });
 };
 

--- a/src/geo/map-view-factory.js
+++ b/src/geo/map-view-factory.js
@@ -3,10 +3,7 @@ var cdb = require('cdb');
 var LeafletLayerViewFactory = require('./leaflet/leaflet-layer-view-factory');
 var GMapsLayerViewFactory = require('./gmaps/gmaps-layer-view-factory');
 
-var MapViewFactory = function (options) {
-  options = options || {};
-  this._vector = options.vector;
-};
+var MapViewFactory = function () {};
 
 MapViewFactory.prototype.createMapView = function (provider, mapModel, el) {
   var MapViewClass;
@@ -30,7 +27,7 @@ MapViewFactory.prototype.createMapView = function (provider, mapModel, el) {
     el: el,
     map: mapModel,
     layerViewFactory: new LayerViewFactoryClass({
-      vector: this._vector
+      vector: mapModel.get('vector')
     })
   });
 };

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -18,7 +18,9 @@ var Map = Model.extend({
     scrollwheel: true,
     drag: true,
     keyboard: true,
-    provider: 'leaflet'
+    provider: 'leaflet',
+    // enforce client-side rendering using GeoJSON vector tiles
+    vector: false
   },
 
   RELOAD_DEBOUNCE_TIME: 10,

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -371,7 +371,9 @@ var Vis = View.extend({
 
     this.$el.append(div);
 
-    var mapViewFactory = new MapViewFactory();
+    var mapViewFactory = new MapViewFactory({
+      vector: data.vector
+    });
     this.mapView = mapViewFactory.createMapView(this.map.get('provider'), this.map, div_hack);
 
     // Bindings

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -311,7 +311,8 @@ var Vis = View.extend({
       legends: data.legends,
       scrollwheel: scrollwheel,
       drag: allowDragging,
-      provider: data.map_provider
+      provider: data.map_provider,
+      vector: data.vector,
     };
 
     if (data.bounds) {
@@ -371,9 +372,7 @@ var Vis = View.extend({
 
     this.$el.append(div);
 
-    var mapViewFactory = new MapViewFactory({
-      vector: data.vector
-    });
+    var mapViewFactory = new MapViewFactory();
     this.mapView = mapViewFactory.createMapView(this.map.get('provider'), this.map, div_hack);
 
     // Bindings

--- a/test/spec/geo/map/shared-for-interactive-layers.js
+++ b/test/spec/geo/map/shared-for-interactive-layers.js
@@ -12,7 +12,7 @@ module.exports = function (LayerModel) {
     'setDataProvider',
     'getDataProvider'
   ];
-  _.each(METHODS, function (method) {  
+  _.each(METHODS, function (method) {
     it('should respond to .' + method, function () {
       var layer = new LayerModel();
 


### PR DESCRIPTION
This change replaces the current mechanism that we use to determine when to render client-side. With this change, viz.json accepts a new `vector` option that can be used to enforce client-side rendering. I added an example that uses this new option(`examples/v4/leaflet-layergroup-vector.html`).

@javisantana yay or nay?