### PR TITLE
Fixes issue with indexes when setting the metadata of layer models from Windshaft response

### DIFF
--- a/src/windshaft/windshaft-map.js
+++ b/src/windshaft/windshaft-map.js
@@ -67,11 +67,7 @@ var WindshaftMap = Backbone.Model.extend({
       filters: filters.toJSON(),
       success: function (mapInstance) {
         this.set(mapInstance);
-        this.trigger('instanceCreated', this, sourceLayerId, forceFetch);
-
-        // TODO: Revisit this (will layerIndex work for NamedMaps??)
-        // Should we move it somewhere else?
-        _.each(options.layers, function (layer, layerIndex) {
+        _.each(layers, function (layer, layerIndex) {
           if (layer.get('type') === 'torque') {
             layer.set('meta', this.getLayerMeta(layerIndex));
             layer.set('urls', this.getTiles('torque'));
@@ -79,6 +75,7 @@ var WindshaftMap = Backbone.Model.extend({
             layer.set('meta', this.getLayerMeta(layerIndex));
           }
         }, this);
+        this.trigger('instanceCreated', this, sourceLayerId, forceFetch);
       }.bind(this),
       error: function (error) {
         console.log('Error creating the map instance on Windshaft: ' + error);
@@ -202,11 +199,18 @@ var WindshaftMap = Backbone.Model.extend({
 
   getLayerMeta: function (layerIndex) {
     var layerMeta = {};
+    var metadataLayerIndex = this._localLayerIndexToWindshaftLayerIndex(layerIndex);
     var layers = this.get('metadata') && this.get('metadata').layers;
-    if (layers && layers[layerIndex]) {
-      layerMeta = layers[layerIndex].meta || {};
+    if (layers && layers[metadataLayerIndex]) {
+      layerMeta = layers[metadataLayerIndex].meta || {};
     }
     return layerMeta;
+  },
+
+  _localLayerIndexToWindshaftLayerIndex: function (layerIndex) {
+    var layers = this.get('metadata') && this.get('metadata').layers;
+    var hasTiledLayer = layers.length > 0 && layers[0].type === 'tiled';
+    return hasTiledLayer ? ++layerIndex : layerIndex;
   },
 
   _encodeParams: function (params, included) {

--- a/test/spec/windshaft/windshaft-map.spec.js
+++ b/test/spec/windshaft/windshaft-map.spec.js
@@ -146,6 +146,142 @@ describe('windshaft/map', function () {
       expect(this.windshaftMap.get('layergroupid')).toEqual('layergroupid');
       expect(this.windshaftMap.get('metadata')).toEqual(this.windshaftMapInstance.metadata);
     });
+
+    describe('metadata', function () {
+      beforeEach(function () {
+        this.dataviews = new Backbone.Collection();
+
+        this.client = new WindshaftClient({
+          endpoint: 'v1',
+          urlTemplate: 'http://{user}.wadus.com',
+          userName: 'rambo'
+        });
+        spyOn(this.client, 'instantiateMap').and.callFake(function (options) {
+          options.success(this.windshaftMapInstance);
+        }.bind(this));
+      });
+
+      describe("when there's a tiled layer as the first layer of the Windshaft response (Named Map)", function () {
+        beforeEach(function () {
+          this.windshaftMapInstance = {
+            layergroupid: 'layergroupid',
+            metadata: {
+              layers: [
+                {
+                  'type': 'tiled'
+                },
+                {
+                  'type': 'mapnik',
+                  'meta': 'cartodb-metadata',
+                  'widgets': {
+                    'dataviewId': {
+                      'url': {
+                        'http': 'http://example.com',
+                        'https': 'https://example.com'
+                      }
+                    }
+                  }
+                },
+                {
+                  'type': 'torque',
+                  'meta': 'torque-metadata'
+                }
+              ]
+            }
+          };
+        });
+
+        it('should set the meta attribute of CartoDB layers from the Windshaft response', function () {
+          this.windshaftMap.createInstance({
+            layers: [ this.cartoDBLayer1, this.torqueLayer ],
+            dataviews: this.dataviews,
+            sourceLayerId: 'sourceLayerId'
+          });
+
+          // 'meta' attribute of the CartoDB layer has been set
+          expect(this.cartoDBLayer1.get('meta')).toEqual('cartodb-metadata');
+        });
+
+        it('should set the meta and url attributes of Torque layers from the Windshaft response', function () {
+          this.windshaftMap.createInstance({
+            layers: [ this.cartoDBLayer1, this.torqueLayer ],
+            dataviews: this.dataviews,
+            sourceLayerId: 'sourceLayerId'
+          });
+
+          // 'meta' and 'urls' of the Torque layer has been set
+          expect(this.torqueLayer.get('meta')).toEqual('torque-metadata');
+          expect(this.torqueLayer.get('urls')).toEqual({
+            tiles: [
+              'http://rambo.wadus.com/api/v1/map/layergroupid/2/{z}/{x}/{y}.json.torque',
+              'http://rambo.wadus.com/api/v1/map/layergroupid/2/{z}/{x}/{y}.json.torque',
+              'http://rambo.wadus.com/api/v1/map/layergroupid/2/{z}/{x}/{y}.json.torque',
+              'http://rambo.wadus.com/api/v1/map/layergroupid/2/{z}/{x}/{y}.json.torque'
+            ],
+            grids: []
+          });
+        });
+      });
+
+      describe("when there isn't a tiled layer as the first layer of the Windshaft response (Named Map)", function () {
+        beforeEach(function () {
+          this.windshaftMapInstance = {
+            layergroupid: 'layergroupid',
+            metadata: {
+              layers: [
+                {
+                  'type': 'mapnik',
+                  'meta': 'cartodb-metadata',
+                  'widgets': {
+                    'dataviewId': {
+                      'url': {
+                        'http': 'http://example.com',
+                        'https': 'https://example.com'
+                      }
+                    }
+                  }
+                },
+                {
+                  'type': 'torque',
+                  'meta': 'torque-metadata'
+                }
+              ]
+            }
+          };
+        });
+
+        it('should set the meta attribute of CartoDB layers from the Windshaft response', function () {
+          this.windshaftMap.createInstance({
+            layers: [ this.cartoDBLayer1, this.torqueLayer ],
+            dataviews: this.dataviews,
+            sourceLayerId: 'sourceLayerId'
+          });
+
+          // 'meta' attribute of the CartoDB layer has been set
+          expect(this.cartoDBLayer1.get('meta')).toEqual('cartodb-metadata');
+        });
+
+        it('should set the meta and url attributes of Torque layers from the Windshaft response', function () {
+          this.windshaftMap.createInstance({
+            layers: [ this.cartoDBLayer1, this.torqueLayer ],
+            dataviews: this.dataviews,
+            sourceLayerId: 'sourceLayerId'
+          });
+
+          // 'meta' and 'urls' of the Torque layer has been set
+          expect(this.torqueLayer.get('meta')).toEqual('torque-metadata');
+          expect(this.torqueLayer.get('urls')).toEqual({
+            tiles: [
+              'http://rambo.wadus.com/api/v1/map/layergroupid/1/{z}/{x}/{y}.json.torque',
+              'http://rambo.wadus.com/api/v1/map/layergroupid/1/{z}/{x}/{y}.json.torque',
+              'http://rambo.wadus.com/api/v1/map/layergroupid/1/{z}/{x}/{y}.json.torque',
+              'http://rambo.wadus.com/api/v1/map/layergroupid/1/{z}/{x}/{y}.json.torque'
+            ],
+            grids: []
+          });
+        });
+      });
+    });
   });
 
   describe('#getBaseURL', function () {


### PR DESCRIPTION
We basically now ignore any possible `tiled` layer at the bottom of layers that comes from Windshaft response when getting the metadata for each of the local layer models.

@xavijam @fdansv PTAL, thanks!

