### PR TITLE
Forcing dataview model fetch new data although sync_on_data_change attribute is disabled

### DIFF
--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -42,7 +42,7 @@ module.exports = DataviewModelBase.extend({
     this._data = new CategoriesCollection();
     this._searchModel = new SearchModel();
 
-    this.on('change:column change:aggregation change:aggregation_column', this._reloadMap, this);
+    this.on('change:column change:aggregation change:aggregation_column', this._reloadMapAndForceFetch, this);
   },
 
   // Set any needed parameter when they have changed in this model

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -139,7 +139,7 @@ module.exports = Model.extend({
     this.listenTo(this._map, 'change:center change:zoom', _.debounce(this._onMapBoundsChanged.bind(this), BOUNDING_BOX_FILTER_WAIT));
 
     this.on('change:url', function (mdl, attrs, opts) {
-      if (opts.forceFetch || this._shouldFetchOnURLChange()) {
+      if ((opts && opts.forceFetch) || this._shouldFetchOnURLChange()) {
         this.fetch();
       }
     }, this);

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -150,7 +150,7 @@ module.exports = Model.extend({
   },
 
   _shouldFetchOnURLChange: function () {
-    return this.get('sync_on_data_change') && this.get('enabled');
+    return (this.get('sync_on_data_change') && this.get('enabled')) || (this._wasUpdated && this.get('enabled'));
   },
 
   _shouldFetchOnBoundingBoxChange: function () {
@@ -163,6 +163,7 @@ module.exports = Model.extend({
 
   update: function (attrs) {
     attrs = _.pick(attrs, this.constructor.ATTRS_NAMES);
+    this._wasUpdated = true;
     this.set(attrs);
   },
 
@@ -187,9 +188,11 @@ module.exports = Model.extend({
       success: function () {
         successCallback && successCallback(arguments);
         this.trigger('loaded', this);
+        this._wasUpdated = false;
       }.bind(this),
       error: function (mdl, err) {
         if (!err || (err && err.statusText !== 'abort')) {
+          this._wasUpdated = false;
           this.trigger('error', mdl, err);
         }
       }.bind(this)

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -179,7 +179,7 @@ module.exports = Model.extend({
   },
 
   _shouldFetchOnURLChange: function () {
-    return (this.get('sync_on_data_change') && this.get('enabled'));
+    return this.get('sync_on_data_change') && this.get('enabled');
   },
 
   _shouldFetchOnBoundingBoxChange: function () {

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -81,13 +81,24 @@ module.exports = Model.extend({
   /**
    * @protected
    */
-  _reloadMap: function () {
-    this._map.reload({
-      sourceLayerId: this.layer.get('id')
+  _reloadMap: function (opts) {
+    opts = opts || {};
+    this._map.reload(
+      _.extend(
+        opts, {
+          sourceLayerId: this.layer.get('id')
+        }
+      )
+    );
+  },
+
+  _reloadMapAndForceFetch: function () {
+    this._reloadMap({
+      forceFetch: true
     });
   },
 
-  _onNewWindshaftMapInstance: function (windshaftMapInstance, sourceLayerId) {
+  _onNewWindshaftMapInstance: function (windshaftMapInstance, sourceLayerId, forceFetch) {
     var url = windshaftMapInstance.getDataviewURL({
       dataviewId: this.get('id'),
       protocol: window.location.protocol === 'https:' ? 'https' : 'http'
@@ -97,7 +108,10 @@ module.exports = Model.extend({
       var silent = (sourceLayerId && sourceLayerId !== this.layer.get('id'));
 
       // TODO: Instead of setting the url here, we could invoke fetch directly
-      this.set('url', url, { silent: silent });
+      this.set('url', url, {
+        silent: silent,
+        forceFetch: forceFetch
+      });
     }
   },
 
@@ -124,8 +138,8 @@ module.exports = Model.extend({
   _onChangeBinds: function () {
     this.listenTo(this._map, 'change:center change:zoom', _.debounce(this._onMapBoundsChanged.bind(this), BOUNDING_BOX_FILTER_WAIT));
 
-    this.on('change:url', function () {
-      if (this._shouldFetchOnURLChange()) {
+    this.on('change:url', function (mdl, attrs, opts) {
+      if (opts.forceFetch || this._shouldFetchOnURLChange()) {
         this.fetch();
       }
     }, this);
@@ -150,7 +164,7 @@ module.exports = Model.extend({
   },
 
   _shouldFetchOnURLChange: function () {
-    return (this.get('sync_on_data_change') && this.get('enabled')) || (this._wasUpdated && this.get('enabled'));
+    return (this.get('sync_on_data_change') && this.get('enabled'));
   },
 
   _shouldFetchOnBoundingBoxChange: function () {
@@ -163,7 +177,6 @@ module.exports = Model.extend({
 
   update: function (attrs) {
     attrs = _.pick(attrs, this.constructor.ATTRS_NAMES);
-    this._wasUpdated = true;
     this.set(attrs);
   },
 
@@ -188,11 +201,9 @@ module.exports = Model.extend({
       success: function () {
         successCallback && successCallback(arguments);
         this.trigger('loaded', this);
-        this._wasUpdated = false;
       }.bind(this),
       error: function (mdl, err) {
         if (!err || (err && err.statusText !== 'abort')) {
-          this._wasUpdated = false;
           this.trigger('error', mdl, err);
         }
       }.bind(this)

--- a/src/dataviews/formula-dataview-model.js
+++ b/src/dataviews/formula-dataview-model.js
@@ -12,7 +12,7 @@ module.exports = DataviewModelBase.extend({
 
   initialize: function () {
     DataviewModelBase.prototype.initialize.apply(this, arguments);
-    this.on('change:column change:operation', this._reloadMap, this);
+    this.on('change:column change:operation', this._reloadMapAndForceFetch, this);
   },
 
   parse: function (r) {

--- a/src/dataviews/histogram-dataview-model.js
+++ b/src/dataviews/histogram-dataview-model.js
@@ -60,7 +60,7 @@ module.exports = DataviewModelBase.extend({
       }
     }, this);
     this.listenTo(this.layer, 'change:meta', this._onChangeLayerMeta);
-    this.on('change:column', this._reloadMap, this);
+    this.on('change:column', this._reloadMapAndForceFetch, this);
     this.on('change:bins change:start change:end', this._fetchAndResetFilter, this);
   },
 

--- a/src/dataviews/list-dataview-model.js
+++ b/src/dataviews/list-dataview-model.js
@@ -15,7 +15,7 @@ module.exports = DataviewModelBase.extend({
   initialize: function (attrs, opts) {
     DataviewModelBase.prototype.initialize.call(this, attrs, opts);
     this._data = new Backbone.Collection(this.get('data'));
-    this.on('change:columns', this._reloadMap, this);
+    this.on('change:columns', this._reloadMapAndForceFetch, this);
   },
 
   getData: function () {

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -82,7 +82,8 @@ var Map = Model.extend({
     if (this._windshaftMap) {
       var instanceOptions = {
         layers: this.layers.models,
-        sourceLayerId: options && options.sourceLayerId
+        sourceLayerId: options && options.sourceLayerId,
+        forceFetch: options && options.forceFetch
       };
 
       if (this._dataviewsCollection) {
@@ -95,8 +96,8 @@ var Map = Model.extend({
   _updateAttributions: function () {
     var defaultCartoDBAttribution = this.defaults.attribution[0];
     var attributions = _.chain(this.layers.models)
-      .map(function(layer) { return sanitize.html(layer.get('attribution')); })
-      .reject(function(attribution) { return attribution == defaultCartoDBAttribution})
+      .map(function (layer) { return sanitize.html(layer.get('attribution')); })
+      .reject(function (attribution) { return attribution === defaultCartoDBAttribution; })
       .compact()
       .uniq()
       .value();

--- a/src/windshaft/windshaft-map.js
+++ b/src/windshaft/windshaft-map.js
@@ -39,6 +39,7 @@ var WindshaftMap = Backbone.Model.extend({
     });
     var dataviews = options.dataviews;
     var sourceLayerId = options.sourceLayerId;
+    var forceFetch = options.forceFetch;
 
     var mapConfig = this.configGenerator.generate({
       layers: layers,
@@ -66,7 +67,7 @@ var WindshaftMap = Backbone.Model.extend({
       filters: filters.toJSON(),
       success: function (mapInstance) {
         this.set(mapInstance);
-        this.trigger('instanceCreated', this, sourceLayerId);
+        this.trigger('instanceCreated', this, sourceLayerId, forceFetch);
 
         // TODO: Revisit this (will layerIndex work for NamedMaps??)
         // Should we move it somewhere else?

--- a/test/spec/dataviews/category-dataview-model.spec.js
+++ b/test/spec/dataviews/category-dataview-model.spec.js
@@ -15,18 +15,18 @@ describe('dataviews/category-dataview-model', function () {
     });
   });
 
-  it('should reload map on changing attrs', function () {
+  it('should reload map and force fetch on changing attrs', function () {
     this.map.reload.calls.reset();
     this.model.set('column', 'random_col');
-    expect(this.map.reload).toHaveBeenCalled();
+    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceLayerId: undefined });
 
     this.map.reload.calls.reset();
     this.model.set('aggregation', 'count');
-    expect(this.map.reload).toHaveBeenCalled();
+    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceLayerId: undefined });
 
     this.map.reload.calls.reset();
     this.model.set('aggregation_column', 'other');
-    expect(this.map.reload).toHaveBeenCalled();
+    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceLayerId: undefined });
   });
 
   it('should define several internal models/collections', function () {

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -72,6 +72,17 @@ describe('dataviews/dataview-model-base', function () {
       expect(this.model.fetch).not.toHaveBeenCalled();
     });
 
+    it('should fetch if url changes and forceFetch option is true, no matter rest of variables', function () {
+      this.model.set('enabled', false);
+      this.model.set('sync_on_data_change', false);
+      spyOn(this.model, 'fetch');
+      this.model.trigger('change:url', this.model, {}, { forceFetch: true });
+      expect(this.model.fetch).toHaveBeenCalled();
+      this.model.fetch.calls.reset();
+      this.model.trigger('change:url', this.model, {}, { forceFetch: false });
+      expect(this.model.fetch).not.toHaveBeenCalled();
+    });
+
     it('should not fetch new data when bbox changes and bbox is disabled', function () {
       this.model.set('sync_on_bbox_change', false);
       spyOn(this.model, 'fetch');

--- a/test/spec/dataviews/formula-dataview-model.spec.js
+++ b/test/spec/dataviews/formula-dataview-model.spec.js
@@ -14,15 +14,15 @@ describe('dataviews/formula-dataview-model', function () {
     });
   });
 
-  it('should reload map on operation change', function () {
+  it('should reload map and force fetch on operation change', function () {
     this.map.reload.calls.reset();
     this.model.set('operation', 'avg');
-    expect(this.map.reload).toHaveBeenCalled();
+    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceLayerId: undefined });
   });
 
-  it('should reload map on column change', function () {
+  it('should reload map and force fetch on column change', function () {
     this.map.reload.calls.reset();
     this.model.set('column', 'other_col');
-    expect(this.map.reload).toHaveBeenCalled();
+    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceLayerId: undefined });
   });
 });

--- a/test/spec/dataviews/histogram-dataview-model.spec.js
+++ b/test/spec/dataviews/histogram-dataview-model.spec.js
@@ -18,10 +18,13 @@ describe('dataviews/histogram-dataview-model', function () {
     });
   });
 
-  it('should reload map on changing attrs', function () {
-    this.map.reload.calls.reset();
-    this.model.set('column', 'random_col');
-    expect(this.map.reload).toHaveBeenCalled();
+
+  describe('when column changes', function () {
+    it('should reload map and force fetch', function () {
+      this.map.reload.calls.reset();
+      this.model.set('column', 'random_col');
+      expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceLayerId: undefined });
+    });
   });
 
   describe('when bins change', function () {

--- a/test/spec/dataviews/histogram-dataview-model.spec.js
+++ b/test/spec/dataviews/histogram-dataview-model.spec.js
@@ -18,7 +18,6 @@ describe('dataviews/histogram-dataview-model', function () {
     });
   });
 
-
   describe('when column changes', function () {
     it('should reload map and force fetch', function () {
       this.map.reload.calls.reset();

--- a/test/spec/dataviews/list-dataview-model.spec.js
+++ b/test/spec/dataviews/list-dataview-model.spec.js
@@ -13,9 +13,9 @@ describe('dataviews/list-dataview-model', function () {
     });
   });
 
-  it('should reload map on columns change', function () {
+  it('should reload map and force fetch on columns change', function () {
     this.map.reload.calls.reset();
     this.model.set('columns', ['asd']);
-    expect(this.map.reload).toHaveBeenCalled();
+    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceLayerId: undefined });
   });
 });

--- a/test/spec/windshaft/windshaft-map.spec.js
+++ b/test/spec/windshaft/windshaft-map.spec.js
@@ -133,7 +133,7 @@ describe('windshaft/map', function () {
         sourceLayerId: 'sourceLayerId'
       });
 
-      expect(onWindshaftInstanceCreated).toHaveBeenCalledWith(this.windshaftMap, 'sourceLayerId');
+      expect(onWindshaftInstanceCreated).toHaveBeenCalledWith(this.windshaftMap, 'sourceLayerId', undefined);
     });
 
     it('should set the attributes of the new instance', function () {


### PR DESCRIPTION
Basically, if a widget has disabled sync_on_data_change, it will not change if there is an update of its 'column'.
We need to test this but I'd like your opinion before doing that. How does this approach sound?

- [ ] Create necessary test(s) for this behaviour.

CR: @alonsogarciapablo

Fixes #1144