### PR TITLE
Remove the possibility to edit start/end values of a histogram

### DIFF
--- a/src/dataviews/histogram-dataview-model.js
+++ b/src/dataviews/histogram-dataview-model.js
@@ -149,9 +149,7 @@ module.exports = DataviewModelBase.extend({
     ATTRS_NAMES: DataviewModelBase.ATTRS_NAMES.concat([
       'column',
       'column_type',
-      'bins',
-      'start',
-      'end'
+      'bins'
     ])
   }
 );


### PR DESCRIPTION
After discussion w/ @javisantana regarding problematic use-cases related to changing start/end values for a time-series histogram, we concluded that it’s better it works like a normal histogram, i.e. the data range gets set on the initial fetch (calculated server-side based on the dataset), and can’t be changed after that.

I'll update DI and editor after this is merged (to remove the possibility to change the start/end dates).

cc @alonsogarciapablo 