### PR TITLE
Infowindow close button

### DIFF
--- a/examples/v4/leaflet-layergroup.html
+++ b/examples/v4/leaflet-layergroup.html
@@ -134,16 +134,17 @@
                         "template_name":"table/views/infowindow_light",
                         "template": " " +
                           '<div class="CDB-infowindow CDB-infowindow--custom js-infowindow" style="max-width: 200px;">' +
+                            '<div class="CDB-infowindow-close js-close"></div>' +
                             '<div class="CDB-infowindow-container">' +
-                              '<div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--dark" style="background: #98E0A8;">' +
+                              '<div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--dark">' +
                                 '<div class="CDB-infowindow-list">' +
                                   '<div class="CDB-infowindow-listItem">' +
                                     '<h4 class="CDB-infowindow-title">{{ name }}</h4>' +
                                   '</div>' +
                                 '</div>' +
                               '</div>' +
-                              '<div class="CDB-hook CDB-hook--green">' +
-                                '<div class="CDB-hook-inner" style="background: #98E0A8;">' +
+                              '<div class="CDB-hook CDB-hook--white">' +
+                                '<div class="CDB-hook-inner">' +
                                 '</div>' +
                               '</div>' +
                             '</div>' +

--- a/src/geo/ui/default-infowindow-template.tpl
+++ b/src/geo/ui/default-infowindow-template.tpl
@@ -1,4 +1,5 @@
 <div class="CDB-infowindow CDB-infowindow--light js-infowindow">
