### PR TITLE
Possibility to set start or/and end params for histogram initialization

### DIFF
--- a/src/dataviews/histogram-dataview-model.js
+++ b/src/dataviews/histogram-dataview-model.js
@@ -148,7 +148,9 @@ module.exports = DataviewModelBase.extend({
     ATTRS_NAMES: DataviewModelBase.ATTRS_NAMES.concat([
       'column',
       'column_type',
-      'bins'
+      'bins',
+      'start',
+      'end'
     ])
   }
 );


### PR DESCRIPTION
Not sure if we should reset histogram widget if any of those params have changed (in Deep-insights).

CR: @alonsogarciapablo 
cc @AbelVM 