### PR TITLE
Leaflet needs to be required before wax

### DIFF
--- a/src/geo/gmaps/gmaps-cartodb-layer-group-view.js
+++ b/src/geo/gmaps/gmaps-cartodb-layer-group-view.js
@@ -1,5 +1,7 @@
 var _ = require('underscore');
 var GMapsLayerView = require('./gmaps-layer-view');
+require('leaflet');
+// NOTE: Leaflet needs to be required before wax because wax relies on global L internally
 var wax = require('wax.cartodb.js');
 var CartoDBDefaultOptions = require('./cartodb-default-options');
 var Projector = require('./projector');

--- a/src/geo/leaflet/leaflet-cartodb-layer-group-view.js
+++ b/src/geo/leaflet/leaflet-cartodb-layer-group-view.js
@@ -1,5 +1,6 @@
-var wax = require('wax.cartodb.js');
 var L = require('leaflet');
+// NOTE: Leaflet needs to be required before wax because wax relies on global L internally
+var wax = require('wax.cartodb.js');
 var config = require('cdb.config');
 var Profiler = require('cdb.core.Profiler');
 var LeafletLayerView = require('./leaflet-layer-view');


### PR DESCRIPTION
For some reason, in the new editor, wax was being included before Leaflet in the `editor3.js` file. This was causing a JS error (when trying to use `L.TileLayer`, `L` was undefined). This little change fixes that. Perhaps, there's a better way to ensure Leaflet is required before wax?

@xavijam @javierarce?