### PR TITLE
Limit the number of subsequent requests to the Maps API using the same payload, params and options

### DIFF
--- a/src/windshaft/map-base.js
+++ b/src/windshaft/map-base.js
@@ -74,13 +74,11 @@ var WindshaftMap = Backbone.Model.extend({
     return !this._requestTracker.maxNumberOfRequestsReached();
   },
 
-  _trackRequest: function (request) {
-    this._requestTracker.track(request);
+  _trackRequest: function (request, response) {
+    this._requestTracker.track(request, response);
   },
 
   _performRequest: function (request) {
-    this._trackRequest(request);
-
     var payload = request.payload;
     var params = request.params;
     var options = request.options;
@@ -89,16 +87,19 @@ var WindshaftMap = Backbone.Model.extend({
       mapDefinition: payload,
       params: params,
       success: function (mapInstance) {
+        this._trackRequest(request, mapInstance);
         this.set(mapInstance);
         this._modelUpdater.updateModels(this, options.sourceLayerId, options.forceFetch);
         this.trigger('instanceCreated');
         options.success && options.success(this);
       }.bind(this),
       error: function (error) {
+        this._trackRequest(request, error);
+
         var errorMsg = 'Request to Maps API failed: ' + error;
         log.error(errorMsg);
         options.error && options.error(errorMsg);
-      }
+      }.bind(this)
     });
   },
 

--- a/src/windshaft/map-base.js
+++ b/src/windshaft/map-base.js
@@ -64,7 +64,6 @@ var WindshaftMap = Backbone.Model.extend({
 
     var request = new Request(payload, params, options);
     if (this._canPerformRequest(request)) {
-      this._trackRequest(request);
       this._performRequest(request);
     }
 
@@ -80,6 +79,8 @@ var WindshaftMap = Backbone.Model.extend({
   },
 
   _performRequest: function (request) {
+    this._trackRequest(request);
+
     var payload = request.payload;
     var params = request.params;
     var options = request.options;

--- a/src/windshaft/map-base.js
+++ b/src/windshaft/map-base.js
@@ -65,6 +65,8 @@ var WindshaftMap = Backbone.Model.extend({
     var request = new Request(payload, params, options);
     if (this._canPerformRequest(request)) {
       this._performRequest(request);
+    } else {
+      log.error('Maximum number of subsequent equal requests to the Maps API reached (' + MAP_INSTANTIATION_LIMIT + '):', payload, params);
     }
 
     return this;
@@ -95,7 +97,6 @@ var WindshaftMap = Backbone.Model.extend({
       }.bind(this),
       error: function (error) {
         this._trackRequest(request, error);
-
         var errorMsg = 'Request to Maps API failed: ' + error;
         log.error(errorMsg);
         options.error && options.error(errorMsg);

--- a/src/windshaft/request-tracker.js
+++ b/src/windshaft/request-tracker.js
@@ -1,0 +1,34 @@
+/**
+ * Keeps track of subsequent equal requests to the Maps API
+ * @param {number} maxNumberOfRequests Maximum number of subsequent requests allowed
+ */
+var RequestTracker = function (maxNumberOfRequests) {
+  this._maxNumberOfRequests = maxNumberOfRequests || 3;
+  this.reset();
+};
+
+RequestTracker.prototype.track = function (request) {
+  if (this._lastRequest && !this._lastRequest.equals(request)) {
+    this.reset();
+  }
+
+  if (!this.maxNumberOfRequestsReached()) {
+    this._lastRequest = request;
+    this._numberOfRequests += 1;
+  }
+};
+
+RequestTracker.prototype.reset = function () {
+  this._lastRequest = undefined;
+  this._numberOfRequests = 0;
+};
+
+RequestTracker.prototype.maxNumberOfRequestsReached = function () {
+  return this._numberOfRequests === this._maxNumberOfRequests;
+};
+
+RequestTracker.prototype.lastRequestEquals = function (request) {
+  return this._lastRequest && this._lastRequest.equals(request);
+};
+
+module.exports = RequestTracker;

--- a/src/windshaft/request-tracker.js
+++ b/src/windshaft/request-tracker.js
@@ -1,3 +1,5 @@
+var _ = require('underscore');
+
 /**
  * Keeps track of subsequent equal requests to the Maps API
  * @param {number} maxNumberOfRequests Maximum number of subsequent requests allowed
@@ -7,19 +9,21 @@ var RequestTracker = function (maxNumberOfRequests) {
   this.reset();
 };
 
-RequestTracker.prototype.track = function (request) {
-  if (this._lastRequest && !this._lastRequest.equals(request)) {
+RequestTracker.prototype.track = function (request, response) {
+  if (!this.lastRequestEquals(request) || !this.lastResponseEquals(response)) {
     this.reset();
   }
 
   if (!this.maxNumberOfRequestsReached()) {
     this._lastRequest = request;
+    this._lastResponse = response;
     this._numberOfRequests += 1;
   }
 };
 
 RequestTracker.prototype.reset = function () {
   this._lastRequest = undefined;
+  this._lastResponse = undefined;
   this._numberOfRequests = 0;
 };
 
@@ -29,6 +33,10 @@ RequestTracker.prototype.maxNumberOfRequestsReached = function () {
 
 RequestTracker.prototype.lastRequestEquals = function (request) {
   return this._lastRequest && this._lastRequest.equals(request);
+};
+
+RequestTracker.prototype.lastResponseEquals = function (response) {
+  return _.isEqual(this._lastResponse, response);
 };
 
 module.exports = RequestTracker;

--- a/src/windshaft/request.js
+++ b/src/windshaft/request.js
@@ -1,0 +1,18 @@
+/**
+ * Simple value object that holds everything need to instantiate a map using the Maps API
+ */
+var Request = function (payload, params, options) {
+  this.payload = payload;
+  this.params = params;
+  this.options = options;
+};
+
+Request.prototype.toHashCode = function () {
+  return JSON.stringify(this.payload) + JSON.stringify(this.params) + JSON.stringify(this.options);
+};
+
+Request.prototype.equals = function (request) {
+  return this.toHashCode() === request.toHashCode();
+};
+
+module.exports = Request;

--- a/test/spec/windshaft/map-base.spec.js
+++ b/test/spec/windshaft/map-base.spec.js
@@ -101,53 +101,85 @@ describe('windshaft/map-base', function () {
       this.dataviewsCollection.add(this.dataview);
     });
 
-    describe('request limit', function () {
-      beforeEach(function () {
-        this.options = { some: 'options' };
-      });
+    var MAX_NUMBER_OF_EQUAL_REQUESTS = 3;
 
-      it('should not make the same request more than 3 times nothing has changed', function () {
-        spyOn(this.client, 'instantiateMap');
-        for (var i = 0; i < 3; i++) {
-          this.windshaftMap.createInstance(this.options);
-
-          expect(this.client.instantiateMap).toHaveBeenCalled();
-          this.client.instantiateMap.calls.reset();
-        }
-
-        this.windshaftMap.createInstance(this.options);
-
-        expect(this.client.instantiateMap).not.toHaveBeenCalled();
-      });
-
-      describe('when max number of same request have been reached', function () {
+    _.each(['success', 'error'], function (result) {
+      describe('request limit (' + result + ')', function () {
         beforeEach(function () {
-          for (var i = 0; i < 3; i++) {
+          this.options = { some: 'options' };
+        });
+
+        it('should not make the same request more than 3 times if nothing has changed and response is the same', function () {
+          spyOn(this.client, 'instantiateMap').and.callFake(function (options) {
+            options[result]({ a: 'b' });
+          });
+
+          for (var i = 0; i < MAX_NUMBER_OF_EQUAL_REQUESTS; i++) {
             this.windshaftMap.createInstance(this.options);
+
+            expect(this.client.instantiateMap).toHaveBeenCalled();
+            this.client.instantiateMap.calls.reset();
           }
-          spyOn(this.client, 'instantiateMap');
+
+          this.windshaftMap.createInstance(this.options);
+
+          expect(this.client.instantiateMap).not.toHaveBeenCalled();
         });
 
-        it('should make a request if payload has changed', function () {
-          spyOn(this.windshaftMap, 'toJSON').and.returnValue({ something: 'different' });
+        it('should make the request if request was done 3 times and response was different the last time', function () {
+          var numberOfRequest = 0;
+          spyOn(this.client, 'instantiateMap').and.callFake(function (options) {
+            numberOfRequest += 1;
+            var response = { a: 'b' };
+            if (numberOfRequest === MAX_NUMBER_OF_EQUAL_REQUESTS) {
+              response = { a: 'something different' };
+            }
+            options[result](response);
+          });
+
+          for (var i = 0; i < MAX_NUMBER_OF_EQUAL_REQUESTS; i++) {
+            this.windshaftMap.createInstance(this.options);
+
+            expect(this.client.instantiateMap).toHaveBeenCalled();
+            this.client.instantiateMap.calls.reset();
+          }
 
           this.windshaftMap.createInstance(this.options);
 
           expect(this.client.instantiateMap).toHaveBeenCalled();
         });
 
-        it('should make a request if options are different', function () {
-          this.windshaftMap.createInstance({ different: 'options' });
+        describe('when max number of subsecuent identical requests (with identical responses) have been performed', function () {
+          beforeEach(function () {
+            for (var i = 0; i < 3; i++) {
+              this.windshaftMap.createInstance(this.options);
+            }
+            spyOn(this.client, 'instantiateMap').and.callFake(function (options) {
+              options[result]({ a: 'b' });
+            });
+          });
 
-          expect(this.client.instantiateMap).toHaveBeenCalled();
-        });
+          it('should make a request if payload has changed', function () {
+            spyOn(this.windshaftMap, 'toJSON').and.returnValue({ something: 'different' });
 
-        it('should make a request if filters have changed', function () {
-          this.filter.accept('something');
+            this.windshaftMap.createInstance(this.options);
 
-          this.windshaftMap.createInstance(this.options);
+            expect(this.client.instantiateMap).toHaveBeenCalled();
+          });
 
-          expect(this.client.instantiateMap).toHaveBeenCalled();
+          it('should make a request if options are different', function () {
+            this.windshaftMap.createInstance({ different: 'options' });
+
+            expect(this.client.instantiateMap).toHaveBeenCalled();
+          });
+
+          it('should make a request if filters have changed', function () {
+            this.filter.accept('something');
+
+            this.windshaftMap.createInstance(this.options);
+
+            expect(this.client.instantiateMap).toHaveBeenCalled();
+          });
         });
       });
     });

--- a/test/spec/windshaft/map-base.spec.js
+++ b/test/spec/windshaft/map-base.spec.js
@@ -110,6 +110,7 @@ describe('windshaft/map-base', function () {
         });
 
         it('should not make the same request more than 3 times if nothing has changed and response is the same', function () {
+          spyOn(log, 'error');
           spyOn(this.client, 'instantiateMap').and.callFake(function (options) {
             options[result]({ a: 'b' });
           });
@@ -124,6 +125,8 @@ describe('windshaft/map-base', function () {
           this.windshaftMap.createInstance(this.options);
 
           expect(this.client.instantiateMap).not.toHaveBeenCalled();
+
+          expect(log.error).toHaveBeenCalledWith('Maximum number of subsequent equal requests to the Maps API reached (3):', this.windshaftMap.toJSON(), { stat_tag: 'stat_tag' });
         });
 
         it('should make the request if request was done 3 times and response was different the last time', function () {


### PR DESCRIPTION
Fixes: https://github.com/CartoDB/cartodb.js/issues/1283.

@viddo I'd like to know your thoughts about this approach... CartoDB.js won't try to instantiate the exact same map more than three times with this change.

cc: @rochoa