### PR TITLE
Keep listening type changes when it was changed once

### DIFF
--- a/src/analysis/analysis-model.js
+++ b/src/analysis/analysis-model.js
@@ -15,15 +15,16 @@ module.exports = Model.extend({
 
     this._camshaftReference = opts.camshaftReference;
     this._map = opts.map;
+    this._initBinds();
+  },
+
+  _initBinds: function () {
     this.bind('change:type', function () {
       this.unbind(null, null, this);
       this._initBinds();
       this._reloadMap();
     }, this);
-    this._initBinds();
-  },
 
-  _initBinds: function () {
     _.each(this._getParamNames(), function (paramName) {
       this.bind('change:' + paramName, this._reloadMap, this);
     }, this);

--- a/test/spec/analysis/analysis-model.spec.js
+++ b/test/spec/analysis/analysis-model.spec.js
@@ -69,6 +69,14 @@ describe('src/analysis/analysis-model.js', function () {
         this.analysisModel.set('type', 'something');
         expect(this.map.reload).toHaveBeenCalled();
       });
+
+      it('should keep listening type change again', function () {
+        this.analysisModel.set('type', 'something');
+        expect(this.map.reload).toHaveBeenCalled();
+        this.map.reload.calls.reset();
+        this.analysisModel.set('type', 'something else');
+        expect(this.map.reload).toHaveBeenCalled();
+      });
     });
   });
 


### PR DESCRIPTION
So, silly me, I was unbinding previous listeners included type, so if type had changed twice, second one won't listen any change :(.

CR: @alonsogarciapablo 