### PR TITLE
Source attribute for dataviews is not required anymore

### DIFF
--- a/src/dataviews/dataviews-factory.js
+++ b/src/dataviews/dataviews-factory.js
@@ -22,10 +22,12 @@ module.exports = Model.extend({
   },
 
   createCategoryModel: function (layerModel, attrs) {
-    _checkProperties(attrs, ['column', 'source']);
+    _checkProperties(attrs, ['column']);
+
     attrs = _.pick(attrs, CategoryDataviewModel.ATTRS_NAMES);
     attrs.aggregation = attrs.aggregation || 'count';
     attrs.aggregation_column = attrs.aggregation_column || attrs.column;
+    attrs.source = attrs.source || { id: layerModel.id };
     if (this.get('apiKey')) {
       attrs.apiKey = this.get('apiKey');
     }
@@ -44,8 +46,9 @@ module.exports = Model.extend({
   },
 
   createFormulaModel: function (layerModel, attrs) {
-    _checkProperties(attrs, ['column', 'operation', 'source']);
+    _checkProperties(attrs, ['column', 'operation']);
     attrs = _.pick(attrs, FormulaDataviewModel.ATTRS_NAMES);
+    attrs.source = attrs.source || { id: layerModel.id };
     if (this.get('apiKey')) {
       attrs.apiKey = this.get('apiKey');
     }
@@ -59,8 +62,9 @@ module.exports = Model.extend({
   },
 
   createHistogramModel: function (layerModel, attrs) {
-    _checkProperties(attrs, ['column', 'source']);
+    _checkProperties(attrs, ['column']);
     attrs = _.pick(attrs, HistogramDataviewModel.ATTRS_NAMES);
+    attrs.source = attrs.source || { id: layerModel.id };
     if (this.get('apiKey')) {
       attrs.apiKey = this.get('apiKey');
     }
@@ -79,8 +83,9 @@ module.exports = Model.extend({
   },
 
   createListModel: function (layerModel, attrs) {
-    _checkProperties(attrs, ['columns', 'source']);
+    _checkProperties(attrs, ['columns']);
     attrs = _.pick(attrs, ListDataviewModel.ATTRS_NAMES);
+    attrs.source = attrs.source || { id: layerModel.id };
     if (this.get('apiKey')) {
       attrs.apiKey = this.get('apiKey');
     }

--- a/src/windshaft/anonymous-map.js
+++ b/src/windshaft/anonymous-map.js
@@ -82,12 +82,34 @@ var AnonymousMap = MapBase.extend({
     var sourceIds = _.uniq(sourceIdsFromLayers.concat(sourceIdsFromDataviews));
     _.each(sourceIds, function (sourceId) {
       var sourceAnalysis = this._analysisCollection.findWhere({ id: sourceId });
-      if (!this._isAnalysisPartOfOtherAnalyses(sourceAnalysis)) {
-        analyses.push(sourceAnalysis.toJSON());
+      if (sourceAnalysis) {
+        if (!this._isAnalysisPartOfOtherAnalyses(sourceAnalysis)) {
+          analyses.push(sourceAnalysis.toJSON());
+        }
+      } else {
+        if (this._getLayerById(sourceId)) {
+          analyses.push(this._getSourceAnalysisForLayer(this._getLayerById(sourceId)));
+        }
       }
     }, this);
 
     return analyses;
+  },
+
+  _getLayerById: function (layerId) {
+    return _.find(this._getLayers(), function (layerModel) {
+      return layerModel.id === layerId;
+    });
+  },
+
+  _getSourceAnalysisForLayer: function (layerModel) {
+    return {
+      id: layerModel.id,
+      type: 'source',
+      params: {
+        query: layerModel.get('sql')
+      }
+    };
   },
 
   _isAnalysisPartOfOtherAnalyses: function (analysisModel) {

--- a/test/spec/dataviews/dataviews-factory.spec.js
+++ b/test/spec/dataviews/dataviews-factory.spec.js
@@ -20,10 +20,10 @@ describe('dataviews/dataviews-factory', function () {
   });
 
   var FACTORY_METHODS_AND_REQUIRED_ATTRIBUTES = [
-    ['createCategoryModel', ['column', 'source']],
-    ['createFormulaModel', ['column', 'operation', 'source']],
-    ['createHistogramModel', ['column', 'source']],
-    ['createListModel', ['columns', 'source']]
+    ['createCategoryModel', ['column']],
+    ['createFormulaModel', ['column', 'operation']],
+    ['createHistogramModel', ['column']],
+    ['createListModel', ['columns']]
   ];
 
   _.each(FACTORY_METHODS_AND_REQUIRED_ATTRIBUTES, function (element) {
@@ -56,6 +56,26 @@ describe('dataviews/dataviews-factory', function () {
       var model = this.factory[factoryMethod](layer, attributes);
 
       expect(model.get('apiKey')).toEqual('THE_API_KEY');
+    });
+
+    it(factoryMethod + " should set a default source using the layer's id when not given one", function () {
+      this.factory = new DataviewsFactory({
+        apiKey: 'THE_API_KEY'
+      }, {
+        dataviewsCollection: this.dataviewsCollection,
+        map: {}
+      });
+
+      var layer = jasmine.createSpyObj('layer', ['getDataProvider']);
+
+      // Set fake attributes
+      var attributes = _.reduce(requiredAttributes, function (object, attributeName) {
+        object[attributeName] = 'something';
+        return object;
+      }, {});
+      var model = this.factory[factoryMethod](layer, attributes);
+
+      expect(model.get('source')).toEqual({ id: layer.id });
     });
   }, this);
 });

--- a/test/spec/windshaft/anonymous-map.spec.js
+++ b/test/spec/windshaft/anonymous-map.spec.js
@@ -330,6 +330,27 @@ describe('windshaft/anonymous-map', function () {
         expect(this.map.toJSON().analyses).toEqual([ analysis ]);
       });
 
+      it('should include a source analysis for dataviews whose source is a layer', function () {
+        var dataview = createFakeDataview({
+          id: 'dataviewId1',
+          source: {
+            id: this.cartoDBLayer1.id
+          }
+        }, this.map, this.cartoDBLayer1);
+
+        this.dataviewsCollection.add(dataview);
+
+        expect(this.map.toJSON().analyses).toEqual([
+          {
+            id: this.cartoDBLayer1.id,
+            type: 'source',
+            params: {
+              query: this.cartoDBLayer1.get('sql')
+            }
+          }
+        ]);
+      });
+
       it("should NOT include an analysis if it's part of the analysis of another layer", function () {
         var analysis1 = this.analysisFactory.analyse({
           id: 'c1',


### PR DESCRIPTION
- Instead a default sourceId is generated based on the layer id. This will fix the tests and examples in deep-insights.js
- Also, an analysis source is included in the map config for dataviews that have a layer as their source.

@fdansv please take a look. thanks!