### PR TITLE
Extracts a VizJSON class with some methods to manipulate viz.json objects

### DIFF
--- a/src/core/util.js
+++ b/src/core/util.js
@@ -119,8 +119,12 @@ util._inferBrowser = function(ua){
   else if(ua.indexOf("Opera") > -1) browser.opera = ua;
   else if(ua.indexOf("Safari") > -1) browser.safari = ua;
   return browser;
-}
+};
 
 util.browser = util._inferBrowser();
+
+util.isMobileDevice = function () {
+  return /Android|webOS|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+};
 
 module.exports = util;

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -1,3 +1,4 @@
+var $ = require('jQuery');
 var _ = require('underscore');
 var L = require('leaflet');
 var Backbone = require('backbone');
@@ -13,9 +14,9 @@ var Map = Model.extend({
   defaults: {
     attribution: [config.get('cartodb_attributions')],
     center: [0, 0],
-    zoom: 3,
+    zoom: 4,
     minZoom: 0,
-    maxZoom: 40,
+    maxZoom: 20,
     scrollwheel: true,
     drag: true,
     keyboard: true,
@@ -33,6 +34,23 @@ var Map = Model.extend({
 
     this._windshaftMap = options.windshaftMap;
     this._dataviewsCollection = options.dataviewsCollection;
+
+    attrs = attrs || {};
+    if (attrs.bounds) {
+      this.set({
+        view_bounds_sw: attrs.bounds[0],
+        view_bounds_ne: attrs.bounds[1],
+        original_view_bounds_sw: attrs.bounds[0],
+        original_view_bounds_ne: attrs.bounds[1]
+      });
+      this.unset('bounds');
+    } else {
+      this.set({
+        center: attrs.center || this.defaults.center,
+        original_center: attrs.center || this.defaults.center,
+        zoom: attrs.zoom || this.defaults.zoom
+      });
+    }
   },
 
   // PUBLIC API METHODS
@@ -349,6 +367,20 @@ var Map = Model.extend({
 
   removeGeometry: function(geom) {
     this.geometries.remove(geom);
+  },
+
+  reCenter: function () {
+    var originalViewBoundsSW = this.get('original_view_bounds_sw');
+    var originalViewBoundsNE = this.get('original_view_bounds_ne');
+    var originalCenter = this.get('original_center');
+    if (originalViewBoundsSW && originalViewBoundsNE) {
+      this.setBounds([
+        originalViewBoundsSW,
+        originalViewBoundsNE
+      ]);
+    } else {
+      this.setCenter(originalCenter);
+    }
   },
 
   setBounds: function(b) {

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -1,4 +1,4 @@
-var $ = require('jQuery');
+var $ = require('jquery');
 var _ = require('underscore');
 var L = require('leaflet');
 var Backbone = require('backbone');

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -413,7 +413,7 @@ var Vis = View.extend({
       ]);
     }
 
-    if (vizjson.map_provider === 'leaflet' && options.gmaps_base_type) {
+    if (options.gmaps_base_type) {
       vizjson.enforceGMapsBaseLayer(options.gmaps_base_type, options.gmaps_style);
     }
   },

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -184,7 +184,6 @@ var Vis = View.extend({
   },
 
   load: function (data, options) {
-
     if (typeof (data) === 'string') {
       var url = data;
       Loader.get(url, function (data) {

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -25,14 +25,13 @@ var WindshaftClient = require('../windshaft/client');
 var WindshaftLayerGroupConfig = require('../windshaft/layergroup-config');
 var WindshaftNamedMapConfig = require('../windshaft/namedmap-config');
 var WindshaftMap = require('../windshaft/windshaft-map');
+var VizJSON = require('./vizjson');
+var util = require('cdb.core.util');
 
 /**
  * Visualization creation
  */
 var Vis = View.extend({
-  DEFAULT_MAX_ZOOM: 20,
-  DEFAULT_MIN_ZOOM: 0,
-
   initialize: function () {
     _.bindAll(this, 'loadingTiles', 'loadTiles', '_onResize');
 
@@ -185,6 +184,7 @@ var Vis = View.extend({
   },
 
   load: function (data, options) {
+
     if (typeof (data) === 'string') {
       var url = data;
       Loader.get(url, function (data) {
@@ -198,11 +198,17 @@ var Vis = View.extend({
       return;
     }
 
-    this.https = (window && window.location.protocol && window.location.protocol === 'https:') || !!data.https;
+    var DEFAULT_OPTIONS = {
+      tiles_loader: true,
+      loaderControl: true,
+      infowindow: true,
+      tooltip: true,
+      time_slider: true
+    };
 
-    options = options || {};
-
-    this._applyOptionsToVizJSON(data, options);
+    options = _.defaults(options || {}, DEFAULT_OPTIONS);
+    var vizjson = new VizJSON(data);
+    this._applyOptionsToVizJSON(vizjson, options);
 
     this._dataviewsCollection = new DataviewCollection();
 
@@ -210,7 +216,7 @@ var Vis = View.extend({
 
     var endpoint;
     var configGenerator;
-    var datasource = data.datasource;
+    var datasource = vizjson.datasource;
 
     // TODO: We can use something else to differentiate types of "datasource"s
     if (datasource.template_name) {
@@ -238,44 +244,28 @@ var Vis = View.extend({
 
     // Create the Map
 
-    var scrollwheel = (options.scrollwheel === undefined) ? data.scrollwheel : options.scrollwheel;
-
-    // Do not allow pan map if zoom overlay and scrollwheel are disabled unless
-    // mobile view is enabled
-    // Check if zoom overlay is present.
-    var hasZoomOverlay = _.isObject(_.find(data.overlays, function (overlay) {
-      return overlay.type == 'zoom';
-    }));
-
-    var allowDragging = this.isMobileDevice() || hasZoomOverlay || scrollwheel;
-
-    this.mapConfig = {
-      title: data.title,
-      description: data.description,
-      maxZoom: data.maxZoom || this.DEFAULT_MAX_ZOOM,
-      minZoom: data.minZoom || this.DEFAULT_MIN_ZOOM,
-      legends: data.legends,
-      scrollwheel: scrollwheel,
-      drag: allowDragging,
-      provider: data.map_provider,
-      vector: data.vector,
-    };
-
-    if (data.bounds) {
-      this.mapConfig.view_bounds_sw = data.bounds[0];
-      this.mapConfig.view_bounds_ne = data.bounds[1];
-    } else {
-      var center = data.center;
-
-      if (typeof (center) === 'string') {
-        center = $.parseJSON(center);
-      }
-
-      this.mapConfig.center = center || [0, 0];
-      this.mapConfig.zoom = data.zoom === undefined ? 4 : data.zoom;
+    var allowDragging = util.isMobileDevice() || vizjson.hasZoomOverlay() || vizjson.scrollwheel;
+    var center = vizjson.center;
+    if (typeof (center) === 'string') {
+      center = $.parseJSON(center);
     }
 
-    this.map = new Map(this.mapConfig, {
+    var mapConfig = {
+      title: vizjson.title,
+      description: vizjson.description,
+      maxZoom: vizjson.maxZoom,
+      minZoom: vizjson.minZoom,
+      legends: vizjson.legends,
+      bounds: vizjson.bounds,
+      center: center,
+      zoom: vizjson.zoom,
+      scrollwheel: !!this.scrollwheel,
+      drag: allowDragging,
+      provider: vizjson.map_provider,
+      vector: vizjson.vector
+    };
+
+    this.map = new Map(mapConfig, {
       windshaftMap: windshaftMap,
       dataviewsCollection: this._dataviewsCollection
     });
@@ -330,6 +320,7 @@ var Vis = View.extend({
     this.mapView.bind('newLayerView', this._addLoading, this);
 
     // Create the Layer Models and set them on hte map
+    this.https = (window && window.location.protocol && window.location.protocol === 'https:') || !!vizjson.https || !!options.https;
     var layerModels = this._newLayerModels(data, this.map);
 
     var infowindowManager = new InfowindowManager(this);
@@ -343,7 +334,7 @@ var Vis = View.extend({
     overlaysCollection.bind('reset', function (overlays) {
       this._addOverlays(overlays, data, options);
     }, this);
-    overlaysCollection.reset(data.overlays);
+    overlaysCollection.reset(vizjson.overlays);
 
     // Create the public Dataview Factory
     this.dataviews = new DataviewsFactory(null, {
@@ -366,6 +357,67 @@ var Vis = View.extend({
     return this;
   },
 
+  _applyOptionsToVizJSON: function (vizjson, options) {
+    vizjson.scrollwheel = options.scrollwheel || vizjson.scrollwheel;
+
+    if (!options.tiles_loader || !options.loaderControl) {
+      vizjson.removeLoaderOverlay();
+    }
+
+    if (options.searchControl === true) {
+      vizjson.addSearchOverlay();
+    } else if (options.searchControl === false) {
+      vizjson.removeSearchOverlay();
+    }
+
+    if ((options.title && vizjson.title) || (options.description && vizjson.description)) {
+      vizjson.addHeaderOverlay(options.title, options.description, options.shareable);
+    }
+
+    if (options.layer_selector) {
+      vizjson.addLayerSelectorOverlay();
+    }
+
+    if (options.zoomControl !== undefined && !options.zoomControl) {
+      vizjson.removeZoomOverlay();
+    }
+
+    // if bounds are present zoom and center will not taken into account
+    var zoom = parseInt(options.zoom, 10);
+    if (!isNaN(zoom)) {
+      vizjson.setZoom(zoom);
+    }
+
+    // Center coordinates?
+    var center_lat = parseFloat(options.center_lat);
+    var center_lon = parseFloat(options.center_lon);
+    if (!isNaN(center_lat) && !isNaN(center_lon)) {
+      vizjson.setCenter([center_lat, center_lon]);
+    }
+
+    // Center object
+    if (options.center !== undefined) {
+      vizjson.setCenter(options.center);
+    }
+
+    // Bounds?
+    var sw_lat = parseFloat(options.sw_lat);
+    var sw_lon = parseFloat(options.sw_lon);
+    var ne_lat = parseFloat(options.ne_lat);
+    var ne_lon = parseFloat(options.ne_lon);
+
+    if (!isNaN(sw_lat) && !isNaN(sw_lon) && !isNaN(ne_lat) && !isNaN(ne_lon)) {
+      vizjson.setBounds([
+        [ sw_lat, sw_lon ],
+        [ ne_lat, ne_lon ]
+      ]);
+    }
+
+    if (vizjson.map_provider === 'leaflet' && options.gmaps_base_type) {
+      vizjson.enforceGMapsBaseLayer(options.gmaps_base_type, options.gmaps_style);
+    }
+  },
+
   /**
    * Force a map instantiation.
    * Only expected to be called if {skipMapInstantiation} flag is set to true when vis is created.
@@ -383,15 +435,7 @@ var Vis = View.extend({
 
   centerMapToOrigin: function () {
     this.mapView.invalidateSize();
-    var c = this.mapConfig;
-    if (c.view_bounds_sw && c.view_bounds_ne) {
-      this.map.setBounds([
-        c.view_bounds_sw,
-        c.view_bounds_ne
-      ]);
-    } else {
-      this.map.setCenter(c.center);
-    }
+    this.map.reCenter();
   },
 
   _newLayerModels: function (vizjson, map) {
@@ -517,187 +561,6 @@ var Vis = View.extend({
     return v;
   },
 
-  // change vizjson based on options
-  _applyOptionsToVizJSON: function (vizjson, opt) {
-    opt = opt || {};
-    opt = _.defaults(opt, {
-      tiles_loader: true,
-      loaderControl: true,
-      infowindow: true,
-      tooltip: true,
-      time_slider: true
-    });
-    vizjson.overlays = vizjson.overlays || [];
-    vizjson.layers = vizjson.layers || [];
-
-    function search_overlay (name) {
-      if (!vizjson.overlays) return null;
-      for (var i = 0; i < vizjson.overlays.length; ++i) {
-        if (vizjson.overlays[i].type === name) {
-          return vizjson.overlays[i];
-        }
-      }
-    }
-
-    function remove_overlay (name) {
-      if (!vizjson.overlays) return;
-      for (var i = 0; i < vizjson.overlays.length; ++i) {
-        if (vizjson.overlays[i].type === name) {
-          vizjson.overlays.splice(i, 1);
-          return;
-        }
-      }
-    }
-
-    this.infowindow = opt.infowindow;
-    this.tooltip = opt.tooltip;
-
-    if (opt.https) {
-      this.https = true;
-    }
-
-    if (opt.gmaps_base_type) {
-      this.gmaps_base_type = opt.gmaps_base_type;
-    }
-
-    if (opt.gmaps_style) {
-      this.gmaps_style = opt.gmaps_style;
-    }
-
-    this.mobile = this.isMobileDevice();
-
-    if (!opt.tiles_loader) {
-      remove_overlay('loader');
-    }
-
-    if (!opt.loaderControl) {
-      remove_overlay('loader');
-    }
-
-    if (opt.searchControl !== undefined) {
-      opt.search = opt.searchControl;
-    }
-
-    if (!search_overlay('search') && opt.search) {
-      vizjson.overlays.push({
-        type: 'search',
-        order: 3
-      });
-    }
-
-    if ((opt.title && vizjson.title) || (opt.description && vizjson.description)) {
-      if (!search_overlay('header')) {
-        vizjson.overlays.unshift({
-          type: 'header',
-          order: 1,
-          shareable: opt.shareable,
-          url: vizjson.url,
-          options: {
-            extra: {
-              title: vizjson.title,
-              description: vizjson.description,
-              show_title: opt.title,
-              show_description: opt.description
-            }
-          }
-        });
-      }
-    }
-
-    if (opt.layer_selector) {
-      if (!search_overlay('layer_selector')) {
-        vizjson.overlays.push({
-          type: 'layer_selector'
-        });
-      }
-    }
-
-    vizjson.overlays.push({
-      type: 'attribution'
-    });
-
-    if (opt.zoomControl !== undefined && !opt.zoomControl) {
-      remove_overlay('zoom');
-    }
-
-    if (opt.search !== undefined && !opt.search) {
-      remove_overlay('search');
-    }
-
-    // if bounds are present zoom and center will not taken into account
-    var zoom = parseInt(opt.zoom);
-    if (!isNaN(zoom)) {
-      vizjson.zoom = zoom;
-      vizjson.bounds = null;
-    }
-
-    // Center coordinates?
-    var center_lat = parseFloat(opt.center_lat);
-    var center_lon = parseFloat(opt.center_lon);
-    if ( !isNaN(center_lat) && !isNaN(center_lon)) {
-      vizjson.center = [center_lat, center_lon];
-      vizjson.bounds = null;
-    }
-
-    // Center object
-    if (opt.center !== undefined) {
-      vizjson.center = opt.center;
-      vizjson.bounds = null;
-    }
-
-    // Bounds?
-    var sw_lat = parseFloat(opt.sw_lat);
-    var sw_lon = parseFloat(opt.sw_lon);
-    var ne_lat = parseFloat(opt.ne_lat);
-    var ne_lon = parseFloat(opt.ne_lon);
-
-    if ( !isNaN(sw_lat) && !isNaN(sw_lon) && !isNaN(ne_lat) && !isNaN(ne_lon)) {
-      vizjson.bounds = [
-        [ sw_lat, sw_lon ],
-        [ ne_lat, ne_lon ]
-      ];
-    }
-
-    if (vizjson.layers.length > 1) {
-      var token = opt.auth_token;
-      function _applyLayerOptions (layers) {
-        for (var i = 1; i < layers.length; ++i) {
-          var o = layers[i].options;
-          o.no_cdn = opt.no_cdn;
-          o.force_cors = opt.force_cors;
-          if (token) {
-            o.auth_token = token;
-          }
-        }
-      }
-      _applyLayerOptions(vizjson.layers);
-    }
-
-    // Force using GMaps ?
-    if ((this.gmaps_base_type) && (vizjson.map_provider === 'leaflet')) {
-      // Check if base_type is correct
-      var typesAllowed = ['roadmap', 'gray_roadmap', 'dark_roadmap', 'hybrid', 'satellite', 'terrain'];
-      if (_.contains(typesAllowed, this.gmaps_base_type)) {
-        if (vizjson.layers) {
-          vizjson.layers[0].options.type = 'GMapsBase';
-          vizjson.layers[0].options.base_type = this.gmaps_base_type;
-          vizjson.layers[0].options.name = this.gmaps_base_type;
-
-          if (this.gmaps_style) {
-            vizjson.layers[0].options.style = typeof this.gmaps_style === 'string' ? JSON.parse(this.gmaps_style) : this.gmaps_style;
-          }
-
-          vizjson.map_provider = 'googlemaps';
-          vizjson.layers[0].options.attribution = ''; // GMaps has its own attribution
-        } else {
-          log.error('No base map loaded. Using Leaflet.');
-        }
-      } else {
-        log.error('GMaps base_type "' + this.gmaps_base_type + ' is not supported. Using leaflet.');
-      }
-    }
-  },
-
   createLayer: function (layerData) {
     var layerModel = Layers.create(layerData.type || layerData.kind, this, layerData);
     return this.mapView.createLayer(layerModel);
@@ -801,10 +664,6 @@ var Vis = View.extend({
     setTimeout(function () {
       self.centerMapToOrigin();
     }, 150);
-  },
-
-  isMobileDevice: function () {
-    return /Android|webOS|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
   }
 }, {
   /**

--- a/src/vis/vizjson.js
+++ b/src/vis/vizjson.js
@@ -117,7 +117,7 @@ VizJSON.prototype.enforceGMapsBaseLayer = function (gmapsBaseType, gmapsStyle) {
         this.layers[0].options.style = typeof gmapsStyle === 'string' ? JSON.parse(gmapsStyle) : gmapsStyle;
       }
 
-      this.map_provider = VizJSON.GMAPS_BASE_LAYER_TYPES.GMAPS;
+      this.map_provider = VizJSON.MAP_PROVIDER_TYPES.GMAPS;
       this.layers[0].options.attribution = ''; // GMaps has its own attribution
     } else {
       log.error('No base map loaded. Using Leaflet.');

--- a/src/vis/vizjson.js
+++ b/src/vis/vizjson.js
@@ -1,0 +1,138 @@
+var _ = require('underscore');
+var log = require('cdb.log');
+
+var GMAPS_BASE_LAYER_TYPES = ['roadmap', 'gray_roadmap', 'dark_roadmap', 'hybrid', 'satellite', 'terrain'];
+
+var VizJSON = function (vizjson) {
+  _.each(Object.keys(vizjson), function (property) {
+    this[property] = vizjson[property];
+  }, this);
+
+  this.overlays = this.overlays || [];
+  this.layers = this.layers || [];
+
+  this._addAttributionOverlay();
+};
+
+VizJSON.OVERLAY_TYPES = {
+  ZOOM: 'zoom',
+  ATTRIBUTION: 'attribution',
+  LOADER: 'loader',
+  SEARCH: 'search',
+  HEADER: 'header',
+  LAYER_SELECTOR: 'layer_selector'
+};
+
+VizJSON.prototype.hasZoomOverlay = function () {
+  return this.hasOverlay(VizJSON.OVERLAY_TYPES.ZOOM);
+};
+
+VizJSON.prototype.hasOverlay = function (overlayType) {
+  return _.isObject(this.getOverlayByType(overlayType));
+};
+
+VizJSON.prototype.getOverlayByType = function (overlayType) {
+  return _.find(this.overlays, function (overlay) {
+    return overlay.type === overlayType;
+  });
+};
+
+VizJSON.prototype.addHeaderOverlay = function (showTitle, showDescription, isShareable) {
+  if (!this.hasOverlay(VizJSON.OVERLAY_TYPES.HEADER)) {
+    this.overlays.unshift({
+      type: VizJSON.OVERLAY_TYPES.HEADER,
+      order: 1,
+      shareable: isShareable,
+      url: this.url,
+      options: {
+        extra: {
+          title: this.title,
+          description: this.description,
+          show_title: showTitle,
+          show_description: showDescription
+        }
+      }
+    });
+  }
+};
+
+VizJSON.prototype.addLayerSelectorOverlay = function () {
+  if (!this.hasOverlay(VizJSON.OVERLAY_TYPES.LAYER_SELECTOR)) {
+    this.overlays.push({
+      type: VizJSON.OVERLAY_TYPES.LAYER_SELECTOR
+    });
+  }
+};
+
+VizJSON.prototype.addSearchOverlay = function () {
+  if (!this.hasOverlay(VizJSON.OVERLAY_TYPES.SEARCH)) {
+    this.overlays.push({
+      type: VizJSON.OVERLAY_TYPES.SEARCH,
+      order: 3
+    });
+  }
+};
+
+VizJSON.prototype.removeOverlay = function (overlayType) {
+  for (var i = 0; i < this.overlays.length; ++i) {
+    if (this.overlays[i].type === overlayType) {
+      this.overlays.splice(i, 1);
+      return;
+    }
+  }
+};
+
+VizJSON.prototype.removeLoaderOverlay = function () {
+  this.removeOverlay(VizJSON.OVERLAY_TYPES.LOADER);
+};
+
+VizJSON.prototype.removeZoomOverlay = function () {
+  this.removeOverlay(VizJSON.OVERLAY_TYPES.ZOOM);
+};
+
+VizJSON.prototype.removeSearchOverlay = function () {
+  this.removeOverlay(VizJSON.OVERLAY_TYPES.SEARCH);
+};
+
+VizJSON.prototype._addAttributionOverlay = function () {
+  this.overlays.push({
+    type: VizJSON.OVERLAY_TYPES.ATTRIBUTION
+  });
+};
+
+VizJSON.prototype.enforceGMapsBaseLayer = function (gmapsBaseType, gmapsStyle) {
+  if (_.contains(GMAPS_BASE_LAYER_TYPES, gmapsBaseType)) {
+    if (this.layers) {
+      this.layers[0].options.type = 'GMapsBase';
+      this.layers[0].options.base_type = gmapsBaseType;
+      this.layers[0].options.name = gmapsBaseType;
+
+      if (gmapsStyle) {
+        this.layers[0].options.style = typeof gmapsStyle === 'string' ? JSON.parse(gmapsStyle) : gmapsStyle;
+      }
+
+      this.map_provider = 'googlemaps';
+      this.layers[0].options.attribution = ''; // GMaps has its own attribution
+    } else {
+      log.error('No base map loaded. Using Leaflet.');
+    }
+  } else {
+    log.error('GMaps base_type "' + gmapsBaseType + ' is not supported. Using leaflet.');
+  }
+};
+
+VizJSON.prototype.setZoom = function (zoom) {
+  this.zoom = zoom;
+  this.bounds = null;
+};
+
+VizJSON.prototype.setCenter = function (center) {
+  this.center = center;
+  this.bounds = null;
+};
+
+VizJSON.prototype.setBounds = function (bounds) {
+  this.bounds = bounds;
+};
+
+module.exports = VizJSON;

--- a/src/vis/vizjson.js
+++ b/src/vis/vizjson.js
@@ -23,6 +23,11 @@ VizJSON.OVERLAY_TYPES = {
   LAYER_SELECTOR: 'layer_selector'
 };
 
+VizJSON.MAP_PROVIDER_TYPES = {
+  GMAPS: 'googlemaps',
+  LEAFLET: 'leaflet'
+}
+
 VizJSON.prototype.hasZoomOverlay = function () {
   return this.hasOverlay(VizJSON.OVERLAY_TYPES.ZOOM);
 };
@@ -101,7 +106,8 @@ VizJSON.prototype._addAttributionOverlay = function () {
 };
 
 VizJSON.prototype.enforceGMapsBaseLayer = function (gmapsBaseType, gmapsStyle) {
-  if (_.contains(GMAPS_BASE_LAYER_TYPES, gmapsBaseType)) {
+  var isGmapsBaseTypeValid = _.contains(GMAPS_BASE_LAYER_TYPES, gmapsBaseType);
+  if (this.map_provider === VizJSON.MAP_PROVIDER_TYPES.LEAFLET && isGmapsBaseTypeValid) {
     if (this.layers) {
       this.layers[0].options.type = 'GMapsBase';
       this.layers[0].options.base_type = gmapsBaseType;
@@ -111,7 +117,7 @@ VizJSON.prototype.enforceGMapsBaseLayer = function (gmapsBaseType, gmapsStyle) {
         this.layers[0].options.style = typeof gmapsStyle === 'string' ? JSON.parse(gmapsStyle) : gmapsStyle;
       }
 
-      this.map_provider = 'googlemaps';
+      this.map_provider = VizJSON.GMAPS_BASE_LAYER_TYPES.GMAPS;
       this.layers[0].options.attribution = ''; // GMaps has its own attribution
     } else {
       log.error('No base map loaded. Using Leaflet.');

--- a/src/vis/vizjson.js
+++ b/src/vis/vizjson.js
@@ -26,7 +26,7 @@ VizJSON.OVERLAY_TYPES = {
 VizJSON.MAP_PROVIDER_TYPES = {
   GMAPS: 'googlemaps',
   LEAFLET: 'leaflet'
-}
+};
 
 VizJSON.prototype.hasZoomOverlay = function () {
   return this.hasOverlay(VizJSON.OVERLAY_TYPES.ZOOM);

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -16,6 +16,39 @@ describe('core/geo/map', function() {
     map.instantiateMap();
   });
 
+  describe('.initialize', function () {
+    it('should parse bounds and set attributes', function () {
+      var map = new Map({
+        bounds: [[0, 1], [2, 3]]
+      });
+
+      expect(map.get('view_bounds_sw')).toEqual([0, 1]);
+      expect(map.get('view_bounds_ne')).toEqual([2, 3]);
+      expect(map.get('original_view_bounds_sw')).toEqual([0, 1]);
+      expect(map.get('original_view_bounds_ne')).toEqual([2, 3]);
+      expect(map.get('bounds')).toBeUndefined();
+    });
+
+    it('should set the center and zoom if no bounds are given', function () {
+      var map = new Map({
+        center: [41.40282319070747, 2.3435211181640625],
+        zoom: 10
+      });
+
+      expect(map.get('center')).toEqual([41.40282319070747, 2.3435211181640625]);
+      expect(map.get('original_center')).toEqual([41.40282319070747, 2.3435211181640625]);
+      expect(map.get('zoom')).toEqual(10);
+    });
+
+    it('should set the default center and zoom if no center and bounds are given', function () {
+      var map = new Map({});
+
+      expect(map.get('center')).toEqual(map.defaults.center);
+      expect(map.get('original_center')).toEqual(map.defaults.center);
+      expect(map.get('zoom')).toEqual(map.defaults.zoom);
+    });
+  });
+
   it("should raise only one change event on setBounds", function() {
     var c = 0;
     map.bind('change:view_bounds_ne', function() {
@@ -42,16 +75,18 @@ describe('core/geo/map', function() {
   });
 
   it("should adjust zoom to layer", function() {
-    expect(map.get('maxZoom')).toEqual(40);
-    expect(map.get('minZoom')).toEqual(0);
+    expect(map.get('maxZoom')).toEqual(map.defaults.maxZoom);
+    expect(map.get('minZoom')).toEqual(map.defaults.minZoom);
 
-    var layer = new PlainLayer({ minZoom: 5, maxZoom: 20 });
+    var layer = new PlainLayer({ minZoom: 5, maxZoom: 25 });
     map.layers.reset(layer);
-    expect(map.get('maxZoom')).toEqual(20);
+
+    expect(map.get('maxZoom')).toEqual(25);
     expect(map.get('minZoom')).toEqual(5);
 
     var layer = new PlainLayer({ minZoom: "7", maxZoom: "31" });
     map.layers.reset(layer);
+
     expect(map.get('maxZoom')).toEqual(31);
     expect(map.get('minZoom')).toEqual(7);
   });
@@ -59,8 +94,9 @@ describe('core/geo/map', function() {
   it("shouldn't set a NaN zoom", function() {
     var layer = new PlainLayer({ minZoom: NaN, maxZoom: NaN });
     map.layers.reset(layer);
-    expect(map.get('maxZoom')).toEqual(40);
-    expect(map.get('minZoom')).toEqual(0);
+
+    expect(map.get('maxZoom')).toEqual(map.defaults.maxZoom);
+    expect(map.get('minZoom')).toEqual(map.defaults.minZoom);
   });
 
   it('should update the attributions of the map when layers are reset/added/removed', function() {
@@ -314,6 +350,41 @@ describe('core/geo/map', function() {
           image: 'http://example.com/image.png'
         });
         expect(this.map.layers.at(0)).toEqual(layer);
+      });
+    });
+
+    describe('.reCenter', function () {
+      it('should set the original bounds if present', function () {
+        var map = new Map({
+          bounds: [[1, 2], [3, 4]],
+          center: '[41.40282319070747, 2.3435211181640625]'
+        });
+
+        // Change internal attributes
+        map.set({
+          view_bounds_sw: 'something',
+          view_bounds_ne: 'else',
+          center: 'different'
+        });
+
+        map.reCenter();
+
+        expect(map.get('view_bounds_sw')).toEqual([1, 2]);
+        expect(map.get('view_bounds_ne')).toEqual([3, 4]);
+      });
+
+      it('should set the original center if bounds are not present', function () {
+        var map = new Map({
+          center: [41.40282319070747, 2.3435211181640625]
+        });
+
+        map.set({
+          center: 'different'
+        });
+
+        map.reCenter();
+
+        expect(map.get('center')).toEqual([ 41.40282319070747, 2.3435211181640625 ]);
       });
     });
   });

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -77,8 +77,7 @@ describe('vis/vis', function () {
     };
     this.vis.load(this.mapConfig, opts);
 
-    expect(this.mapConfig.center[0]).toEqual(43.3);
-    expect(this.mapConfig.center[1]).toEqual(89.0);
+    expect(this.vis.map.get('center')).toEqual([43.3, 89.0]);
   });
 
   it('should not parse center if values are not correct', function () {
@@ -89,8 +88,7 @@ describe('vis/vis', function () {
     };
     this.vis.load(this.mapConfig, opts);
 
-    expect(this.mapConfig.center[0]).not.toEqual(43.3);
-    expect(this.mapConfig.center[1]).not.toEqual('ham');
+    expect(this.vis.map.get('center')).toEqual([40.044, -101.95]);
   });
 
   it('should parse bounds values if they are correct', function () {
@@ -103,10 +101,8 @@ describe('vis/vis', function () {
     };
     this.vis.load(this.mapConfig, opts);
 
-    expect(this.mapConfig.bounds[0][0]).toEqual(43.3);
-    expect(this.mapConfig.bounds[0][1]).toEqual(12);
-    expect(this.mapConfig.bounds[1][0]).toEqual(12);
-    expect(this.mapConfig.bounds[1][1]).toEqual(0);
+    expect(this.vis.map.get('view_bounds_sw')).toEqual([43.3, 12]);
+    expect(this.vis.map.get('view_bounds_ne')).toEqual([12, 0]);
   });
 
   it('should not parse bounds values if they are not correct', function () {
@@ -119,10 +115,8 @@ describe('vis/vis', function () {
     };
     this.vis.load(this.mapConfig, opts);
 
-    expect(this.mapConfig.bounds[0][0]).not.toEqual(43.3);
-    expect(this.mapConfig.bounds[0][1]).not.toEqual(12);
-    expect(this.mapConfig.bounds[1][0]).not.toEqual(12);
-    expect(this.mapConfig.bounds[1][1]).not.toEqual(0);
+    expect(this.vis.map.get('view_bounds_sw')).toEqual([1, 2]);
+    expect(this.vis.map.get('view_bounds_ne')).toEqual([3, 4]);
   });
 
   it('should create a google maps map when provider is google maps', function () {
@@ -157,7 +151,6 @@ describe('vis/vis', function () {
     vis.load(this.mapConfig);
     $(window).trigger('resize');
     expect(vis._onResize).toHaveBeenCalled();
-    expect(vis.mapConfig).toBeDefined();
   });
 
   it("shouldn't bind resize changes when map height is greater than 0", function () {
@@ -376,18 +369,10 @@ describe('vis/vis', function () {
       expect(this.vis.mapView.invalidateSize).toHaveBeenCalled();
     });
 
-    it('should set map bounds again', function () {
-      spyOn(this.vis.map, 'setBounds');
+    it('should re-center the map', function () {
+      spyOn(this.vis.map, 'reCenter');
       this.vis.centerMapToOrigin();
-      expect(this.vis.map.setBounds).toHaveBeenCalled();
-    });
-
-    it('should set center if bounds are undefined', function () {
-      delete this.vis.mapConfig.view_bounds_ne;
-      delete this.vis.mapConfig.view_bounds_sw;
-      spyOn(this.vis.map, 'setCenter');
-      this.vis.centerMapToOrigin();
-      expect(this.vis.map.setCenter).toHaveBeenCalled();
+      expect(this.vis.map.reCenter).toHaveBeenCalled();
     });
   });
 

--- a/test/spec/vis/vizjson.spec.js
+++ b/test/spec/vis/vizjson.spec.js
@@ -1,0 +1,295 @@
+var VizJSON = require('../../../src/vis/vizjson');
+
+describe('src/vis/vizjson', function () {
+  it('should expose the vizjson attributes', function () {
+    var vizjson = new VizJSON({
+      key1: 'value1',
+      key2: 'value2'
+    });
+
+    expect(vizjson.key1).toEqual('value1');
+    expect(vizjson.key2).toEqual('value2');
+  });
+
+  it('should have an attribution overlay by default', function () {
+    var vizjson = new VizJSON({});
+
+    expect(vizjson.getOverlayByType(VizJSON.OVERLAY_TYPES.ATTRIBUTION)).toEqual({
+      type: VizJSON.OVERLAY_TYPES.ATTRIBUTION
+    });
+  });
+
+  describe('.hasZoomOverlay', function () {
+    it("should return true if there's a zoom overlay", function () {
+      var vizjson = new VizJSON({
+        overlays: [{
+          type: VizJSON.OVERLAY_TYPES.ZOOM
+        }]
+      });
+
+      expect(vizjson.hasZoomOverlay()).toBeTruthy();
+    });
+  });
+
+  describe('.hasOverlay', function () {
+    it("should return true if there's an overlay with the given type", function () {
+      var vizjson = new VizJSON({
+        overlays: [{
+          type: 'something'
+        }]
+      });
+
+      expect(vizjson.hasOverlay('something')).toBeTruthy();
+    });
+
+    it("should return false if there isn't an overlay with the given type", function () {
+      var vizjson = new VizJSON({
+        overlays: [{
+          type: 'something'
+        }]
+      });
+
+      expect(vizjson.hasOverlay('else')).toBeFalsy();
+    });
+  });
+
+  describe('.getOverlayByType', function () {
+    it("should return the overlay if there's an overlay with the given type", function () {
+      var vizjson = new VizJSON({
+        overlays: [{
+          type: 'something'
+        }]
+      });
+
+      expect(vizjson.getOverlayByType('something')).toEqual({
+        type: 'something'
+      });
+    });
+
+    it("should return nothing if there isn't an overlay with the given type", function () {
+      var vizjson = new VizJSON({
+        overlays: [{
+          type: 'something'
+        }]
+      });
+
+      expect(vizjson.getOverlayByType('else')).toBeUndefined();
+    });
+  });
+
+  describe('.addHeaderOverlay', function () {
+    it('should add a header Overlay', function () {
+      var vizjson = new VizJSON({
+        url: 'http://cartodb.com',
+        title: 'title',
+        description: 'description'
+      });
+
+      vizjson.addHeaderOverlay('show_title', 'show_description', 'is_shareable');
+
+      expect(vizjson.getOverlayByType('header')).toEqual({
+        type: 'header',
+        order: 1,
+        shareable: 'is_shareable',
+        url: 'http://cartodb.com',
+        options: {
+          extra: {
+            title: 'title',
+            description: 'description',
+            show_title: 'show_title',
+            show_description: 'show_description'
+          }
+        }
+      });
+    });
+  });
+
+  describe('.addLayerSelectorOverlay', function () {
+    it('should add a layer selector Overlay', function () {
+      var vizjson = new VizJSON({});
+
+      vizjson.addLayerSelectorOverlay();
+
+      expect(vizjson.getOverlayByType('layer_selector')).toEqual({
+        type: 'layer_selector'
+      });
+    });
+  });
+
+  describe('.addSearchOverlay', function () {
+    it('should add a search overlay', function () {
+      var vizjson = new VizJSON({});
+
+      vizjson.addSearchOverlay();
+
+      expect(vizjson.getOverlayByType('search')).toEqual({
+        type: 'search',
+        order: 3
+      });
+    });
+  });
+
+  describe('.removeOverlay', function () {
+    it('should remove the overlay of the given type', function () {
+      var vizjson = new VizJSON({
+        overlays: [{
+          type: 'something'
+        }]
+      });
+
+      expect(vizjson.getOverlayByType('something')).toBeDefined();
+
+      vizjson.removeOverlay('something');
+
+      expect(vizjson.getOverlayByType('something')).not.toBeDefined();
+    });
+  });
+
+  describe('.removeLoaderOverlay', function () {
+    it('should remove the loader overlay', function () {
+      var vizjson = new VizJSON({
+        overlays: [{
+          type: VizJSON.OVERLAY_TYPES.LOADER
+        }]
+      });
+
+      expect(vizjson.getOverlayByType(VizJSON.OVERLAY_TYPES.LOADER)).toBeDefined();
+
+      vizjson.removeLoaderOverlay();
+
+      expect(vizjson.getOverlayByType(VizJSON.OVERLAY_TYPES.LOADER)).not.toBeDefined();
+    });
+  });
+
+  describe('.removeZoomOverlay', function () {
+    it('should remove the zoom overlay', function () {
+      var vizjson = new VizJSON({
+        overlays: [{
+          type: VizJSON.OVERLAY_TYPES.ZOOM
+        }]
+      });
+
+      expect(vizjson.getOverlayByType(VizJSON.OVERLAY_TYPES.ZOOM)).toBeDefined();
+
+      vizjson.removeZoomOverlay();
+
+      expect(vizjson.getOverlayByType(VizJSON.OVERLAY_TYPES.ZOOM)).not.toBeDefined();
+    });
+  });
+
+  describe('.removeSearchOverlay', function () {
+    it('should remove the search overlay', function () {
+      var vizjson = new VizJSON({
+        overlays: [{
+          type: VizJSON.OVERLAY_TYPES.SEARCH
+        }]
+      });
+
+      expect(vizjson.getOverlayByType(VizJSON.OVERLAY_TYPES.SEARCH)).toBeDefined();
+
+      vizjson.removeSearchOverlay();
+
+      expect(vizjson.getOverlayByType(VizJSON.OVERLAY_TYPES.SEARCH)).not.toBeDefined();
+    });
+  });
+
+  describe('.enforceGMapsBaseLayer', function () {
+    it('should replace the existing base layer by a GMaps one', function () {
+      var vizjson = new VizJSON({
+        layers: [{
+          options: {
+            type: 'Tiled',
+            url: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
+            name: 'Positron',
+            className: 'httpsbasemapscartocdncomlight_nolabelszxypng',
+            attribution: '&copy; <a href=\'http://www.openstreetmap.org/copyright\'>OpenStreetMap</a> contributors &copy; <a href= \'http://cartodb.com/attributions\'>CartoDB</a>',
+            urlTemplate: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png'
+          }
+        }]
+      });
+
+      vizjson.enforceGMapsBaseLayer('roadmap', { color: 'blue' });
+
+      expect(vizjson.layers[0]).toEqual({
+        options: {
+          type: 'GMapsBase',
+          url: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
+          name: 'roadmap',
+          className: 'httpsbasemapscartocdncomlight_nolabelszxypng',
+          attribution: '',
+          urlTemplate: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
+          base_type: 'roadmap',
+          style: {color: 'blue'}
+        }
+      });
+    });
+
+    it('should NOT replace the existing base layer by a GMaps one if the given type is not valid', function () {
+      var vizjson = new VizJSON({
+        layers: [{
+          options: {
+            type: 'Tiled',
+            url: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
+            name: 'Positron',
+            className: 'httpsbasemapscartocdncomlight_nolabelszxypng',
+            attribution: '&copy; <a href=\'http://www.openstreetmap.org/copyright\'>OpenStreetMap</a> contributors &copy; <a href= \'http://cartodb.com/attributions\'>CartoDB</a>',
+            urlTemplate: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png'
+          }
+        }]
+      });
+
+      vizjson.enforceGMapsBaseLayer('invalid type', { color: 'blue' });
+
+      expect(vizjson.layers[0]).toEqual({
+        options: {
+          type: 'Tiled',
+          url: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
+          name: 'Positron',
+          className: 'httpsbasemapscartocdncomlight_nolabelszxypng',
+          attribution: '&copy; <a href=\'http://www.openstreetmap.org/copyright\'>OpenStreetMap</a> contributors &copy; <a href= \'http://cartodb.com/attributions\'>CartoDB</a>',
+          urlTemplate: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png'
+        }
+      });
+    });
+  });
+
+  describe('.setZoom', function () {
+    it('should set a new zoom and unset bounds', function () {
+      var vizjson = new VizJSON({
+        zoom: 'old_zoom',
+        bounds: 'bounds'
+      });
+
+      vizjson.setZoom('new_zoom');
+
+      expect(vizjson.zoom).toEqual('new_zoom');
+      expect(vizjson.bounds).toBeNull();
+    });
+  });
+
+  describe('.setCenter', function () {
+    it('should set a new center and unset bounds', function () {
+      var vizjson = new VizJSON({
+        center: 'old_center',
+        bounds: 'bounds'
+      });
+
+      vizjson.setCenter('new_center');
+
+      expect(vizjson.center).toEqual('new_center');
+      expect(vizjson.bounds).toBeNull();
+    });
+  });
+
+  describe('.setBounds', function () {
+    it('should set bounds', function () {
+      var vizjson = new VizJSON({
+        bounds: 'old_bounds'
+      });
+
+      vizjson.setBounds('new_bounds');
+
+      expect(vizjson.bounds).toEqual('new_bounds');
+    });
+  });
+});

--- a/test/spec/vis/vizjson.spec.js
+++ b/test/spec/vis/vizjson.spec.js
@@ -196,6 +196,7 @@ describe('src/vis/vizjson', function () {
   describe('.enforceGMapsBaseLayer', function () {
     it('should replace the existing base layer by a GMaps one', function () {
       var vizjson = new VizJSON({
+        map_provider: VizJSON.MAP_PROVIDER_TYPES.LEAFLET,
         layers: [{
           options: {
             type: 'Tiled',
@@ -222,10 +223,43 @@ describe('src/vis/vizjson', function () {
           style: {color: 'blue'}
         }
       });
+      expect(vizjson.map_provider).toEqual(VizJSON.MAP_PROVIDER_TYPES.GMAPS)
+    });
+
+    it('should NOT replace the existing base layer by a GMaps one if map_provider is not leaflet', function () {
+      var vizjson = new VizJSON({
+        map_provider: 'something'
+        layers: [{
+          options: {
+            type: 'Tiled',
+            url: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
+            name: 'Positron',
+            className: 'httpsbasemapscartocdncomlight_nolabelszxypng',
+            attribution: '&copy; <a href=\'http://www.openstreetmap.org/copyright\'>OpenStreetMap</a> contributors &copy; <a href= \'http://cartodb.com/attributions\'>CartoDB</a>',
+            urlTemplate: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png'
+          }
+        }]
+      });
+
+      vizjson.enforceGMapsBaseLayer('roadmap', { color: 'blue' });
+
+      expect(vizjson.layers[0]).toEqual({
+        options: {
+          type: 'Tiled',
+          url: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
+          name: 'Positron',
+          className: 'httpsbasemapscartocdncomlight_nolabelszxypng',
+          attribution: '&copy; <a href=\'http://www.openstreetmap.org/copyright\'>OpenStreetMap</a> contributors &copy; <a href= \'http://cartodb.com/attributions\'>CartoDB</a>',
+          urlTemplate: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png'
+        }
+      });
+
+      expect(vizjson.map_provider).toEqual('something');
     });
 
     it('should NOT replace the existing base layer by a GMaps one if the given type is not valid', function () {
       var vizjson = new VizJSON({
+        map_provider: VizJSON.MAP_PROVIDER_TYPES.LEAFLET,
         layers: [{
           options: {
             type: 'Tiled',
@@ -250,6 +284,8 @@ describe('src/vis/vizjson', function () {
           urlTemplate: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png'
         }
       });
+
+      expect(vizjson.map_provider).toEqual(VizJSON.MAP_PROVIDER_TYPES.LEAFLET);
     });
   });
 

--- a/test/spec/vis/vizjson.spec.js
+++ b/test/spec/vis/vizjson.spec.js
@@ -223,12 +223,12 @@ describe('src/vis/vizjson', function () {
           style: {color: 'blue'}
         }
       });
-      expect(vizjson.map_provider).toEqual(VizJSON.MAP_PROVIDER_TYPES.GMAPS)
+      expect(vizjson.map_provider).toEqual(VizJSON.MAP_PROVIDER_TYPES.GMAPS);
     });
 
     it('should NOT replace the existing base layer by a GMaps one if map_provider is not leaflet', function () {
       var vizjson = new VizJSON({
-        map_provider: 'something'
+        map_provider: 'something',
         layers: [{
           options: {
             type: 'Tiled',


### PR DESCRIPTION
This PR completes the first task of #804.

These changes will allow us to easily extract loading and manipulation of the vizjson (based on `createVis`  options) to `createVis`, which is the next step in #804.

@viddo could you please take a look? Thanks!
