### PR TITLE
Fixed analysis section in map config for anonymous maps:

### DIFF
--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -261,7 +261,7 @@ module.exports = DataviewModelBase.extend({
   toJSON: function () {
     return {
       type: 'aggregation',
-      source: { id: this._getSourceId() },
+      source: { id: this.getSourceId() },
       options: {
         column: this.get('column'),
         aggregation: this.get('aggregation'),

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -221,8 +221,8 @@ module.exports = Model.extend({
     throw new Error('toJSON should be defined for each dataview');
   },
 
-  _getSourceId: function () {
-    return this.get('sourceId') || this.layer.get('source') || this.layer.get('id');
+  getSourceId: function () {
+    return this.get('source').id;
   },
 
   remove: function () {
@@ -241,7 +241,7 @@ module.exports = Model.extend({
       'sync_on_data_change',
       'sync_on_bbox_change',
       'enabled',
-      'sourceId'
+      'source'
     ]
   }
 );

--- a/src/dataviews/dataviews-factory.js
+++ b/src/dataviews/dataviews-factory.js
@@ -2,7 +2,7 @@ var _ = require('underscore');
 var Model = require('../core/model');
 var CategoryFilter = require('../windshaft/filters/category');
 var RangeFilter = require('../windshaft/filters/range');
-var CategorDataviewModel = require('./category-dataview-model');
+var CategoryDataviewModel = require('./category-dataview-model');
 var FormulaDataviewModel = require('./formula-dataview-model');
 var HistogramDataviewModel = require('./histogram-dataview-model');
 var ListDataviewModel = require('./list-dataview-model');
@@ -22,8 +22,8 @@ module.exports = Model.extend({
   },
 
   createCategoryModel: function (layerModel, attrs) {
-    _checkProperties(attrs, ['column']);
-    attrs = _.pick(attrs, CategorDataviewModel.ATTRS_NAMES);
+    _checkProperties(attrs, ['column', 'source']);
+    attrs = _.pick(attrs, CategoryDataviewModel.ATTRS_NAMES);
     attrs.aggregation = attrs.aggregation || 'count';
     attrs.aggregation_column = attrs.aggregation_column || attrs.column;
     if (this.get('apiKey')) {
@@ -35,7 +35,7 @@ module.exports = Model.extend({
     });
 
     return this._newModel(
-      new CategorDataviewModel(attrs, {
+      new CategoryDataviewModel(attrs, {
         map: this._map,
         filter: categoryFilter,
         layer: layerModel
@@ -44,7 +44,7 @@ module.exports = Model.extend({
   },
 
   createFormulaModel: function (layerModel, attrs) {
-    _checkProperties(attrs, ['column', 'operation']);
+    _checkProperties(attrs, ['column', 'operation', 'source']);
     attrs = _.pick(attrs, FormulaDataviewModel.ATTRS_NAMES);
     if (this.get('apiKey')) {
       attrs.apiKey = this.get('apiKey');
@@ -59,7 +59,7 @@ module.exports = Model.extend({
   },
 
   createHistogramModel: function (layerModel, attrs) {
-    _checkProperties(attrs, ['column']);
+    _checkProperties(attrs, ['column', 'source']);
     attrs = _.pick(attrs, HistogramDataviewModel.ATTRS_NAMES);
     if (this.get('apiKey')) {
       attrs.apiKey = this.get('apiKey');
@@ -79,7 +79,7 @@ module.exports = Model.extend({
   },
 
   createListModel: function (layerModel, attrs) {
-    _checkProperties(attrs, ['columns']);
+    _checkProperties(attrs, ['columns', 'source']);
     attrs = _.pick(attrs, ListDataviewModel.ATTRS_NAMES);
     if (this.get('apiKey')) {
       attrs.apiKey = this.get('apiKey');

--- a/src/dataviews/formula-dataview-model.js
+++ b/src/dataviews/formula-dataview-model.js
@@ -25,7 +25,7 @@ module.exports = DataviewModelBase.extend({
   toJSON: function () {
     return {
       type: 'formula',
-      source: { id: this._getSourceId() },
+      source: { id: this.getSourceId() },
       options: {
         column: this.get('column'),
         operation: this.get('operation')

--- a/src/dataviews/histogram-dataview-model.js
+++ b/src/dataviews/histogram-dataview-model.js
@@ -173,7 +173,7 @@ module.exports = DataviewModelBase.extend({
   toJSON: function (d) {
     return {
       type: 'histogram',
-      source: { id: this._getSourceId() },
+      source: { id: this.getSourceId() },
       options: {
         column: this.get('column'),
         bins: this.get('bins')

--- a/src/dataviews/list-dataview-model.js
+++ b/src/dataviews/list-dataview-model.js
@@ -37,7 +37,7 @@ module.exports = DataviewModelBase.extend({
   toJSON: function () {
     return {
       type: 'list',
-      source: { id: this._getSourceId() },
+      source: { id: this.getSourceId() },
       options: {
         columns: this.get('columns')
       }

--- a/src/vis/vis-view.js
+++ b/src/vis/vis-view.js
@@ -275,7 +275,7 @@ var Vis = View.extend({
       return layerModel.get('source') === analysisModel.get('id');
     });
     var isAnalysisLinkedToDataview = this._dataviewsCollection.any(function (dataviewModel) {
-      var sourceId = dataviewModel.get('sourceId') || dataviewModel.layer.get('source');
+      var sourceId = dataviewModel.getSourceId();
       return analysisModel.get('id') === sourceId;
     });
     return isAnalysisLinkedToLayer || isAnalysisLinkedToDataview;

--- a/src/windshaft/anonymous-map.js
+++ b/src/windshaft/anonymous-map.js
@@ -5,68 +5,83 @@ var DEFAULT_CARTOCSS_VERSION = '2.1.0';
 
 var AnonymousMap = MapBase.extend({
   toJSON: function () {
-    var config = {
-      layers: [],
-      dataviews: {},
-      analyses: []
+    return {
+      layers: this._calculateLayersSection(),
+      dataviews: this._calculateDataviewsSection(),
+      analyses: this._calculateAnalysesSection()
     };
+  },
 
-    _.each(this._getLayers(), function (layerModel) {
-      var layerSourceId = layerModel.get('source');
-      if (layerSourceId) {
-        var sourceAnalysis = this._analysisCollection.findWhere({ id: layerSourceId });
-        if (!this._isAnalysisPartOfOtherAnalyses(sourceAnalysis)) {
-          config.analyses.push(sourceAnalysis.toJSON());
-        }
-      } else {
-        if (this._isAnyDataviewLinkedTo(layerModel)) {
-          layerSourceId = layerModel.get('id');
-          config.analyses.push({
-            id: layerSourceId,
-            type: 'source',
-            params: {
-              query: layerModel.get('sql')
+  _calculateLayersSection: function () {
+    return _.chain(this._getLayers())
+      .map(function (layerModel) {
+        if (layerModel.isVisible()) {
+          var layerConfig = {
+            type: layerModel.get('type').toLowerCase(),
+            options: {
+              cartocss: layerModel.get('cartocss'),
+              cartocss_version: layerModel.get('cartocss_version') || DEFAULT_CARTOCSS_VERSION,
+              interactivity: layerModel.getInteractiveColumnNames()
             }
-          });
-        }
-      }
-
-      if (layerModel.isVisible()) {
-        var layerConfig = {
-          type: layerModel.get('type').toLowerCase(),
-          options: {
-            cartocss: layerModel.get('cartocss'),
-            cartocss_version: layerModel.get('cartocss_version') || DEFAULT_CARTOCSS_VERSION,
-            interactivity: layerModel.getInteractiveColumnNames()
-          }
-        };
-
-        if (layerSourceId) {
-          layerConfig.options.source = { id: layerSourceId };
-        } else if (layerModel.get('sql')) { // Layer has some SQL that needs to be converted into a "source" analysis
-          layerConfig.options.sql = layerModel.get('sql');
-        }
-
-        if (layerModel.get('sql_wrap')) {
-          layerConfig.options.sql_wrap = layerModel.get('sql_wrap');
-        }
-
-        if (layerModel.infowindow && layerModel.infowindow.hasFields()) {
-          layerConfig.options.attributes = {
-            id: 'cartodb_id',
-            columns: layerModel.infowindow.getFieldNames()
           };
-        }
 
-        config.layers.push(layerConfig);
+          var layerSourceId = layerModel.get('source');
+          if (layerSourceId) {
+            layerConfig.options.source = { id: layerSourceId };
+          } else if (layerModel.get('sql')) { // Layer has some SQL that needs to be converted into a "source" analysis
+            layerConfig.options.sql = layerModel.get('sql');
+          }
+
+          if (layerModel.get('sql_wrap')) {
+            layerConfig.options.sql_wrap = layerModel.get('sql_wrap');
+          }
+
+          if (layerModel.infowindow && layerModel.infowindow.hasFields()) {
+            layerConfig.options.attributes = {
+              id: 'cartodb_id',
+              columns: layerModel.infowindow.getFieldNames()
+            };
+          }
+
+          return layerConfig;
+        }
+      }, this)
+      .compact()
+      .value();
+  },
+
+  _calculateDataviewsSection: function () {
+    return this._dataviewsCollection.reduce(function (dataviews, dataviewModel) {
+      dataviews[dataviewModel.get('id')] = dataviewModel.toJSON();
+      return dataviews;
+    }, {});
+  },
+
+  _calculateAnalysesSection: function () {
+    var analyses = [];
+    var sourceIdsFromLayers = _.chain(this._getLayers())
+      .map(function (layerModel) {
+        return layerModel.get('source');
+      })
+      .compact()
+      .value();
+
+    var sourceIdsFromDataviews = this._dataviewsCollection.chain()
+      .map(function (dataviewModel) {
+        return dataviewModel.getSourceId();
+      })
+      .compact()
+      .value();
+
+    var sourceIds = _.uniq(sourceIdsFromLayers.concat(sourceIdsFromDataviews));
+    _.each(sourceIds, function (sourceId) {
+      var sourceAnalysis = this._analysisCollection.findWhere({ id: sourceId });
+      if (!this._isAnalysisPartOfOtherAnalyses(sourceAnalysis)) {
+        analyses.push(sourceAnalysis.toJSON());
       }
     }, this);
 
-    this._dataviewsCollection.each(function (dataviewModel) {
-      config.dataviews[dataviewModel.get('id')] = dataviewModel.toJSON();
-    });
-
-    return config;
+    return analyses;
   },
 
   _isAnalysisPartOfOtherAnalyses: function (analysisModel) {

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -415,39 +415,8 @@ describe('dataviews/dataview-model-base', function () {
     });
   });
 
-  describe('_getSourceId', function () {
-    it('should return the layer ID', function () {
-      var layer = new Backbone.Model({
-        id: 'layerId'
-      });
-      layer.getDataProvider = jasmine.createSpy('getDataProvider').and.returnValue(undefined);
-
-      var dataview = new DataviewModelBase(null, { // eslint-disable-line
-        map: this.map,
-        windshaftMap: this.windshaftMap,
-        layer: layer
-      });
-
-      expect(dataview._getSourceId()).toEqual('layerId');
-    });
-
-    it("should return the ID of the layer's source", function () {
-      var layer = new Backbone.Model({
-        id: 'layerId',
-        source: 'a1'
-      });
-      layer.getDataProvider = jasmine.createSpy('getDataProvider').and.returnValue(undefined);
-
-      var dataview = new DataviewModelBase(null, { // eslint-disable-line
-        map: this.map,
-        windshaftMap: this.windshaftMap,
-        layer: layer
-      });
-
-      expect(dataview._getSourceId()).toEqual('a1');
-    });
-
-    it('should return the sourceId', function () {
+  describe('getSourceId', function () {
+    it('should return the id of the source', function () {
       var layer = new Backbone.Model({
         id: 'layerId',
         source: 'a1'
@@ -455,14 +424,16 @@ describe('dataviews/dataview-model-base', function () {
       layer.getDataProvider = jasmine.createSpy('getDataProvider').and.returnValue(undefined);
 
       var dataview = new DataviewModelBase({
-        sourceId: 'THE_SOURCE_ID'
+        source: {
+          id: 'THE_SOURCE_ID'
+        }
       }, { // eslint-disable-line
         map: this.map,
         windshaftMap: this.windshaftMap,
         layer: layer
       });
 
-      expect(dataview._getSourceId()).toEqual('THE_SOURCE_ID');
+      expect(dataview.getSourceId()).toEqual('THE_SOURCE_ID');
     });
   });
 });

--- a/test/spec/dataviews/dataviews-factory.spec.js
+++ b/test/spec/dataviews/dataviews-factory.spec.js
@@ -20,10 +20,10 @@ describe('dataviews/dataviews-factory', function () {
   });
 
   var FACTORY_METHODS_AND_REQUIRED_ATTRIBUTES = [
-    ['createCategoryModel', ['column']],
-    ['createFormulaModel', ['column', 'operation']],
-    ['createHistogramModel', ['column']],
-    ['createListModel', ['columns']]
+    ['createCategoryModel', ['column', 'source']],
+    ['createFormulaModel', ['column', 'operation', 'source']],
+    ['createHistogramModel', ['column', 'source']],
+    ['createListModel', ['columns', 'source']]
   ];
 
   _.each(FACTORY_METHODS_AND_REQUIRED_ATTRIBUTES, function (element) {

--- a/test/spec/windshaft/anonymous-map.spec.js
+++ b/test/spec/windshaft/anonymous-map.spec.js
@@ -14,7 +14,7 @@ var createFakeAnalysis = function (attrs) {
 };
 
 var createFakeDataview = function (attrs, windshaftMap, layer) {
-  if (!attrs.id) { throw new Error('id is required'); };
+  if (!attrs.id) { throw new Error('id is required'); }
   attrs = _.defaults(attrs, {
     column: 'column1',
     bins: 5,


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/7605.

- Dataviews get sourceId from `{ source: { id: 'X' } }` attribute (that's what deep-insights.js is sending). Before, CartoDB.js was assuming attribute was called 'sourceId'.
- Assume dataviews will always have a source, instead of falling back to layer.
- Include an analysis node for dataviews in the map config for named maps, which was missing before.

@viddo 👍  👎  ? Thanks!

cc: @javisantana 