### PR TITLE
V4 layer index

### DIFF
--- a/src/geo/gmaps/gmaps-torque-layer-view.js
+++ b/src/geo/gmaps/gmaps-torque-layer-view.js
@@ -35,7 +35,11 @@ _.extend(
         // REAL HACK
         this.provider.templateUrl = this.model.get('urls').tiles[0];
         // set meta
-        _.extend(this.provider.options, this.model.get('meta'));
+        var meta = this.model.get('meta');
+        if (typeof meta.cartocss !== 'string') {
+          delete meta.cartocss;
+        }
+        _.extend(this.provider.options, meta);
         this.model.set(this.model.get('meta'));
         // this needs to be deferred in order to break the infinite loop
         // of setReady changing keys and keys updating the model

--- a/src/geo/leaflet/leaflet-torque-layer.js
+++ b/src/geo/leaflet/leaflet-torque-layer.js
@@ -49,7 +49,11 @@ var LeafletTorqueLayer = L.TorqueLayer.extend({
       // REAL HACK
       this.provider.templateUrl = this.model.get('urls').tiles[0];
       // set meta
-      _.extend(this.provider.options, this.model.get('meta'));
+      var meta = this.model.get('meta');
+      if (typeof meta.cartocss !== 'string') {
+        delete meta.cartocss;
+      }
+      _.extend(this.provider.options, meta);
       this.model.set(this.model.get('meta'));
       // this needs to be deferred in order to break the infinite loop
       // of setReady changing keys and keys updating the model

--- a/src/geo/map/cartodb-layer.js
+++ b/src/geo/map/cartodb-layer.js
@@ -99,6 +99,13 @@ var CartoDBLayer = LayerModelBase.extend({
     return this.get('options') && this.get('options').layer_name || this.get('layer_name');
   },
 
+  // Torque layers have the layer_index defined in options.named_map.layer_index
+  // Layers inside a "namedmap" layer have the layer_index defined in the root of their definition
+  getLayerIndex: function() {
+    var named_map_options = this.get('options') && this.get('options').named_map;
+    return named_map_options && named_map_options.layer_index || this.get('layer_index');
+  },
+
   setDataProvider: function (dataProvider) {
     this._dataProvider = dataProvider;
   },

--- a/src/geo/map/cartodb-layer.js
+++ b/src/geo/map/cartodb-layer.js
@@ -99,11 +99,9 @@ var CartoDBLayer = LayerModelBase.extend({
     return this.get('options') && this.get('options').layer_name || this.get('layer_name');
   },
 
-  // Torque layers have the layer_index defined in options.named_map.layer_index
   // Layers inside a "namedmap" layer have the layer_index defined in the root of their definition
-  getLayerIndex: function() {
-    var named_map_options = this.get('options') && this.get('options').named_map;
-    return named_map_options && named_map_options.layer_index || this.get('layer_index');
+  getLayerIndex: function () {
+    return this.get('layer_index');
   },
 
   setDataProvider: function (dataProvider) {

--- a/src/geo/map/torque-layer.js
+++ b/src/geo/map/torque-layer.js
@@ -124,6 +124,12 @@ var TorqueLayer = LayerModelBase.extend({
     return this.get('layer_name') || this.get('table_name');
   },
 
+  // Torque layers have the layer_index defined in options.named_map.layer_index
+  getLayerIndex: function () {
+    var named_map_options = this.get('options') && this.get('options').named_map;
+    return named_map_options && named_map_options.layer_index;
+  },
+
   getInteractiveColumnNames: function() {
     return [];
   },

--- a/src/windshaft/named-map.js
+++ b/src/windshaft/named-map.js
@@ -6,13 +6,15 @@ var NamedMap = MapBase.extend({
     var json = {};
     var layers = this._getLayers();
     var styles = layers.reduce(function (p, c, i) {
+      var layerIndex = c.getLayerIndex || i;
       var style = c.get('cartocss');
       if (style) {
-        p[i] = style;
+        p[layerIndex] = style;
       }
       return p;
     }, {});
-    _.each(layers, function (layerModel, layerIndex) {
+    _.each(layers, function (layerModel, index) {
+      var layerIndex = layerModel.getLayerIndex || index;
       json['layer' + layerIndex] = layerModel.isVisible() ? 1 : 0;
     });
     json.styles = styles;

--- a/src/windshaft/named-map.js
+++ b/src/windshaft/named-map.js
@@ -6,7 +6,7 @@ var NamedMap = MapBase.extend({
     var json = {};
     var layers = this._getLayers();
     var styles = layers.reduce(function (p, c, i) {
-      var layerIndex = c.getLayerIndex || i;
+      var layerIndex = c.getLayerIndex() || i;
       var style = c.get('cartocss');
       if (style) {
         p[layerIndex] = style;
@@ -14,7 +14,7 @@ var NamedMap = MapBase.extend({
       return p;
     }, {});
     _.each(layers, function (layerModel, index) {
-      var layerIndex = layerModel.getLayerIndex || index;
+      var layerIndex = layerModel.getLayerIndex() || index;
       json['layer' + layerIndex] = layerModel.isVisible() ? 1 : 0;
     });
     json.styles = styles;


### PR DESCRIPTION
Use `layer_index` (added here https://github.com/CartoDB/cartodb/pull/7454) for references to named maps layers.