### PR TITLE
Prevents tilejson listener from invalidating cartocss

### DIFF
--- a/src/geo/leaflet/leaflet-cartodb-vector-layer-group-view.js
+++ b/src/geo/leaflet/leaflet-cartodb-vector-layer-group-view.js
@@ -62,7 +62,6 @@ var LeafletCartoDBVectorLayerGroupView = CartoDBd3Layer.extend({
 
   _onTileJSONChanged: function () {
     var tilejson = this.model.get('urls');
-    this.options.styles = this.model.layers.pluck('cartocss');
     this.setUrl(tilejson.tiles[0]);
   },
 


### PR DESCRIPTION
@alonsogarciapablo After you fixed the passing of metadata, the only thing that was broken was the tilejson listener reassigning styles by plucking the client styles. Since now we're relying on meta to always pass the styles, removing that style setter fixes the issue. Named maps are visible again in vector.