### PR TITLE
Points d3.cartodb to latest commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "underscore": "1.8.3",
     "cartoassets": "CartoDB/CartoAssets#master",
     "d3": "3.5.8",
-    "d3.cartodb": "git://github.com/CartoDB/d3.cartodb.git#c3f420a"
+    "d3.cartodb": "git://github.com/CartoDB/d3.cartodb.git#78168701bfa09bb240ab686313ff887c978107f9"
   },
   "devDependencies": {
     "browserify": "11.2.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "underscore": "1.8.3",
     "cartoassets": "CartoDB/CartoAssets#master",
     "d3": "3.5.8",
-    "d3.cartodb": "git://github.com/CartoDB/d3.cartodb.git#78168701bfa09bb240ab686313ff887c978107f9"
+    "d3.cartodb": "git://github.com/CartoDB/d3.cartodb.git#7816870"
   },
   "devDependencies": {
     "browserify": "11.2.0",


### PR DESCRIPTION
Includes nice fixes such as excluding empty `GeometryCollection` from entering the filter and performing contains checks to lines and polygons.

@xavijam 