### PR TITLE
Use the main branch instead of commit for dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "underscore": "1.8.3",
     "cartoassets": "CartoDB/CartoAssets#master",
     "d3": "3.5.8",
-    "d3.cartodb": "CartoDB/d3.cartodb#7816870"
+    "d3.cartodb": "CartoDB/d3.cartodb#gh-pages"
   },
   "devDependencies": {
     "browserify": "11.2.0",


### PR DESCRIPTION
As discussed with @javisantana, will change the internal libs to not use commits by main branches for reference instead.

@fdansv can you confirm that the gh-pages is the correct “main” branch of d3.cartodb?