### PR TITLE
Disable filter and unset range on bins, start, and end change on a histogram dataview

### DIFF
--- a/src/dataviews/histogram-dataview-model.js
+++ b/src/dataviews/histogram-dataview-model.js
@@ -61,7 +61,7 @@ module.exports = DataviewModelBase.extend({
     }, this);
     this.listenTo(this.layer, 'change:meta', this._onChangeLayerMeta);
     this.on('change:column', this._reloadMap, this);
-    this.on('change:bins change:start change:end', this._refreshAndResetFilter, this);
+    this.on('change:bins change:start change:end', this._fetchAndResetFilter, this);
   },
 
   enableFilter: function () {
@@ -137,8 +137,8 @@ module.exports = DataviewModelBase.extend({
     }, this);
   },
 
-  _refreshAndResetFilter: function () {
-    this.refresh();
+  _fetchAndResetFilter: function () {
+    this.fetch();
     this.disableFilter();
     this.filter.unsetRange();
   }

--- a/src/dataviews/histogram-dataview-model.js
+++ b/src/dataviews/histogram-dataview-model.js
@@ -61,7 +61,7 @@ module.exports = DataviewModelBase.extend({
     }, this);
     this.listenTo(this.layer, 'change:meta', this._onChangeLayerMeta);
     this.on('change:column', this._reloadMap, this);
-    this.on('change:bins', this.refresh, this);
+    this.on('change:bins change:start change:end', this._refreshAndResetFilter, this);
   },
 
   enableFilter: function () {
@@ -135,6 +135,12 @@ module.exports = DataviewModelBase.extend({
         this.trigger('histogram_sizes', this);
       }
     }, this);
+  },
+
+  _refreshAndResetFilter: function () {
+    this.refresh();
+    this.disableFilter();
+    this.filter.unsetRange();
   }
 },
 

--- a/test/spec/dataviews/histogram-dataview-model.spec.js
+++ b/test/spec/dataviews/histogram-dataview-model.spec.js
@@ -1,4 +1,5 @@
 var Model = require('../../../src/core/model');
+var RangeFilter = require('../../../src/windshaft/filters/range');
 var HistogramDataviewModel = require('../../../src/dataviews/histogram-dataview-model');
 
 describe('dataviews/histogram-dataview-model', function () {
@@ -6,7 +7,7 @@ describe('dataviews/histogram-dataview-model', function () {
     this.map = jasmine.createSpyObj('map', ['getViewBounds', 'bind', 'reload']);
     this.map.getViewBounds.and.returnValue([[1, 2], [3, 4]]);
     var windshaftMap = jasmine.createSpyObj('windhsaftMap', ['bind']);
-    this.filter = new Model();
+    this.filter = new RangeFilter();
     this.layer = new Model();
     this.model = new HistogramDataviewModel({}, {
       map: this.map,
@@ -22,12 +23,73 @@ describe('dataviews/histogram-dataview-model', function () {
     expect(this.map.reload).toHaveBeenCalled();
   });
 
-  it('should refresh data on bins change', function () {
-    this.map.reload.calls.reset();
-    spyOn(this.model, 'fetch');
-    this.model.set('bins', 123);
-    expect(this.map.reload).not.toHaveBeenCalled();
-    expect(this.model.fetch).toHaveBeenCalled();
+  describe('when bins change', function () {
+    beforeEach(function () {
+      this.map.reload.calls.reset();
+      spyOn(this.model, 'fetch');
+      spyOn(this.model.filter, 'unsetRange');
+
+      this.model.set('bins', 123);
+    });
+
+    it('should refresh data on bins change', function () {
+      expect(this.map.reload).not.toHaveBeenCalled();
+      expect(this.model.fetch).toHaveBeenCalled();
+    });
+
+    it('should disable filter', function () {
+      expect(this.model.get('own_filter')).toBeUndefined();
+    });
+
+    it('should unset range filter', function () {
+      expect(this.model.filter.unsetRange).toHaveBeenCalled();
+    });
+  });
+
+  describe('when start change', function () {
+    beforeEach(function () {
+      this.map.reload.calls.reset();
+      spyOn(this.model, 'fetch');
+      spyOn(this.model.filter, 'unsetRange');
+
+      this.model.set('start', 0);
+    });
+
+    it('should refresh data on bins change', function () {
+      expect(this.map.reload).not.toHaveBeenCalled();
+      expect(this.model.fetch).toHaveBeenCalled();
+    });
+
+    it('should disable filter', function () {
+      expect(this.model.get('own_filter')).toBeUndefined();
+    });
+
+    it('should unset range filter', function () {
+      expect(this.model.filter.unsetRange).toHaveBeenCalled();
+    });
+  });
+
+  describe('when end change', function () {
+    beforeEach(function () {
+      this.map.reload.calls.reset();
+      spyOn(this.model, 'fetch');
+      spyOn(this.model.filter, 'unsetRange');
+
+      this.model.set('end', 0);
+    });
+
+    it('should refresh data on bins change', function () {
+      expect(this.map.reload).not.toHaveBeenCalled();
+      expect(this.model.fetch).toHaveBeenCalled();
+    });
+
+    it('should disable filter', function () {
+      expect(this.model.get('own_filter')).toBeUndefined();
+    });
+
+    it('should unset range filter', function () {
+      expect(this.model.filter.unsetRange).toHaveBeenCalled();
+    });
   });
 
   it('should include the bbox after the first fetch', function () {


### PR DESCRIPTION
Extracted from https://github.com/CartoDB/deep-insights.js/blob/96c5b72846d5c6c13c97c10260f435ba60f6b538/src/widgets/histogram/content-view.js#L314-L315 since
this should apply for all histograms, including time-series (which is also why start and end are included)

Required to solve https://github.com/CartoDB/deep-insights.js/issues/244 (PR: https://github.com/CartoDB/deep-insights.js/pull/253)

@alonsogarciapablo can you review?