+  <div class="CDB-infowindow-close js-close"></div>
   <div class="CDB-infowindow-container">
     <% if (typeof loading !== 'undefined' && loading) { %>
       <div class="CDB-Loader js-loader is-visible"></div>

--- a/src/geo/ui/infowindow-model.js
+++ b/src/geo/ui/infowindow-model.js
@@ -22,7 +22,10 @@ var InfowindowModel = Backbone.Model.extend({
 
     // Set a default template
     if (!this._hasTemplate()) {
-      this.set('template', this.DEFAULT_TEMPLATE);
+      this.set({
+        template: this.DEFAULT_TEMPLATE,
+        template_type: 'underscore'
+      });
     }
   },
 

--- a/src/geo/ui/infowindow-view.js
+++ b/src/geo/ui/infowindow-view.js
@@ -29,9 +29,9 @@ var Infowindow = View.extend({
 
   events: {
     // Close bindings
-    'click .close': '_closeInfowindow',
-    'touchstart .close': '_closeInfowindow',
-    'MSPointerDown .close': '_closeInfowindow',
+    'click .js-close': '_closeInfowindow',
+    'touchstart .js-close': '_closeInfowindow',
+    'MSPointerDown .js-close': '_closeInfowindow',
     // Rest infowindow bindings
     'dragstart': '_checkOrigin',
     'mousedown': '_checkOrigin',

--- a/styleguide/infowindows.html
+++ b/styleguide/infowindows.html
@@ -25,13 +25,7 @@
           <h2>Infowindows light</h2>
           <div class="block clearfix u-tspace-xl">
             <div class="CDB-infowindow CDB-infowindow--light js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-inner">
                   <div class="CDB-infowindow-list ">
@@ -70,13 +64,7 @@
             <br>
             <br>
             <div class="CDB-infowindow CDB-infowindow--light js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-bg">
                   <div class="CDB-infowindow-inner">
@@ -102,13 +90,7 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--light js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-tabs">
                   <div class="CDB-infowindow-tabsItem">
@@ -161,13 +143,7 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--light js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-inner has-scroll">
                   <div class="CDB-infowindow-list">
@@ -216,13 +192,7 @@
           <h2>Infowindows dark</h2>
           <div class="block clearfix u-tspace-xl">
             <div class="CDB-infowindow CDB-infowindow--dark js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-inner">
                   <div class="CDB-infowindow-list ">
@@ -245,13 +215,7 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--dark js-infowindow" style="  max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+             <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-inner">
                   <div class="CDB-loading">
@@ -277,13 +241,7 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--dark js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-inner">
                   <div class="CDB-infowindow-list">
@@ -307,13 +265,7 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--dark js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-tabs">
                   <div class="CDB-infowindow-tabsItem">
@@ -366,13 +318,7 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--dark js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-inner has-scroll">
                   <div class="CDB-infowindow-list">
@@ -416,13 +362,7 @@
           <h2>Infowindows header dark</h2>
           <div class="block clearfix u-tspace-xl">
             <div class="CDB-infowindow CDB-infowindow--custom js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--dark" style="background: #98E0A8;">
                   <div class="CDB-infowindow-list">
@@ -444,13 +384,7 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--custom js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--dark" style="background: #98E0A8;">
                   <div class="CDB-infowindow-list">
@@ -474,13 +408,7 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--custom has-header js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--dark" style="background: #98E0A8;">
                   <div class="CDB-infowindow-list">
@@ -524,13 +452,7 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--custom has-header js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--dark" style="background: #98E0A8;">
                   <div class="CDB-infowindow-tabs">
@@ -587,13 +509,7 @@
           <h2>Infowindows header light</h2>
           <div class="block clearfix u-tspace-xl">
             <div class="CDB-infowindow CDB-infowindow--custom js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--light" style="background: #E68165;">
                   <div class="CDB-infowindow-list">
@@ -616,13 +532,7 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--custom js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--light" style="background: #E68165;">
                   <div class="CDB-infowindow-list">
@@ -646,13 +556,7 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--custom has-header js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--light" style="background: #E68165;">
                   <div class="CDB-infowindow-list">
@@ -695,13 +599,7 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--custom has-header js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--light" style="background: #E68165;">
                   <div class="CDB-infowindow-list">
@@ -743,13 +641,7 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--custom has-header js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--light" style="background: #E68165;">
                   <div class="CDB-infowindow-tabs">
@@ -815,13 +707,7 @@
 
 
             <div class="CDB-infowindow CDB-infowindow--light has-header-image js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover" style="height:116px;">
                   <div class="CDB-infowindow-mediaTitle">
@@ -840,13 +726,7 @@
             <br/>
             <br/>
             <div class="CDB-infowindow CDB-infowindow--light has-header-image js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover" style="height:133px;">
                   <div class="CDB-infowindow-mediaTitle">
@@ -867,13 +747,7 @@
             <br/>
 
             <div class="CDB-infowindow CDB-infowindow--light has-header-image js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover" style="height: 116px;">
                   <div class="CDB-infowindow-mediaTitle">
@@ -896,13 +770,7 @@
             <br/>
 
             <div class="CDB-infowindow CDB-infowindow--light js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover" style="height: 116px;">
                   <div class="CDB-infowindow-mediaTitle">
@@ -929,13 +797,7 @@
             <br/>
 
             <div class="CDB-infowindow CDB-infowindow--light has-header js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover">
                   <div class="CDB-infowindow-mediaTitle">
@@ -982,13 +844,7 @@
             <br/>
             <br/>
             <div class="CDB-infowindow CDB-infowindow--light is-loading has-header js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-inner">
                   <div class="CDB-Loader is-visible"></div>
@@ -1009,13 +865,7 @@
             <br/>
             <br/>
             <div class="CDB-infowindow CDB-infowindow--light has-header is-loading js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover">
                   <div class="CDB-Loader is-visible"></div>
@@ -1048,13 +898,8 @@
             <br/>
             <br/>
             <div class="CDB-infowindow CDB-infowindow--light has-header is-loading js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
+
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover">
                   <div class="CDB-infowindow-mediaTitle">
@@ -1092,13 +937,8 @@
             <br/>
             <br/>
             <div class="CDB-infowindow CDB-infowindow--light has-header has-header-image has-fields has-title is-fail js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
+
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia has-title js-cover">
                   <div class="CDB-infowindow-mediaTitle">
@@ -1135,13 +975,7 @@
             <br/>
             <br/>
             <div class="CDB-infowindow CDB-infowindow--light has-header is-fail js-infowindow" style="max-width: 200px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover">
                   <p class="CDB-infowindow-fail">Non-valid picture URL</p>
@@ -1170,13 +1004,7 @@
             <br/>
 
             <div class="CDB-infowindow CDB-infowindow--light has-header js-infowindow" style="max-width: 300px;">
-              <div class="CDB-infowindow-close js-close">
-                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
-                    </g>
-                </svg>
-              </div>
+              <div class="CDB-infowindow-close js-close"></div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-tabs">
                   <div class="CDB-infowindow-tabsItem">

--- a/styleguide/infowindows.html
+++ b/styleguide/infowindows.html
@@ -25,6 +25,13 @@
           <h2>Infowindows light</h2>
           <div class="block clearfix u-tspace-xl">
             <div class="CDB-infowindow CDB-infowindow--light js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-inner">
                   <div class="CDB-infowindow-list ">
@@ -63,6 +70,13 @@
             <br>
             <br>
             <div class="CDB-infowindow CDB-infowindow--light js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-bg">
                   <div class="CDB-infowindow-inner">
@@ -88,6 +102,13 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--light js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-tabs">
                   <div class="CDB-infowindow-tabsItem">
@@ -140,6 +161,13 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--light js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-inner has-scroll">
                   <div class="CDB-infowindow-list">
@@ -188,6 +216,13 @@
           <h2>Infowindows dark</h2>
           <div class="block clearfix u-tspace-xl">
             <div class="CDB-infowindow CDB-infowindow--dark js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-inner">
                   <div class="CDB-infowindow-list ">
@@ -209,7 +244,14 @@
             <br>
             <br>
 
-            <div class="CDB-infowindow CDB-infowindow--dark js-infowindow" style="max-width: 200px;">
+            <div class="CDB-infowindow CDB-infowindow--dark js-infowindow" style="  max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-inner">
                   <div class="CDB-loading">
@@ -235,6 +277,13 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--dark js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-inner">
                   <div class="CDB-infowindow-list">
@@ -258,6 +307,13 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--dark js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-tabs">
                   <div class="CDB-infowindow-tabsItem">
@@ -310,6 +366,13 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--dark js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-inner has-scroll">
                   <div class="CDB-infowindow-list">
@@ -353,6 +416,13 @@
           <h2>Infowindows header dark</h2>
           <div class="block clearfix u-tspace-xl">
             <div class="CDB-infowindow CDB-infowindow--custom js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--dark" style="background: #98E0A8;">
                   <div class="CDB-infowindow-list">
@@ -374,6 +444,13 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--custom js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--dark" style="background: #98E0A8;">
                   <div class="CDB-infowindow-list">
@@ -397,6 +474,13 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--custom has-header js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--dark" style="background: #98E0A8;">
                   <div class="CDB-infowindow-list">
@@ -440,6 +524,13 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--custom has-header js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--dark" style="background: #98E0A8;">
                   <div class="CDB-infowindow-tabs">
@@ -496,6 +587,13 @@
           <h2>Infowindows header light</h2>
           <div class="block clearfix u-tspace-xl">
             <div class="CDB-infowindow CDB-infowindow--custom js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--light" style="background: #E68165;">
                   <div class="CDB-infowindow-list">
@@ -518,6 +616,13 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--custom js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--light" style="background: #E68165;">
                   <div class="CDB-infowindow-list">
@@ -541,6 +646,13 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--custom has-header js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--light" style="background: #E68165;">
                   <div class="CDB-infowindow-list">
@@ -583,6 +695,13 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--custom has-header js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--light" style="background: #E68165;">
                   <div class="CDB-infowindow-list">
@@ -624,6 +743,13 @@
             <br>
 
             <div class="CDB-infowindow CDB-infowindow--custom has-header js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerBg CDB-infowindow-headerBg--light" style="background: #E68165;">
                   <div class="CDB-infowindow-tabs">
@@ -689,6 +815,13 @@
 
 
             <div class="CDB-infowindow CDB-infowindow--light has-header-image js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover" style="height:116px;">
                   <div class="CDB-infowindow-mediaTitle">
@@ -707,6 +840,13 @@
             <br/>
             <br/>
             <div class="CDB-infowindow CDB-infowindow--light has-header-image js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover" style="height:133px;">
                   <div class="CDB-infowindow-mediaTitle">
@@ -727,6 +867,13 @@
             <br/>
 
             <div class="CDB-infowindow CDB-infowindow--light has-header-image js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover" style="height: 116px;">
                   <div class="CDB-infowindow-mediaTitle">
@@ -749,6 +896,13 @@
             <br/>
 
             <div class="CDB-infowindow CDB-infowindow--light js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover" style="height: 116px;">
                   <div class="CDB-infowindow-mediaTitle">
@@ -775,6 +929,13 @@
             <br/>
 
             <div class="CDB-infowindow CDB-infowindow--light has-header js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover">
                   <div class="CDB-infowindow-mediaTitle">
@@ -821,6 +982,13 @@
             <br/>
             <br/>
             <div class="CDB-infowindow CDB-infowindow--light is-loading has-header js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-inner">
                   <div class="CDB-Loader is-visible"></div>
@@ -841,6 +1009,13 @@
             <br/>
             <br/>
             <div class="CDB-infowindow CDB-infowindow--light has-header is-loading js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover">
                   <div class="CDB-Loader is-visible"></div>
@@ -873,6 +1048,13 @@
             <br/>
             <br/>
             <div class="CDB-infowindow CDB-infowindow--light has-header is-loading js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover">
                   <div class="CDB-infowindow-mediaTitle">
@@ -910,6 +1092,13 @@
             <br/>
             <br/>
             <div class="CDB-infowindow CDB-infowindow--light has-header has-header-image has-fields has-title is-fail js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia has-title js-cover">
                   <div class="CDB-infowindow-mediaTitle">
@@ -946,6 +1135,13 @@
             <br/>
             <br/>
             <div class="CDB-infowindow CDB-infowindow--light has-header is-fail js-infowindow" style="max-width: 200px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-header CDB-infowindow-headerMedia js-cover">
                   <p class="CDB-infowindow-fail">Non-valid picture URL</p>
@@ -974,6 +1170,13 @@
             <br/>
 
             <div class="CDB-infowindow CDB-infowindow--light has-header js-infowindow" style="max-width: 300px;">
+              <div class="CDB-infowindow-close js-close">
+                <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1,0 L7,6 M7,0 L1,6" class="CDB-infowindow-closePath" ></path>
+                    </g>
+                </svg>
+              </div>
               <div class="CDB-infowindow-container">
                 <div class="CDB-infowindow-tabs">
                   <div class="CDB-infowindow-tabsItem">

--- a/test/spec/geo/ui/infowindow.spec.js
+++ b/test/spec/geo/ui/infowindow.spec.js
@@ -6,7 +6,7 @@ var InfowindowModel = require('../../../../src/geo/ui/infowindow-model');
 var Infowindow = require('../../../../src/geo/ui/infowindow-view');
 
 describe('geo/ui/infowindow-view', function() {
-  var model, view;
+  var model, view, mapView;
 
   beforeEach(function() {
     var container = $('<div>').css('height', '200px');
@@ -191,6 +191,27 @@ describe('geo/ui/infowindow-view', function() {
     var item2 = view.$el.find('.CDB-infowindow-listItem:nth-child(2)');
     expect(item2.find('.CDB-infowindow-title').text()).toEqual('true');
     expect(item2.find('.CDB-infowindow-subtitle').text()).toEqual('jamon2');
+  });
+
+  it('should close the infowindow when user clicks close button', function () {
+    model.set({
+      template: '<div><button class="js-close">X</button></div>'
+    });
+    view = new Infowindow({
+      model: model,
+      mapView: mapView
+    });
+
+    view.render();
+
+    // Infowindow is visible
+    model.set('visibility', true, { silent: true });
+    expect(model.get('visibility')).toBe(true);
+
+    view.$('.js-close').click();
+
+    // Infowindow has been closed
+    expect(model.get('visibility')).toBe(false);
   });
 
   describe("custom template", function() {

--- a/themes/scss/infowindow/cartodb-infowindow-default.scss
+++ b/themes/scss/infowindow/cartodb-infowindow-default.scss
@@ -12,6 +12,7 @@
   transform: translateY(-24px) translateX(4px); /* remove when fix the position */
   font-family: 'Open Sans';
   cursor: default;
+  -webkit-font-smoothing: antialiased;
 }
 .CDB-infowindow-container {
   border-radius: 4px;
@@ -37,15 +38,16 @@
   margin: -20px -24px 18px;
 }
 .CDB-infowindow-subtitle {
-  font-size: 9px;
+  font-size: 10px;
   font-weight: $sFontWeight-lighter;
   line-height: $sLineHeight-small;
   text-transform: uppercase;
+  margin-bottom: 2px;
 }
 .CDB-infowindow-title {
-  font-size: $sFontSize-small;
-  font-weight: $sFontWeight-lighter;
-  line-height: $sLineHeight-small;
+  font-size: $sFontSize-medium;
+  font-weight: $sFontWeight-semibold;
+  line-height: $sLineHeight-medium;
 }
 .CDB-infowindow-link {
   display: inline-block;
@@ -69,8 +71,7 @@
 }
 
 .CDB-infowindow-listItem {
-  margin-top: 8px;
-  word-break: break-all;
+  margin-top: 12px;
 }
 .CDB-infowindow-listItem:first-child {
   margin-top: 0;
@@ -179,9 +180,14 @@
   display: none;
   width: 100%;
   transition: opacity 150ms ease-in-out;
-  border-radius: 4px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
   opacity: 1;
 }
+.has-header .CDB-infowindow-media-item {
+  border-radius: 0;
+}
+
 .CDB-hook {
   position: absolute;
   bottom: 1px;
@@ -273,6 +279,7 @@
   width: auto;
   padding: 21px 24px 0;
   font-size: 10px;
+  font-weight: 600;
   line-height: 14px;
   overflow: hidden;
 }
@@ -377,4 +384,34 @@ img[data-clipPath]{
 }
 .CDB-infowindow-mask image {
   visibility: visible;
+}
+
+.CDB-infowindow-close {
+  position: absolute;
+  top: -12px;
+  right: -12px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #FFF;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.24);
+  z-index: 2;
+  cursor: pointer;
+  display: -webkit-box;      /* OLD - iOS 6-, Safari 3.1-6 */
+  display: -moz-box;         /* OLD - Firefox 19- (buggy but mostly works) */
+  display: -ms-flexbox;      /* TWEENER - IE 10 */
+  display: -webkit-flex;     /* NEW - Chrome */
+  display: flex;
+  -webkit-align-items: center;
+  -moz-align-items: center;
+  -ms-align-items: center;
+  align-items: center;
+  -webkit-justify-content: center;
+  -moz-justify-content: center;
+  -ms-justify-content: center;
+  justify-content: center;
+}
+
+.CDB-infowindow-closePath {
+  stroke: #3AA9E3;
 }

--- a/themes/scss/infowindow/cartodb-infowindow-default.scss
+++ b/themes/scss/infowindow/cartodb-infowindow-default.scss
@@ -397,21 +397,6 @@ img[data-clipPath]{
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.24);
   z-index: 2;
   cursor: pointer;
-  display: -webkit-box;      /* OLD - iOS 6-, Safari 3.1-6 */
-  display: -moz-box;         /* OLD - Firefox 19- (buggy but mostly works) */
-  display: -ms-flexbox;      /* TWEENER - IE 10 */
-  display: -webkit-flex;     /* NEW - Chrome */
-  display: flex;
-  -webkit-align-items: center;
-  -moz-align-items: center;
-  -ms-align-items: center;
-  align-items: center;
-  -webkit-justify-content: center;
-  -moz-justify-content: center;
-  -ms-justify-content: center;
-  justify-content: center;
+  background: #fff url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iOHB4IiBoZWlnaHQ9IjZweCIgdmlld0JveD0iMCAwIDggNiIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4gICAgICAgIDx0aXRsZT5TdHJva2UgMzwvdGl0bGU+ICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPiAgICA8ZGVmcz48L2RlZnM+ICAgIDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+ICAgICAgICA8cGF0aCBkPSJNMSwwIEw3LDYgTTcsMCBMMSw2IiBpZD0iU3Ryb2tlLTMiIHN0cm9rZT0iIzNBQTlFMyI+PC9wYXRoPiAgICA8L2c+PC9zdmc+) no-repeat center center;
 }
 
-.CDB-infowindow-closePath {
-  stroke: #3AA9E3;
-}

--- a/themes/scss/infowindow/themes/dark.scss
+++ b/themes/scss/infowindow/themes/dark.scss
@@ -3,14 +3,14 @@
 
 $sBg-dark: #2E3C43;
 
-.CDB-infowindow--dark {
+.CDB-infowindow.CDB-infowindow--dark {
   background: $sBg-dark;
   color: #FFF;
   .CDB-infowindow-title {
     color: #FFF;
   }
   .CDB-infowindow-subtitle {
-    color: rgba(255, 255, 255, 0.32);
+    color: rgba(255, 255, 255, 0.64);
   }
   .CDB-hook-inner {
     background: $sBg-dark;


### PR DESCRIPTION
Fixes: https://github.com/CartoDB/cartodb.js/issues/1301.

New markup needs to include the .js-close element.

```
<div class="CDB-infowindow CDB-infowindow--light js-infowindow" style="max-width: 200px;">
  <div class="CDB-infowindow-close js-close"></div>
  ...
</div>
```