### PR TITLE
Allow creating layers at a given position

### DIFF
--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -120,7 +120,8 @@ var Map = Model.extend({
     });
     this.listenTo(layerModel, 'destroy', this._removeLayerModelFromCollection);
     this.layers.add(layerModel, {
-      silent: silent
+      silent: options.silent,
+      at: options.at
     });
 
     return layerModel;

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -114,7 +114,6 @@ var Map = Model.extend({
 
   _addNewLayerModel: function (type, attrs, options) {
     options = options || {};
-    var silent = options.silent;
     var layerModel = LayersFactory.create(type, attrs, {
       map: this
     });

--- a/src/geo/map/layers.js
+++ b/src/geo/map/layers.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var Backbone = require('backbone');
 var LayerModelBase = require('./layer-model-base');
 
@@ -27,27 +28,25 @@ var Layers = Backbone.Collection.extend({
       this.at(0).set({ order: 0 });
 
       if (this.size() > 1) {
-        var layersByType = {};
-        var i;
-        for (i = 1; i < this.size(); ++i) {
-          var layer = this.at(i);
-          var layerType = layer.get('type');
-          layersByType[layerType] = layersByType[layerType] || [];
-          layersByType[layerType].push(layer);
-        }
+        var layersByType = this.reduce(function (layersByType, layerModel, index) {
+          var type = layerModel.get('type');
+          if (index === 0 && type === TILED_LAYER_TYPE) { return layersByType; }
+          layersByType[type] = layersByType[type] || [];
+          layersByType[type].push(layerModel);
+          return layersByType;
+        }, {});
 
-        var lastOrder = 0;
+        var lastOrder = 1;
         var sortedTypes = [CARTODB_LAYER_TYPE, TORQUE_LAYER_TYPE, TILED_LAYER_TYPE];
-        for (i = 0; i < sortedTypes.length; ++i) {
-          var type = sortedTypes[i];
-          var layers = layersByType[type] || [];
-          for (var j = 0; j < layers.length; ++j) {
-            layer = layers[j];
-            layer.set({
-              order: ++lastOrder
+        _.each(sortedTypes, function (layerType) {
+          var layers = layersByType[layerType] || [];
+          _.each(layers, function (layerModel) {
+            layerModel.set({
+              order: lastOrder
             });
-          }
-        }
+            lastOrder += 1;
+          });
+        });
       }
     }
 

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -118,7 +118,7 @@ describe('core/geo/map', function() {
 
     var layer1 = new CartoDBLayer({ attribution: 'attribution1' });
     var layer2 = new CartoDBLayer({ attribution: 'attribution1' });
-    var layer3 = new CartoDBLayer({ attribution: 'testCase' });
+    var layer3 = new CartoDBLayer({ attribution: 'wadus' });
     var layer4 = new CartoDBLayer({ attribution: '' });
 
     map.layers.reset([ layer1, layer2, layer3, layer4 ]);
@@ -126,7 +126,7 @@ describe('core/geo/map', function() {
     // Attributions have been updated removing duplicated and empty attributions
     expect(map.get('attribution')).toEqual([
       "attribution1",
-      "testCase",
+      "wadus",
       "CartoDB <a href=\"http://cartodb.com/attributions\" target=\"_blank\">attribution</a>",
     ]);
 
@@ -137,7 +137,7 @@ describe('core/geo/map', function() {
     // The attribution of the new layer has been appended before the default CartoDB attribution
     expect(map.get('attribution')).toEqual([
       "attribution1",
-      "testCase",
+      "wadus",
       "attribution2",
       "CartoDB <a href=\"http://cartodb.com/attributions\" target=\"_blank\">attribution</a>",
     ]);
@@ -147,7 +147,7 @@ describe('core/geo/map', function() {
     // The attribution of the layer has been updated in the map
     expect(map.get('attribution')).toEqual([
       "attribution1",
-      "testCase",
+      "wadus",
       "new attribution",
       "CartoDB <a href=\"http://cartodb.com/attributions\" target=\"_blank\">attribution</a>",
     ]);
@@ -156,7 +156,7 @@ describe('core/geo/map', function() {
 
     expect(map.get('attribution')).toEqual([
       "attribution1",
-      "testCase",
+      "wadus",
       "CartoDB <a href=\"http://cartodb.com/attributions\" target=\"_blank\">attribution</a>",
     ]);
 
@@ -168,7 +168,7 @@ describe('core/geo/map', function() {
     // Default CartoDB only appears once and it's the last one
     expect(map.get('attribution')).toEqual([
       "attribution1",
-      "testCase",
+      "wadus",
       "CartoDB <a href=\"http://cartodb.com/attributions\" target=\"_blank\">attribution</a>",
     ]);
   });

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -118,7 +118,7 @@ describe('core/geo/map', function() {
 
     var layer1 = new CartoDBLayer({ attribution: 'attribution1' });
     var layer2 = new CartoDBLayer({ attribution: 'attribution1' });
-    var layer3 = new CartoDBLayer({ attribution: 'wadus' });
+    var layer3 = new CartoDBLayer({ attribution: 'testCase' });
     var layer4 = new CartoDBLayer({ attribution: '' });
 
     map.layers.reset([ layer1, layer2, layer3, layer4 ]);
@@ -126,7 +126,7 @@ describe('core/geo/map', function() {
     // Attributions have been updated removing duplicated and empty attributions
     expect(map.get('attribution')).toEqual([
       "attribution1",
-      "wadus",
+      "testCase",
       "CartoDB <a href=\"http://cartodb.com/attributions\" target=\"_blank\">attribution</a>",
     ]);
 
@@ -137,7 +137,7 @@ describe('core/geo/map', function() {
     // The attribution of the new layer has been appended before the default CartoDB attribution
     expect(map.get('attribution')).toEqual([
       "attribution1",
-      "wadus",
+      "testCase",
       "attribution2",
       "CartoDB <a href=\"http://cartodb.com/attributions\" target=\"_blank\">attribution</a>",
     ]);
@@ -147,7 +147,7 @@ describe('core/geo/map', function() {
     // The attribution of the layer has been updated in the map
     expect(map.get('attribution')).toEqual([
       "attribution1",
-      "wadus",
+      "testCase",
       "new attribution",
       "CartoDB <a href=\"http://cartodb.com/attributions\" target=\"_blank\">attribution</a>",
     ]);
@@ -156,7 +156,7 @@ describe('core/geo/map', function() {
 
     expect(map.get('attribution')).toEqual([
       "attribution1",
-      "wadus",
+      "testCase",
       "CartoDB <a href=\"http://cartodb.com/attributions\" target=\"_blank\">attribution</a>",
     ]);
 
@@ -168,7 +168,7 @@ describe('core/geo/map', function() {
     // Default CartoDB only appears once and it's the last one
     expect(map.get('attribution')).toEqual([
       "attribution1",
-      "wadus",
+      "testCase",
       "CartoDB <a href=\"http://cartodb.com/attributions\" target=\"_blank\">attribution</a>",
     ]);
   });
@@ -260,148 +260,97 @@ describe('core/geo/map', function() {
       });
     });
 
-    describe('.createCartoDBLayer', function () {
-      it('should throw an error if no properties are given', function () {
-        expect(function () {
-          this.map.createCartoDBLayer({});
-        }.bind(this)).toThrowError('The following attributes are missing: sql,cartocss');
-      });
-
-      it('should return a layer of the corresponding type', function () {
-        var layer = this.map.createCartoDBLayer({
+    var testCases = [
+      {
+        createMethod: 'createCartoDBLayer',
+        expectedLayerModelClass: CartoDBLayer,
+        testAttributes: {
           sql: 'something',
           cartocss: 'else'
-        });
-        expect(layer instanceof CartoDBLayer).toBeTruthy();
-      });
-
-      it('should add the layer model to the collection of layers', function () {
-        var layer = this.map.createCartoDBLayer({
+        },
+        expectedErrorMessage: 'The following attributes are missing: sql,cartocss'
+      },
+      {
+        createMethod: 'createTorqueLayer',
+        expectedLayerModelClass: TorqueLayer,
+        testAttributes: {
           sql: 'something',
           cartocss: 'else'
-        });
-        expect(this.map.layers.at(0)).toEqual(layer);
-      });
-    });
-
-    describe('.createTorqueLayer', function () {
-      it('should throw an error if no properties are given', function () {
-        expect(function () {
-          this.map.createTorqueLayer({});
-        }.bind(this)).toThrowError('The following attributes are missing: sql,cartocss');
-      });
-
-      it('should return a layer of the corresponding type', function () {
-        var layer = this.map.createTorqueLayer({
-          sql: 'something',
-          cartocss: 'else'
-        });
-        expect(layer instanceof TorqueLayer).toBeTruthy();
-      });
-
-      it('should add the layer model to the collection of layers', function () {
-        var layer = this.map.createTorqueLayer({
-          sql: 'something',
-          cartocss: 'else'
-        });
-        expect(this.map.layers.at(0)).toEqual(layer);
-      });
-    });
-
-    describe('.createTileLayer', function () {
-      it('should throw an error if no properties are given', function () {
-        expect(function () {
-          this.map.createTileLayer({});
-        }.bind(this)).toThrowError('The following attributes are missing: urlTemplate');
-      });
-
-      it('should return a layer of the corresponding type', function () {
-        var layer = this.map.createTileLayer({
+        },
+        expectedErrorMessage: 'The following attributes are missing: sql,cartocss'
+      },
+      {
+        createMethod: 'createTileLayer',
+        expectedLayerModelClass: TileLayer,
+        testAttributes: {
           urlTemplate: 'http://example.com'
-        });
-        expect(layer instanceof TileLayer).toBeTruthy();
-      });
-
-      it('should add the layer model to the collection of layers', function () {
-        var layer = this.map.createTileLayer({
+        },
+        expectedErrorMessage: 'The following attributes are missing: urlTemplate'
+      },
+      {
+        createMethod: 'createWMSLayer',
+        expectedLayerModelClass: WMSLayer,
+        testAttributes: {
           urlTemplate: 'http://example.com'
-        });
-        expect(this.map.layers.at(0)).toEqual(layer);
-      });
-    });
-
-    describe('.createWMSLayer', function () {
-      it('should throw an error if no properties are given', function () {
-        expect(function () {
-          this.map.createWMSLayer({});
-        }.bind(this)).toThrowError('The following attributes are missing: urlTemplate');
-      });
-
-      it('should return a layer of the corresponding type', function () {
-        var layer = this.map.createWMSLayer({
-          urlTemplate: 'http://example.com'
-        });
-        expect(layer instanceof WMSLayer).toBeTruthy();
-      });
-
-      it('should add the layer model to the collection of layers', function () {
-        var layer = this.map.createWMSLayer({
-          urlTemplate: 'http://example.com'
-        });
-        expect(this.map.layers.at(0)).toEqual(layer);
-      });
-    });
-
-    describe('.createGMapsBaseLayer', function () {
-      it('should throw an error if no properties are given', function () {
-        expect(function () {
-          this.map.createGMapsBaseLayer({});
-        }.bind(this)).toThrowError('The following attributes are missing: base_type');
-      });
-
-      it('should return a layer of the corresponding type', function () {
-        var layer = this.map.createGMapsBaseLayer({
+        },
+        expectedErrorMessage: 'The following attributes are missing: urlTemplate'
+      },
+      {
+        createMethod: 'createGMapsBaseLayer',
+        expectedLayerModelClass: GMapsBaseLayer,
+        testAttributes: {
           base_type: 'http://example.com'
-        });
-        expect(layer instanceof GMapsBaseLayer).toBeTruthy();
-      });
-
-      it('should add the layer model to the collection of layers', function () {
-        var layer = this.map.createGMapsBaseLayer({
-          base_type: 'http://example.com'
-        });
-        expect(this.map.layers.at(0)).toEqual(layer);
-      });
-    });
-
-    describe('.createPlainLayer', function () {
-      it('should throw an error if no properties are given', function () {
-        expect(function () {
-          this.map.createPlainLayer({});
-        }.bind(this)).toThrowError('The following attributes are missing: image|color');
-      });
-
-      it('should return a layer of the corresponding type if color attribute is present', function () {
-        var layer = this.map.createPlainLayer({
+        },
+        expectedErrorMessage: 'The following attributes are missing: base_type'
+      },
+      {
+        createMethod: 'createPlainLayer',
+        expectedLayerModelClass: PlainLayer,
+        testAttributes: {
           color: '#FABADA'
-        });
-        expect(layer instanceof PlainLayer).toBeTruthy();
-      });
-
-      it('should return a layer of the corresponding type if image attribute is present', function () {
-        var layer = this.map.createPlainLayer({
+        },
+        expectedErrorMessage: 'The following attributes are missing: image|color'
+      },
+      {
+        createMethod: 'createPlainLayer',
+        expectedLayerModelClass: PlainLayer,
+        testAttributes: {
           image: 'http://example.com/image.png'
-        });
-        expect(layer instanceof PlainLayer).toBeTruthy();
-      });
+        },
+        expectedErrorMessage: 'The following attributes are missing: image|color'
+      }
+    ];
 
-      it('should add the layer model to the collection of layers', function () {
-        var layer = this.map.createPlainLayer({
-          color: '#FABADA'
+    _.each(testCases, function (testCase) {
+      describe('.' + testCase.createMethod, function () {
+        it('should throw an error if no properties are given', function () {
+          expect(function () {
+            this.map[testCase.createMethod]({});
+          }.bind(this)).toThrowError(testCase.expectedErrorMessage);
         });
-        expect(this.map.layers.at(0)).toEqual(layer);
+
+        it('should return a layer of the corresponding type', function () {
+          var layer = this.map[testCase.createMethod](testCase.testAttributes);
+          expect(layer instanceof testCase.expectedLayerModelClass).toBeTruthy();
+        });
+
+        it('should add the layer model to the collection of layers', function () {
+          var layer = this.map[testCase.createMethod](testCase.testAttributes);
+          expect(this.map.layers.at(0)).toEqual(layer);
+        });
+
+        it('should add the layer model at the given position', function () {
+          var layer1 = this.map[testCase.createMethod](testCase.testAttributes);
+
+          var layer0 = this.map[testCase.createMethod](testCase.testAttributes, { at: 0 });
+          var layer2 = this.map[testCase.createMethod](testCase.testAttributes, { at: 2 });
+
+          expect(this.map.layers.at(0)).toEqual(layer0);
+          expect(this.map.layers.at(1)).toEqual(layer1);
+          expect(this.map.layers.at(2)).toEqual(layer2);
+        });
       });
-    });
+    }, this);
 
     describe('.reCenter', function () {
       it('should set the original bounds if present', function () {


### PR DESCRIPTION
This PR changes things so that `map.createCartoDBLayer`, `map.createTorqueLayer`, etc. accept `at` option to specify where the position where the layer should be inserted. Orders are automatically re-assigned [here](https://github.com/CartoDB/cartodb.js/blob/v4/src/geo/map/layers.js#L16). Also refactored the method that assign indexes a bit.

@viddo would you please take a look? thx!