### PR TITLE
Ensure featureClick and featureOver events are bound once

### DIFF
--- a/src/vis/infowindow-manager.js
+++ b/src/vis/infowindow-manager.js
@@ -48,8 +48,8 @@ InfowindowManager.prototype._addInfowindowOverlay = function (layerView, layerMo
 
 InfowindowManager.prototype._bindFeatureClickEvent = function (layerView) {
   var infowindowView = layerView.infowindowView;
-  layerView.unbind('featureClick');
-  layerView.bind('featureClick', function (e, latlng, pos, data, layerIndex) {
+
+  var onFeatureClick = function (e, latlng, pos, data, layerIndex) {
     var layerModel = layerView.model;
     if (layerModel.layers) {
       layerModel = layerModel.layers.at(layerIndex);
@@ -106,7 +106,9 @@ InfowindowManager.prototype._bindFeatureClickEvent = function (layerView) {
         return feature.cartodb_id !== cartoDBId;
       }).hide();
     }
-  });
+  };
+  layerView.unbind('featureClick', onFeatureClick);
+  layerView.bind('featureClick', onFeatureClick);
 };
 
 module.exports = InfowindowManager;

--- a/src/vis/infowindow-manager.js
+++ b/src/vis/infowindow-manager.js
@@ -26,7 +26,7 @@ InfowindowManager.prototype._addInfowindowForLayer = function (layerModel) {
     var layerView = this._mapView.getLayerViewByLayerCid(layerModel.cid);
 
     this._addInfowindowOverlay(layerView, layerModel);
-    this._bindFeatureClickEvent(layerView, layerModel);
+    this._bindFeatureClickEvent(layerView);
 
     layerView.bind('mouseover', function () {
       this._mapView.setCursor('pointer');
@@ -46,9 +46,18 @@ InfowindowManager.prototype._addInfowindowOverlay = function (layerView, layerMo
   }
 };
 
-InfowindowManager.prototype._bindFeatureClickEvent = function (layerView, layerModel) {
+InfowindowManager.prototype._bindFeatureClickEvent = function (layerView) {
   var infowindowView = layerView.infowindowView;
+  layerView.unbind('featureClick');
   layerView.bind('featureClick', function (e, latlng, pos, data, layerIndex) {
+    var layerModel = layerView.model;
+    if (layerModel.layers) {
+      layerModel = layerModel.layers.at(layerIndex);
+    }
+    if (!layerModel) {
+      throw new Error('featureClick event for layer ' + layerIndex + ' was captured but layerModel coudn\'t be retrieved');
+    }
+
     var infowindowFields = layerModel.getInfowindowData();
     if (!infowindowFields) {
       return;

--- a/src/vis/tooltip-manager.js
+++ b/src/vis/tooltip-manager.js
@@ -53,8 +53,8 @@ TooltipManager.prototype._addTooltipOverlay = function (layerView, layerModel) {
 
 TooltipManager.prototype._bindFeatureOverEvent = function (layerView) {
   var tooltipView = layerView.tooltipView;
-  layerView.unbind('featureOver');
-  layerView.bind('featureOver', function (e, latlng, pos, data, layerIndex) {
+
+  var onFeatureOver = function (e, latlng, pos, data, layerIndex) {
     var layerModel = layerView.model;
     if (layerModel.layers) {
       layerModel = layerModel.layers.at(layerIndex);
@@ -72,7 +72,9 @@ TooltipManager.prototype._bindFeatureOverEvent = function (layerView) {
     } else {
       tooltipView.disable();
     }
-  });
+  };
+  layerView.unbind('featureOver', onFeatureOver);
+  layerView.bind('featureOver', onFeatureOver);
 };
 
 module.exports = TooltipManager;

--- a/src/vis/tooltip-manager.js
+++ b/src/vis/tooltip-manager.js
@@ -24,7 +24,7 @@ TooltipManager.prototype._addTooltipForLayer = function (layerModel) {
     var layerView = this._mapView.getLayerViewByLayerCid(layerModel.cid);
 
     this._addTooltipOverlay(layerView, layerModel);
-    this._bindFeatureOverEvent(layerView, layerModel);
+    this._bindFeatureOverEvent(layerView);
   }
 };
 
@@ -51,15 +51,24 @@ TooltipManager.prototype._addTooltipOverlay = function (layerView, layerModel) {
   }
 };
 
-TooltipManager.prototype._bindFeatureOverEvent = function (layerView, layerModel) {
+TooltipManager.prototype._bindFeatureOverEvent = function (layerView) {
   var tooltipView = layerView.tooltipView;
-  layerView.bind('featureOver', function (e, latlng, pos, data, layer) {
+  layerView.unbind('featureOver');
+  layerView.bind('featureOver', function (e, latlng, pos, data, layerIndex) {
+    var layerModel = layerView.model;
+    if (layerModel.layers) {
+      layerModel = layerModel.layers.at(layerIndex);
+    }
+    if (!layerModel) {
+      throw new Error('featureOver event for layer ' + layerIndex + ' was captured but layerModel coudn\'t be retrieved');
+    }
+
     var tooltipData = layerModel.getTooltipData();
     if (tooltipData) {
       tooltipView.setTemplate(tooltipData.template);
       tooltipView.setFields(tooltipData.fields);
       tooltipView.setAlternativeNames(tooltipData.alternative_names);
-      tooltipView.enable();
+      // tooltipView.enable();
     } else {
       tooltipView.disable();
     }

--- a/test/spec/vis/infowindow-manager-spec.js
+++ b/test/spec/vis/infowindow-manager-spec.js
@@ -116,45 +116,63 @@ describe('src/vis/infowindow-manager.js', function () {
     expect(this.mapView.addInfowindow).not.toHaveBeenCalled();
   });
 
-  it('should correctly bind the featureClick event to the corresponding layerView', function () {
+  it('should correctly bind the featureClick event to the corresponding layerView (when layerView has a group of layers)', function () {
     spyOn(this.mapView, 'addInfowindow');
 
-    var layer = new CartoDBLayer({
+    var layer1 = new CartoDBLayer({
       infowindow: {
-        template: 'template',
+        template: 'template1',
         template_type: 'underscore',
         fields: [{
           'name': 'name',
           'title': true,
           'position': 1
         }],
-        alternative_names: 'alternative_names'
+        alternative_names: 'alternative_names1'
+      }
+    });
+
+    var layer2 = new CartoDBLayer({
+      infowindow: {
+        template: 'template2',
+        template_type: 'underscore',
+        fields: [{
+          'name': 'description',
+          'title': true,
+          'position': 1
+        }],
+        alternative_names: 'alternative_names2'
       }
     });
 
     var infowindowManager = new InfowindowManager(this.vis);
     infowindowManager.manage(this.mapView, this.map);
 
-    this.map.layers.reset([ layer ]);
+    this.map.layers.reset([ layer1, layer2 ]);
     var infowindowView = this.mapView.addInfowindow.calls.mostRecent().args[0];
     var infowindowModel = infowindowView.model;
 
     this.layerView.model = {
-      fetchAttributes: jasmine.createSpy('fetchAttributes').and.returnValue({ name: 'Juan' })
+      fetchAttributes: jasmine.createSpy('fetchAttributes').and.callFake(function (layerIndex, cartoDBId, callback) {
+        callback({ name: 'juan' });
+      }),
+      layers: new Backbone.Collection([ layer1, layer2 ])
     };
     spyOn(infowindowView, 'adjustPan');
 
-    // Simulate the featureClick event
-    this.layerView.trigger('featureClick', {}, [100, 200], undefined, { cartodb_id: 10 }, 1);
+    // Simulate the featureClick event for layer #0
+    this.layerView.trigger('featureClick', {}, [100, 200], undefined, { cartodb_id: 10 }, 0);
 
     // A request to fetch the attributes for the right cartodb_id and layerIndex has been triggered
-    expect(this.layerView.model.fetchAttributes).toHaveBeenCalledWith(1, 10, jasmine.any(Function));
+    expect(this.layerView.model.fetchAttributes.calls.count()).toEqual(1);
+    expect(this.layerView.model.fetchAttributes).toHaveBeenCalledWith(0, 10, jasmine.any(Function));
+    this.layerView.model.fetchAttributes.calls.reset();
 
     // InfowindowModel has been updated
     expect(infowindowModel.attributes).toEqual({
-      'template': 'template',
+      'template': 'template1',
       'template_type': 'underscore',
-      'alternative_names': 'alternative_names',
+      'alternative_names': 'alternative_names1',
       'fields': [
         {
           'name': 'name',
@@ -182,7 +200,129 @@ describe('src/vis/infowindow-manager.js', function () {
           }
         ]
       },
-      'visibility': true
+      'visibility': true,
+      'sanitizeTemplate': undefined,
+      'width': undefined
+    });
+
+    // Simulate the featureClick event for layer #1
+    this.layerView.trigger('featureClick', {}, [100, 200], undefined, { cartodb_id: 100 }, 1);
+
+    // A request to fetch the attributes for the right cartodb_id and layerIndex has been triggered
+    expect(this.layerView.model.fetchAttributes.calls.count()).toEqual(1);
+    expect(this.layerView.model.fetchAttributes).toHaveBeenCalledWith(1, 100, jasmine.any(Function));
+    this.layerView.model.fetchAttributes.calls.reset();
+
+    // InfowindowModel has been updated
+    expect(infowindowModel.attributes).toEqual({
+      'template': 'template2',
+      'template_type': 'underscore',
+      'alternative_names': 'alternative_names2',
+      'fields': [
+        {
+          'name': 'description',
+          'title': true,
+          'position': 1
+        }
+      ],
+      'template_name': 'infowindow_light',
+      'latlng': [
+        100,
+        200
+      ],
+      'offset': [
+        28,
+        0
+      ],
+      'maxHeight': 180,
+      'autoPan': true,
+      'content': {
+        'fields': [
+          {
+            'type': 'loading',
+            'title': 'loading',
+            'value': '…'
+          }
+        ]
+      },
+      'visibility': true,
+      'sanitizeTemplate': undefined,
+      'width': undefined
+    });
+  });
+
+  it('should correctly bind the featureClick event to the corresponding layerView (when layerView has a single layer)', function () {
+    spyOn(this.mapView, 'addInfowindow');
+
+    var layer = new CartoDBLayer({
+      infowindow: {
+        template: 'template1',
+        template_type: 'underscore',
+        fields: [{
+          'name': 'name',
+          'title': true,
+          'position': 1
+        }],
+        alternative_names: 'alternative_names1'
+      }
+    });
+
+    var infowindowManager = new InfowindowManager(this.vis);
+    infowindowManager.manage(this.mapView, this.map);
+
+    this.map.layers.reset([ layer ]);
+    var infowindowView = this.mapView.addInfowindow.calls.mostRecent().args[0];
+    var infowindowModel = infowindowView.model;
+
+    this.layerView.model = layer;
+    layer.fetchAttributes = jasmine.createSpy('fetchAttributes').and.callFake(function (layerIndex, cartoDBId, callback) {
+      callback({ name: 'juan' });
+    });
+    spyOn(infowindowView, 'adjustPan');
+
+    // Simulate the featureClick event for layer #0
+    this.layerView.trigger('featureClick', {}, [100, 200], undefined, { cartodb_id: 10 }, 0);
+
+    // A request to fetch the attributes for the right cartodb_id and layerIndex has been triggered
+    expect(this.layerView.model.fetchAttributes.calls.count()).toEqual(1);
+    expect(this.layerView.model.fetchAttributes).toHaveBeenCalledWith(0, 10, jasmine.any(Function));
+    this.layerView.model.fetchAttributes.calls.reset();
+
+    // InfowindowModel has been updated
+    expect(infowindowModel.attributes).toEqual({
+      'template': 'template1',
+      'template_type': 'underscore',
+      'alternative_names': 'alternative_names1',
+      'fields': [
+        {
+          'name': 'name',
+          'title': true,
+          'position': 1
+        }
+      ],
+      'template_name': 'infowindow_light',
+      'latlng': [
+        100,
+        200
+      ],
+      'offset': [
+        28,
+        0
+      ],
+      'maxHeight': 180,
+      'autoPan': true,
+      'content': {
+        'fields': [
+          {
+            'type': 'loading',
+            'title': 'loading',
+            'value': '…'
+          }
+        ]
+      },
+      'visibility': true,
+      'sanitizeTemplate': undefined,
+      'width': undefined
     });
   });
 
@@ -214,12 +354,13 @@ describe('src/vis/infowindow-manager.js', function () {
     var infowindowView = this.mapView.addInfowindow.calls.mostRecent().args[0];
 
     this.layerView.model = {
-      fetchAttributes: jasmine.createSpy('fetchAttributes').and.returnValue({ name: 'Juan' })
+      fetchAttributes: jasmine.createSpy('fetchAttributes').and.returnValue({ name: 'Juan' }),
+      layers: new Backbone.Collection([ layer ])
     };
     spyOn(infowindowView, 'adjustPan');
 
     // Simulate the featureClick event
-    this.layerView.trigger('featureClick', {}, [100, 200], undefined, { cartodb_id: 10 }, 1);
+    this.layerView.trigger('featureClick', {}, [100, 200], undefined, { cartodb_id: 10 }, 0);
 
     expect(this.layerView.tooltipView.setFilter).toHaveBeenCalled();
     var filterFunction = this.layerView.tooltipView.setFilter.calls.mostRecent().args[0];

--- a/test/spec/vis/tooltip-manager-spec.js
+++ b/test/spec/vis/tooltip-manager-spec.js
@@ -145,7 +145,6 @@ describe('src/vis/tooltip-manager.js', function () {
       }
     });
 
-
     var tooltipManager = new TooltipManager(this.vis);
     tooltipManager.manage(this.mapView, this.map);
 


### PR DESCRIPTION
There was a problem with how we were binding featureClick and featureOver events to layerView. We're basically binding the same events multiple times and when one of these two events, handlers were being executed multiple times (one per layer). This PR fixes it.

@javisantana :es: please