### PR TITLE
Hide infowindow when fields are cleared

### DIFF
--- a/src/vis/infowindow-manager.js
+++ b/src/vis/infowindow-manager.js
@@ -74,6 +74,10 @@ InfowindowManager.prototype._bindFeatureClickEvent = function (layerView) {
         return feature.cartodb_id !== data.cartodb_id;
       }).hide();
     }
+
+    this._infowindowModel.once('change:visibility', function () {
+      layerView.tooltipView.setFilter(null);
+    }, this);
   }, this);
 };
 

--- a/test/spec/vis/infowindow-manager-spec.js
+++ b/test/spec/vis/infowindow-manager-spec.js
@@ -523,6 +523,55 @@ describe('src/vis/infowindow-manager.js', function () {
     expect(filterFunction({ cartodb_id: 0 })).toBeTruthy();
   });
 
+  it('should clear the filter on the tooltipView when the infowindow is hidden', function () {
+    // Simulate that the layerView has been added a tooltipView
+    var tooltipView = jasmine.createSpyObj('tooltipView', ['setFilter', 'hide']);
+    tooltipView.setFilter.and.returnValue(tooltipView);
+    this.layerView.tooltipView = tooltipView;
+
+    spyOn(this.mapView, 'addInfowindow');
+
+    var layer = new CartoDBLayer({
+      infowindow: {
+        template: 'template',
+        template_type: 'underscore',
+        fields: [{
+          'name': 'name',
+          'title': true,
+          'position': 1
+        }],
+        alternative_names: 'alternative_names'
+      }
+    });
+
+    var infowindowManager = new InfowindowManager(this.vis);
+    infowindowManager.manage(this.mapView, this.map);
+
+    this.map.layers.reset([ layer ]);
+    var infowindowView = this.mapView.addInfowindow.calls.mostRecent().args[0];
+
+    this.layerView.model = {
+      fetchAttributes: jasmine.createSpy('fetchAttributes'),
+      getLayerAt: function (index) {
+        return layer;
+      },
+
+      getIndexOf: function (layerModel) {
+        return 0;
+      }
+    };
+    spyOn(infowindowView, 'adjustPan');
+
+    // Simulate the featureClick event
+    this.layerView.trigger('featureClick', {}, [100, 200], undefined, { cartodb_id: 10 }, 0);
+
+    this.layerView.tooltipView.setFilter.calls.reset();
+
+    infowindowView.model.set('visibility', false);
+
+    expect(this.layerView.tooltipView.setFilter).toHaveBeenCalledWith(null);
+  });
+
   it('should reload the map when the infowindow template gets new fields', function () {
     spyOn(this.map, 'reload');
 

--- a/test/spec/vis/infowindow-manager-spec.js
+++ b/test/spec/vis/infowindow-manager-spec.js
@@ -669,4 +669,82 @@ describe('src/vis/infowindow-manager.js', function () {
 
     expect(this.map.reload.calls.argsFor(0)[0].success).toEqual(jasmine.any(Function));
   });
+
+  it('should hide the infowindow when fields are cleared in the infowindow template', function () {
+    // Simulate that the layerView has been added a tooltipView
+    var tooltipView = jasmine.createSpyObj('tooltipView', ['setFilter', 'hide']);
+    tooltipView.setFilter.and.returnValue(tooltipView);
+    this.layerView.tooltipView = tooltipView;
+
+    spyOn(this.map, 'reload');
+    spyOn(this.mapView, 'addInfowindow');
+
+    var layer1 = new CartoDBLayer({
+      infowindow: {
+        template: 'template',
+        template_type: 'underscore',
+        fields: [{
+          'name': 'name',
+          'title': true,
+          'position': 1
+        }],
+        alternative_names: 'alternative_names'
+      }
+    });
+
+    var layer2 = new CartoDBLayer({
+      infowindow: {
+        template: 'template',
+        template_type: 'underscore',
+        fields: [{
+          'name': 'name',
+          'title': true,
+          'position': 1
+        }],
+        alternative_names: 'alternative_names'
+      }
+    });
+
+    var infowindowManager = new InfowindowManager(this.vis);
+    infowindowManager.manage(this.mapView, this.map);
+
+    this.map.layers.reset([ layer1, layer2 ]);
+
+    var infowindowView = this.mapView.addInfowindow.calls.mostRecent().args[0];
+
+    this.layerView.model = {
+      fetchAttributes: jasmine.createSpy('fetchAttributes').and.returnValue({ description: 'THE DESCRIPTION' }),
+      getLayerAt: function (index) {
+        return index === 0 ? layer1 : layer2;
+      },
+
+      getIndexOf: function (layerModel) {
+        return layerModel === layer1 ? 0 : 1;
+      }
+    };
+
+    spyOn(infowindowView, 'adjustPan');
+    // Simulate the featureClick event for layer #0
+    this.layerView.trigger('featureClick', {}, [100, 200], undefined, { cartodb_id: 10 }, 0);
+
+    expect(infowindowView.model.get('visibility')).toBe(true);
+
+    // Clear fields on layer #1
+    layer2.infowindow.update({
+      fields: []
+    });
+
+    // Nothing happened
+    expect(infowindowView.model.get('visibility')).toBe(true);
+    expect(this.map.reload).not.toHaveBeenCalledWith({});
+
+    // Clear fields on layer #0 (the one that was opened)
+    layer1.infowindow.update({
+      fields: []
+    });
+
+    // Infowindow has been closed and map has NOT been reloaded
+    expect(infowindowView.model.get('visibility')).toBe(false);
+    expect(this.map.reload).not.toHaveBeenCalledWith({});
+  });
 });


### PR DESCRIPTION
Fixes #1267.

I also implemented some changes so that the filter of the tooltipView is cleared when the infowindow is closed. This was causing tooltips not to work on the feature that was clicked and infowindow was then closed.

@xavijam since you opened that issue... 👍 or 👎 ? Thanks!