### PR TITLE
Do not add cartodb_id column in interactivity column if there is no infowindow or tooltip field names required

### DIFF
--- a/src/geo/map/cartodb-layer.js
+++ b/src/geo/map/cartodb-layer.js
@@ -74,11 +74,14 @@ var CartoDBLayer = LayerModelBase.extend({
   },
 
   getInteractiveColumnNames: function() {
-    return _.uniq(
-      ['cartodb_id']
-        .concat(this.getInfowindowFieldNames())
-         .concat(this.getTooltipFieldNames())
+    var fieldNames = _.union(
+      this.getInfowindowFieldNames(),
+      this.getTooltipFieldNames()
     );
+    if (fieldNames.length) {
+      fieldNames.unshift('cartodb_id');
+    }
+    return _.uniq(fieldNames);
   },
 
   // Layers inside a "layergroup" layer have the layer_name defined in options.layer_name

--- a/test/spec/geo/map/cartodb-layer.spec.js
+++ b/test/spec/geo/map/cartodb-layer.spec.js
@@ -1,4 +1,5 @@
 var CartoDBLayer = require('../../../../src/geo/map/cartodb-layer');
+var _ = require('underscore');
 var sharedTestsForInteractiveLayers = require('./shared-for-interactive-layers');
 
 describe('geo/map/cartodb-layer', function () {
@@ -9,7 +10,7 @@ describe('geo/map/cartodb-layer', function () {
     expect(layer.get('type')).toEqual('CartoDB');
   });
 
-  describe('.getInteractiveColumnNames', function() {
+  describe('.getInteractiveColumnNames', function () {
     beforeEach(function () {
       this.layer = new CartoDBLayer();
       spyOn(this.layer, 'getInfowindowFieldNames');
@@ -26,7 +27,7 @@ describe('geo/map/cartodb-layer', function () {
       expect(_.contains(this.layer.getInteractiveColumnNames(), 'cartodb_id')).toBeTruthy();
     });
 
-    it('should not include cartodb_id if there isn\'t any field required', function () {
+    it("should not include cartodb_id if there isn't any field required", function () {
       this.layer.getInfowindowFieldNames.and.returnValue([]);
       this.layer.getTooltipFieldNames.and.returnValue([]);
       expect(_.contains(this.layer.getInteractiveColumnNames(), 'cartodb_id')).toBeFalsy();

--- a/test/spec/geo/map/cartodb-layer.spec.js
+++ b/test/spec/geo/map/cartodb-layer.spec.js
@@ -32,7 +32,5 @@ describe('geo/map/cartodb-layer', function () {
       this.layer.getTooltipFieldNames.and.returnValue([]);
       expect(_.contains(this.layer.getInteractiveColumnNames(), 'cartodb_id')).toBeFalsy();
     });
-
   });
-
 });

--- a/test/spec/geo/map/cartodb-layer.spec.js
+++ b/test/spec/geo/map/cartodb-layer.spec.js
@@ -8,4 +8,30 @@ describe('geo/map/cartodb-layer', function () {
     var layer = new CartoDBLayer();
     expect(layer.get('type')).toEqual('CartoDB');
   });
+
+  describe('.getInteractiveColumnNames', function() {
+    beforeEach(function () {
+      this.layer = new CartoDBLayer();
+      spyOn(this.layer, 'getInfowindowFieldNames');
+      spyOn(this.layer, 'getTooltipFieldNames');
+    });
+
+    it('should include cartodb_id if there is any other field required from the infowindow or tooltip', function () {
+      this.layer.getInfowindowFieldNames.and.returnValue(['column_a']);
+      this.layer.getTooltipFieldNames.and.returnValue([]);
+      expect(_.contains(this.layer.getInteractiveColumnNames(), 'cartodb_id')).toBeTruthy();
+
+      this.layer.getInfowindowFieldNames.and.returnValue([]);
+      this.layer.getTooltipFieldNames.and.returnValue(['column_b']);
+      expect(_.contains(this.layer.getInteractiveColumnNames(), 'cartodb_id')).toBeTruthy();
+    });
+
+    it('should not include cartodb_id if there isn\'t any field required', function () {
+      this.layer.getInfowindowFieldNames.and.returnValue([]);
+      this.layer.getTooltipFieldNames.and.returnValue([]);
+      expect(_.contains(this.layer.getInteractiveColumnNames(), 'cartodb_id')).toBeFalsy();
+    });
+
+  });
+
 });

--- a/test/spec/windshaft/layergroup-config.spec.js
+++ b/test/spec/windshaft/layergroup-config.spec.js
@@ -60,7 +60,7 @@ describe('windshaft/layergroup-config', function () {
               sql: 'sql1',
               cartocss: 'cartoCSS1',
               cartocss_version: '2.0',
-              interactivity: [ 'cartodb_id' ],
+              interactivity: [],
               widgets: {
                 dataviewId: {
                   type: 'histogram',
@@ -78,7 +78,7 @@ describe('windshaft/layergroup-config', function () {
               sql: 'sql2',
               cartocss: 'cartoCSS2',
               cartocss_version: '2.0',
-              interactivity: [ 'cartodb_id' ],
+              interactivity: [],
               widgets: {
                 dataviewId2: {
                   type: 'histogram',
@@ -110,7 +110,7 @@ describe('windshaft/layergroup-config', function () {
               sql: 'sql2',
               cartocss: 'cartoCSS2',
               cartocss_version: '2.0',
-              interactivity: [ 'cartodb_id' ],
+              interactivity: [],
               widgets: {
                 dataviewId2: {
                   type: 'histogram',


### PR DESCRIPTION
Fixes #1182 
CR: @alonsogarciapablo 

cc @javisantana @fdansv 