### PR TITLE
Fixes return value of the _getSourceId method

### DIFF
--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -246,7 +246,7 @@ module.exports = Model.extend({
   _getSourceId: function () {
     var source = this.layer.get('source');
     if (source) {
-      return source.get('id');
+      return source;
     }
 
     return this.layer.get('id');

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -244,12 +244,7 @@ module.exports = Model.extend({
   },
 
   _getSourceId: function () {
-    var source = this.layer.get('source');
-    if (source) {
-      return source;
-    }
-
-    return this.layer.get('id');
+    return this.layer.get('source') || this.layer.get('id');
   },
 
   remove: function () {

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -456,7 +456,7 @@ describe('dataviews/dataview-model-base', function () {
     it("should return the ID of the layer's source", function () {
       var layer = new Backbone.Model({
         id: 'layerId',
-        source: new Backbone.Model({ id: 'someOtherId' })
+        source: 'a1'
       });
       layer.getDataProvider = jasmine.createSpy('getDataProvider').and.returnValue(undefined);
 
@@ -466,7 +466,7 @@ describe('dataviews/dataview-model-base', function () {
         layer: layer
       });
 
-      expect(dataview._getSourceId()).toEqual('someOtherId');
+      expect(dataview._getSourceId()).toEqual('a1');
     });
   });
 });


### PR DESCRIPTION
The `source` of a layer is not a model anymore, so the method should change.