### PR TITLE
cdb.createVis returns a vis model that triggers load event when vizjson has been loaded

### DIFF
--- a/src/api/create-vis.js
+++ b/src/api/create-vis.js
@@ -13,9 +13,12 @@ var DEFAULT_OPTIONS = {
   show_empty_infowindow_fields: false
 };
 
-var createVis = function (el, vizjson, options, callback) {
+var createVis = function (el, vizjson, options) {
+  if (typeof el === 'string') {
+    el = document.getElementById(el);
+  }
   if (!el) {
-    throw new TypeError('a DOM element must be provided');
+    throw new TypeError('a valid DOM element or selector must be provided');
   }
   if (!vizjson) {
     throw new TypeError('a vizjson URL or object must be provided');
@@ -24,48 +27,40 @@ var createVis = function (el, vizjson, options, callback) {
   var args = arguments;
   var fn = args[args.length - 1];
 
-  if (_.isFunction(fn)) {
-    callback = fn;
-  }
-  if (typeof el === 'string') {
-    el = document.getElementById(el);
-  }
 
   options = _.defaults(options || {}, DEFAULT_OPTIONS);
 
-  var visModel = new VisModel();
+  var visModel = new VisModel({
+    apiKey: options.apiKey
+  });
 
   var visView = new VisView({
     el: el,
     model: visModel
   });
 
-  if (callback) {
-    visView.done(callback);
-  }
-
   if (typeof vizjson === 'string') {
     var url = vizjson;
     Loader.get(url, function (vizjson) {
       if (vizjson) {
-        loadVizJSON(visView, vizjson, options);
+        loadVizJSON(visModel, vizjson, options);
       } else {
         throw new Error('error fetching viz.json file');
       }
     });
   } else {
-    loadVizJSON(visView, vizjson, options);
+    loadVizJSON(visModel, vizjson, options);
   }
 
-  return visView;
+  return visModel;
 };
 
-var loadVizJSON = function (vis, vizjsonData, options) {
+var loadVizJSON = function (visModel, vizjsonData, options) {
   var vizjson = new VizJSON(vizjsonData);
   applyOptionsToVizJSON(vizjson, options);
-  vis.load(vizjson, options);
+  visModel.load(vizjson, options);
   if (!options.skipMapInstantiation) {
-    vis.instantiateMap();
+    visModel.instantiateMap();
   }
 };
 

--- a/src/api/create-vis.js
+++ b/src/api/create-vis.js
@@ -26,8 +26,15 @@ var createVis = function (el, vizjson, options) {
 
   options = _.defaults(options || {}, DEFAULT_OPTIONS);
 
+  var isProtocolHTTPs = window && window.location.protocol && window.location.protocol === 'https:';
+
   var visModel = new VisModel({
-    apiKey: options.apiKey
+    title: options.title || vizjson.title,
+    description: options.description || vizjson.description,
+    apiKey: options.apiKey,
+    showLegends: options.legends === true || vizjson.legends === true,
+    showEmptyInfowindowFields: options.show_empty_infowindow_fields === true,
+    https: isProtocolHTTPs || options.https === true || vizjson.https === true
   });
 
   new VisView({ // eslint-disable-line
@@ -54,7 +61,7 @@ var createVis = function (el, vizjson, options) {
 var loadVizJSON = function (visModel, vizjsonData, options) {
   var vizjson = new VizJSON(vizjsonData);
   applyOptionsToVizJSON(vizjson, options);
-  visModel.load(vizjson, options);
+  visModel.load(vizjson);
   if (!options.skipMapInstantiation) {
     visModel.instantiateMap();
   }

--- a/src/api/create-vis.js
+++ b/src/api/create-vis.js
@@ -24,17 +24,13 @@ var createVis = function (el, vizjson, options) {
     throw new TypeError('a vizjson URL or object must be provided');
   }
 
-  var args = arguments;
-  var fn = args[args.length - 1];
-
-
   options = _.defaults(options || {}, DEFAULT_OPTIONS);
 
   var visModel = new VisModel({
     apiKey: options.apiKey
   });
 
-  var visView = new VisView({
+  new VisView({ // eslint-disable-line
     el: el,
     model: visModel
   });

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -152,9 +152,9 @@ var Map = Model.extend({
     }
   },
 
-  instantiateMap: function () {
+  instantiateMap: function (options) {
     this._initBinds();
-    this.reload();
+    this.reload(_.pick(options, ['success', 'error']));
   },
 
   _onLayersResetted: function () {

--- a/src/vis/infowindow-manager.js
+++ b/src/vis/infowindow-manager.js
@@ -18,6 +18,7 @@ InfowindowManager.prototype.manage = function (mapView, map) {
   this._map.layers.bind('reset', function (layers) {
     layers.each(this._addInfowindowForLayer, this);
   }, this);
+  this._map.layers.each(this._addInfowindowForLayer, this);
   this._map.layers.bind('add', this._addInfowindowForLayer, this);
 };
 

--- a/src/vis/tooltip-manager.js
+++ b/src/vis/tooltip-manager.js
@@ -16,6 +16,7 @@ TooltipManager.prototype.manage = function (mapView, map) {
   this._map.layers.bind('reset', function (layers) {
     layers.each(this._addTooltipForLayer, this);
   }, this);
+  this._map.layers.each(this._addTooltipForLayer, this);
   this._map.layers.bind('add', this._addTooltipForLayer, this);
 };
 

--- a/src/vis/vis-view.js
+++ b/src/vis/vis-view.js
@@ -31,7 +31,7 @@ var Vis = View.extend({
       }
     }, this);
 
-    this.model.on('load', this.render, this);
+    this.model.once('load', this.render, this);
     this.model.on('invalidateSize', this._invalidateSize, this);
     this.overlays = [];
 

--- a/src/vis/vis-view.js
+++ b/src/vis/vis-view.js
@@ -159,7 +159,7 @@ var Vis = View.extend({
   },
 
   _addOverlays: function (options) {
-    overlays = this.model.overlaysCollection.toJSON();
+    var overlays = this.model.overlaysCollection.toJSON();
     // Sort the overlays by its internal order
     overlays = _.sortBy(overlays, function (overlay) {
       return overlay.order === null ? Number.MAX_VALUE : overlay.order;

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -275,8 +275,7 @@ var VisModel = Backbone.Model.extend({
     });
 
     return layerModels;
-   }
-
+  }
 });
 
 module.exports = VisModel;

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -153,7 +153,7 @@ var VisModel = Backbone.Model.extend({
     this._windshaftMap.bind('instanceCreated', this._onMapInstanceCreated, this);
 
     // Lastly: reset the layer models on the map
-    var layerModels = this._newLayerModels(vizjson, this.map, { https: this.get('https') });
+    var layerModels = this._newLayerModels(vizjson, this.map);
     this.map.layers.reset(layerModels);
 
     // "Load" existing analyses from the viz.json. This will generate
@@ -248,10 +248,10 @@ var VisModel = Backbone.Model.extend({
     this.map.reCenter();
   },
 
-  _newLayerModels: function (vizjson, map, options) {
+  _newLayerModels: function (vizjson, map) {
     var layerModels = [];
     var layersOptions = {
-      https: options.https,
+      https: this.get('https'),
       map: map
     };
     _.each(vizjson.layers, function (layerData) {

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -17,7 +17,10 @@ var Layers = require('./vis/layers');
 
 var VisModel = Backbone.Model.extend({
   defaults: {
-    loading: false
+    loading: false,
+    https: false,
+    showLegends: false,
+    showEmptyInfowindowFields: false
   },
 
   initialize: function () {
@@ -55,9 +58,7 @@ var VisModel = Backbone.Model.extend({
     return this.map.layers.at(index);
   },
 
-  load: function (vizjson, options) {
-    options = options || {};
-
+  load: function (vizjson) {
     // Create the WindhaftClient
     var endpoint;
     var WindshaftMapClass;
@@ -116,7 +117,6 @@ var VisModel = Backbone.Model.extend({
       description: vizjson.description,
       maxZoom: vizjson.maxZoom,
       minZoom: vizjson.minZoom,
-      legends: vizjson.legends,
       bounds: vizjson.bounds,
       center: vizjson.center,
       zoom: vizjson.zoom,
@@ -153,11 +153,7 @@ var VisModel = Backbone.Model.extend({
     this._windshaftMap.bind('instanceCreated', this._onMapInstanceCreated, this);
 
     // Lastly: reset the layer models on the map
-    var isProtocolHTTPs = window && window.location.protocol && window.location.protocol === 'https:';
-    var useHTTPs = isProtocolHTTPs ||
-      vizjson.https === true ||
-      options.https === true;
-    var layerModels = this._newLayerModels(vizjson, this.map, { https: useHTTPs });
+    var layerModels = this._newLayerModels(vizjson, this.map, { https: this.get('https') });
     this.map.layers.reset(layerModels);
 
     // "Load" existing analyses from the viz.json. This will generate

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -1,4 +1,19 @@
+var _ = require('underscore');
 var Backbone = require('backbone');
+var util = require('cdb.core.util');
+var Map = require('../geo/map');
+var DataviewsFactory = require('../dataviews/dataviews-factory');
+var WindshaftConfig = require('../windshaft/config');
+var WindshaftClient = require('../windshaft/client');
+var WindshaftNamedMap = require('../windshaft/named-map');
+var WindshaftAnonymousMap = require('../windshaft/anonymous-map');
+var AnalysisFactory = require('../analysis/analysis-factory');
+var CartoDBLayerGroupNamedMap = require('../geo/cartodb-layer-group-named-map');
+var CartoDBLayerGroupAnonymousMap = require('../geo/cartodb-layer-group-anonymous-map');
+var ModelUpdater = require('./model-updater');
+var LayersCollection = require('../geo/map/layers');
+var AnalysisPoller = require('../analysis/analysis-poller');
+var Layers = require('./vis/layers');
 
 var VisModel = Backbone.Model.extend({
   defaults: {
@@ -7,6 +22,190 @@ var VisModel = Backbone.Model.extend({
 
   initialize: function () {
     this._loadingObjects = [];
+    this._analysisPoller = new AnalysisPoller();
+    this._layersCollection = new LayersCollection();
+    this._analysisCollection = new Backbone.Collection();
+    this._dataviewsCollection = new Backbone.Collection();
+
+    this.overlaysCollection = new Backbone.Collection();
+  },
+
+  done: function (callback) {
+    this.on('done', callback);
+    return this;
+  },
+
+  error: function (callback) {
+    this.on('error', callback);
+    return this;
+  },
+
+  /**
+   * @return Array of {LayerModel}
+   */
+  getLayers: function () {
+    return _.clone(this.map.layers.models);
+  },
+
+  /**
+   * @param {Integer} index Layer index (including base layer if present)
+   * @return {LayerModel}
+   */
+  getLayer: function (index) {
+    return this.map.layers.at(index);
+  },
+
+  load: function (vizjson, options) {
+    options = options || {};
+
+    // Create the WindhaftClient
+    var endpoint;
+    var WindshaftMapClass;
+    var CartoDBLayerGroupClass;
+
+    var datasource = vizjson.datasource;
+    var isNamedMap = !!datasource.template_name;
+
+    if (isNamedMap) {
+      endpoint = [ WindshaftConfig.MAPS_API_BASE_URL, 'named', datasource.template_name ].join('/');
+      CartoDBLayerGroupClass = CartoDBLayerGroupNamedMap;
+      WindshaftMapClass = WindshaftNamedMap;
+    } else {
+      endpoint = WindshaftConfig.MAPS_API_BASE_URL;
+      CartoDBLayerGroupClass = CartoDBLayerGroupAnonymousMap;
+      WindshaftMapClass = WindshaftAnonymousMap;
+    }
+
+    this.layerGroupModel = new CartoDBLayerGroupClass({
+      apiKey: this.get('apiKey')
+    }, {
+      layersCollection: this._layersCollection
+    });
+
+    var windshaftClient = new WindshaftClient({
+      endpoint: endpoint,
+      urlTemplate: datasource.maps_api_template,
+      userName: datasource.user_name,
+      forceCors: datasource.force_cors || true
+    });
+
+    var modelUpdater = new ModelUpdater({
+      layerGroupModel: this.layerGroupModel,
+      dataviewsCollection: this._dataviewsCollection,
+      layersCollection: this._layersCollection,
+      analysisCollection: this._analysisCollection
+    });
+
+    // Create the WindshaftMap
+    this._windshaftMap = new WindshaftMapClass({
+      apiKey: this.get('apiKey'),
+      statTag: datasource.stat_tag
+    }, {
+      client: windshaftClient,
+      modelUpdater: modelUpdater,
+      dataviewsCollection: this._dataviewsCollection,
+      layersCollection: this._layersCollection,
+      analysisCollection: this._analysisCollection
+    });
+
+    // Create the Map
+    var allowDragging = util.isMobileDevice() || vizjson.hasZoomOverlay() || vizjson.scrollwheel;
+
+    var mapConfig = {
+      title: vizjson.title,
+      description: vizjson.description,
+      maxZoom: vizjson.maxZoom,
+      minZoom: vizjson.minZoom,
+      legends: vizjson.legends,
+      bounds: vizjson.bounds,
+      center: vizjson.center,
+      zoom: vizjson.zoom,
+      scrollwheel: !!this.scrollwheel,
+      drag: allowDragging,
+      provider: vizjson.map_provider,
+      vector: vizjson.vector
+    };
+
+    this.map = new Map(mapConfig, {
+      layersCollection: this._layersCollection,
+      windshaftMap: this._windshaftMap,
+      dataviewsCollection: this._dataviewsCollection
+    });
+
+    // Reset the collection of overlays
+    this.overlaysCollection.reset(vizjson.overlays);
+
+    // Create the public Dataview Factory
+    this.dataviews = new DataviewsFactory({
+      apiKey: this.get('apiKey')
+    }, {
+      dataviewsCollection: this._dataviewsCollection,
+      map: this.map
+    });
+
+    // Create the public Analysis Factory
+    this.analysis = new AnalysisFactory({
+      apiKey: this.get('apiKey'),
+      analysisCollection: this._analysisCollection,
+      map: this.map
+    });
+
+    this._windshaftMap.bind('instanceCreated', this._onMapInstanceCreated, this);
+
+    // Lastly: reset the layer models on the map
+    var isProtocolHTTPs = window && window.location.protocol && window.location.protocol === 'https:';
+    var useHTTPs = isProtocolHTTPs ||
+      vizjson.https === true ||
+      options.https === true;
+    var layerModels = this._newLayerModels(vizjson, this.map, { https: useHTTPs });
+    this.map.layers.reset(layerModels);
+
+    // "Load" existing analyses from the viz.json. This will generate
+    // the analyses graphs and index analysis nodes in the
+    // collection of analysis
+    if (vizjson.analyses) {
+      _.each(vizjson.analyses, function (analysis) {
+        this.analysis.analyse(analysis);
+      }, this);
+    }
+    // Global variable for easier console debugging / testing
+    window.vis = this;
+
+    _.defer(function () {
+      this.trigger('load', this);
+    }.bind(this));
+  },
+
+  _onMapInstanceCreated: function () {
+    this._analysisPoller.reset();
+    this._analysisCollection.each(function (analysisModel) {
+      analysisModel.unbind('change:status', this._onAnalysisStatusChanged, this);
+      if (analysisModel.url() && !analysisModel.isDone()) {
+        this._analysisPoller.poll(analysisModel);
+        this.trackLoadingObject(analysisModel);
+        analysisModel.bind('change:status', this._onAnalysisStatusChanged, this);
+      }
+    }, this);
+  },
+
+  _onAnalysisStatusChanged: function (analysisModel) {
+    if (analysisModel.isDone()) {
+      this.untrackLoadingObject(analysisModel);
+      if (this._isAnalysisSourceOfLayerOrDataview(analysisModel)) {
+        this.map.reload();
+      }
+    }
+  },
+
+  _isAnalysisSourceOfLayerOrDataview: function (analysisModel) {
+    var isAnalysisLinkedToLayer = this._layersCollection.any(function (layerModel) {
+      return layerModel.get('source') === analysisModel.get('id');
+    });
+    var isAnalysisLinkedToDataview = this._dataviewsCollection.any(function (dataviewModel) {
+      var sourceId = dataviewModel.getSourceId();
+      return analysisModel.get('id') === sourceId;
+    });
+    return isAnalysisLinkedToLayer || isAnalysisLinkedToDataview;
   },
 
   trackLoadingObject: function (object) {
@@ -24,7 +223,60 @@ var VisModel = Backbone.Model.extend({
         this.set('loading', false);
       }
     }
-  }
+  },
+
+  /**
+   * Force a map instantiation.
+   * Only expected to be called if {skipMapInstantiation} flag is set to true when vis is created.
+   */
+  instantiateMap: function (options) {
+    options = options || {};
+    var self = this;
+
+    // TODO: invalidateSize
+    this._dataviewsCollection.on('add reset remove', _.debounce(this.invalidateSize, 10), this);
+    this.map.instantiateMap(_.pick(options, ['success', 'error']));
+
+    // Trigger 'done' event
+    _.defer(function () {
+      self.trigger('done', self, self.map.layers);
+    });
+  },
+
+  invalidateSize: function () {
+    this.trigger('invalidateSize');
+  },
+
+  centerMapToOrigin: function () {
+    this.invalidateSize();
+    this.map.reCenter();
+  },
+
+  _newLayerModels: function (vizjson, map, options) {
+    var layerModels = [];
+    var layersOptions = {
+      https: options.https,
+      map: map
+    };
+    _.each(vizjson.layers, function (layerData) {
+      if (layerData.type === 'layergroup' || layerData.type === 'namedmap') {
+        var layersData;
+        if (layerData.type === 'layergroup') {
+          layersData = layerData.options.layer_definition.layers;
+        } else {
+          layersData = layerData.options.named_map.layers;
+        }
+        _.each(layersData, function (layerData) {
+          layerModels.push(Layers.create('CartoDB', layerData, layersOptions));
+        });
+      } else {
+        layerModels.push(Layers.create(layerData.type, layerData, layersOptions));
+      }
+    });
+
+    return layerModels;
+   }
+
 });
 
 module.exports = VisModel;

--- a/test/spec/geo/geocoder/nokia-geocoder.spec.js
+++ b/test/spec/geo/geocoder/nokia-geocoder.spec.js
@@ -36,7 +36,7 @@ describe('geo/geocoder/nokia-geocoder', function() {
 
   it("we shouldn't get a direction that doesn't exist", function(done) {
     var data;
-    NOKIA.geocode('ASDF1234567890', function(d) {
+    NOKIA.geocode('68461092610314965639', function(d) {
       data = d;
       expect(data.length).toEqual(0);
       done();

--- a/test/spec/geo/gmaps/gmaps-map-view.spec.js
+++ b/test/spec/geo/gmaps/gmaps-map-view.spec.js
@@ -11,7 +11,10 @@ var GMapsLayerViewFactory = require('../../../../src/geo/gmaps/gmaps-layer-view-
 var GMapsTiledLayerView = require('../../../../src/geo/gmaps/gmaps-tiled-layer-view');
 var GMapsPlainLayerView = require('../../../../src/geo/gmaps/gmaps-plain-layer-view');
 
-describe('geo/gmaps/gmaps-map-view', function () {
+// Skipping this tests that are failing in CI, due to:
+// -> TypeError: 'undefined' is not an object (evaluating 'a.addEventListener') in
+//    http://maps.googleapis.com/maps/api/js?sensor=false&v=3.12 (line 88)
+xdescribe('geo/gmaps/gmaps-map-view', function () {
   var mapView;
   var map;
   var spy;

--- a/test/spec/geo/gmaps/gmaps-map-view.spec.js
+++ b/test/spec/geo/gmaps/gmaps-map-view.spec.js
@@ -11,10 +11,7 @@ var GMapsLayerViewFactory = require('../../../../src/geo/gmaps/gmaps-layer-view-
 var GMapsTiledLayerView = require('../../../../src/geo/gmaps/gmaps-tiled-layer-view');
 var GMapsPlainLayerView = require('../../../../src/geo/gmaps/gmaps-plain-layer-view');
 
-// Skipping this tests that are failing in CI, due to:
-// -> TypeError: 'undefined' is not an object (evaluating 'a.addEventListener') in
-//    http://maps.googleapis.com/maps/api/js?sensor=false&v=3.12 (line 88)
-xdescribe('geo/gmaps/gmaps-map-view', function () {
+describe('geo/gmaps/gmaps-map-view', function () {
   var mapView;
   var map;
   var spy;

--- a/test/spec/vis/infowindow-manager-spec.js
+++ b/test/spec/vis/infowindow-manager-spec.js
@@ -30,7 +30,28 @@ describe('src/vis/infowindow-manager.js', function () {
     };
   });
 
-  it('should add a new infowindow view to the map view when new layers are reseted', function () {
+  it('should add a new infowindow view to the map view when new layers were previously reset', function () {
+    spyOn(this.mapView, 'addInfowindow');
+
+    var layer = new CartoDBLayer({
+      infowindow: {
+        fields: [{
+          'name': 'name',
+          'title': true,
+          'position': 1
+        }]
+      }
+    });
+
+    this.map.layers.reset([ layer ]);
+
+    var infowindowManager = new InfowindowManager(this.vis);
+    infowindowManager.manage(this.mapView, this.map);
+
+    expect(this.mapView.addInfowindow).toHaveBeenCalled();
+  });
+
+  it('should add a new infowindow view to the map view when new layers are reset', function () {
     spyOn(this.mapView, 'addInfowindow');
 
     var layer = new CartoDBLayer({

--- a/test/spec/vis/tooltip-manager-spec.js
+++ b/test/spec/vis/tooltip-manager-spec.js
@@ -30,7 +30,28 @@ describe('src/vis/tooltip-manager.js', function () {
     };
   });
 
-  it('should add a new tooltip view to the map view when new layers are reseted', function () {
+  it('should add a new tooltip view to the map view when layers were previously reset', function () {
+    spyOn(this.mapView, 'addOverlay');
+
+    var layer = new CartoDBLayer({
+      tooltip: {
+        fields: [{
+          'name': 'name',
+          'title': true,
+          'position': 1
+        }]
+      }
+    });
+
+    this.map.layers.reset([ layer ]);
+
+    var tooltipManager = new TooltipManager(this.vis);
+    tooltipManager.manage(this.mapView, this.map);
+
+    expect(this.mapView.addOverlay).toHaveBeenCalled();
+  });
+
+  it('should add a new tooltip view to the map view when new layers are reset', function () {
     spyOn(this.mapView, 'addOverlay');
 
     var layer = new CartoDBLayer({

--- a/test/spec/vis/vis-view.spec.js
+++ b/test/spec/vis/vis-view.spec.js
@@ -2,7 +2,6 @@ var $ = require('jquery');
 var _ = require('underscore');
 var Backbone = require('backbone');
 var View = require('../../../src/core/view');
-
 // required due to implicit dependency in vis --> map-view
 var cdb = require('cdb');
 _.extend(cdb.geo, require('../../../src/geo/leaflet'));
@@ -10,6 +9,7 @@ _.extend(cdb.geo, require('../../../src/geo/gmaps'));
 
 var Overlay = require('../../../src/vis/vis/overlay');
 var VisView = require('../../../src/vis/vis-view');
+var VisModel = require('../../../src/vis/vis');
 var VizJSON = require('../../../src/api/vizjson');
 
 require('../../../src/vis/overlays'); // Overlay.register calls
@@ -41,283 +41,112 @@ describe('vis/vis-view', function () {
       }
     };
 
-    this.vis = new Backbone.Model();
-    this.vis.trackLoadingObject = jasmine.createSpy();
-    this.vis.untrackLoadingObject = jasmine.createSpy();
-    this.vis.clearLoadingObjects = jasmine.createSpy();
+    this.visModel = new VisModel();
 
     this.createNewVis = function (attrs) {
       attrs.widgets = new Backbone.Collection();
-      attrs.model = this.vis;
+      attrs.model = this.visModel;
       this.visView = new VisView(attrs);
       return this.visView;
     };
     this.createNewVis({
       el: this.container
     });
-    this.visView.load(new VizJSON(this.mapConfig));
+    this.visModel.load(new VizJSON(this.mapConfig));
+    this.visView.render();
   });
 
   afterEach(function () {
     jasmine.clock().uninstall();
   });
 
-  describe('public API', function () {
-    describe('dataviews factory', function () {
-      it('should be defined', function () {
-        expect(this.visView.dataviews).toBeDefined();
-      });
+  it('should create a leaflet map when provider is leaflet', function () {
+    this.visModel.map.set('provider', 'leaflet');
 
-      it('should have an api_key when using an api_key option', function () {
-        this.visView.load(new VizJSON(this.mapConfig), {
-          apiKey: 'API_KEY'
-        });
+    this.visView.render();
 
-        expect(this.visView.dataviews.get('apiKey')).toEqual('API_KEY');
-      });
-    });
-
-    describe('analyses factory', function () {
-      it('should be defined', function () {
-        expect(this.visView.analysis).toBeDefined();
-      });
-    });
+    expect(this.visView.mapView._leafletMap).not.toEqual(undefined);
   });
 
-  it('should insert default max and minZoom values when not provided', function () {
-    expect(this.visView.mapView._leafletMap.options.maxZoom).toEqual(20);
-    expect(this.visView.mapView._leafletMap.options.minZoom).toEqual(0);
-  });
+  it('should create a google maps map when provider is googlemaps', function () {
+    this.visModel.map.set('provider', 'googlemaps');
 
-  it('should insert user max and minZoom values when provided', function () {
-    this.container = $('<div>').css('height', '200px');
-    this.mapConfig.maxZoom = 10;
-    this.mapConfig.minZoom = 5;
-    this.visView.load(new VizJSON(this.mapConfig));
+    this.visView.render();
 
-    expect(this.visView.mapView._leafletMap.options.maxZoom).toEqual(10);
-    expect(this.visView.mapView._leafletMap.options.minZoom).toEqual(5);
-  });
-
-  it('should create a google maps map when provider is google maps', function () {
-    this.container = $('<div>').css('height', '200px');
-    this.mapConfig.map_provider = 'googlemaps';
-    this.visView.load(new VizJSON(this.mapConfig));
     expect(this.visView.mapView._gmapsMap).not.toEqual(undefined);
   });
 
-  it('should not invalidate map if map height is 0', function (done) {
-    jasmine.clock().install();
-    var container = $('<div>').css('height', '0');
-    var vis = this.createNewVis({el: container});
-    this.mapConfig.map_provider = 'googlemaps';
-
-    vis.load(new VizJSON(this.mapConfig));
-
-    setTimeout(function () {
-      spyOn(vis.mapView, 'invalidateSize');
-      expect(vis.mapView.invalidateSize).not.toHaveBeenCalled();
-      done();
-    }, 4000);
-    jasmine.clock().tick(4000);
-  });
-
   it('should bind resize changes when map height is 0', function () {
+    jasmine.clock().install();
+    spyOn(this.visModel, 'centerMapToOrigin');
+
     var container = $('<div>').css('height', '0');
-    var vis = this.createNewVis({el: container});
-    this.mapConfig.map_provider = 'googlemaps';
-    vis.load(new VizJSON(this.mapConfig));
-    spyOn(vis, '_onResize');
+    var vis = this.createNewVis({ el: container });
+    spyOn(vis, '_onResize').and.callThrough();
+
+    this.visModel.load(new VizJSON(this.mapConfig));
+
+    // Wait until view has been rendered after load
+    jasmine.clock().tick(10);
 
     $(window).trigger('resize');
 
     expect(vis._onResize).toHaveBeenCalled();
+    vis._onResize.calls.reset();
+
+    jasmine.clock().tick(160);
+
+    expect(this.visModel.centerMapToOrigin).toHaveBeenCalled();
+
+    $(window).trigger('resize');
+    expect(vis._onResize).not.toHaveBeenCalled();
   });
 
-  it("shouldn't bind resize changes when map height is greater than 0", function () {
+  it('should NOT bind resize changes when map height is greater than 0', function () {
+    jasmine.clock().install();
+    spyOn(this.visModel, 'centerMapToOrigin');
+
     var container = $('<div>').css('height', '200px');
     var vis = this.createNewVis({el: container});
-    this.mapConfig.map_provider = 'googlemaps';
-    vis.load(new VizJSON(this.mapConfig));
-    spyOn(vis, '_onResize');
+    spyOn(vis, '_onResize').and.callThrough();
+
+    this.visModel.load(new VizJSON(this.mapConfig));
+
+    // Wait until view has been rendered after load
+    jasmine.clock().tick(10);
 
     $(window).trigger('resize');
 
     expect(vis._onResize).not.toHaveBeenCalled();
-    expect(vis.center).not.toBeDefined();
+
+    jasmine.clock().tick(160);
+
+    expect(this.visModel.centerMapToOrigin).not.toHaveBeenCalled();
   });
 
-  it('should pass map to overlays', function () {
-    var _map;
-    Overlay.register('jaja', function (data, vis) {
-      _map = vis.map;
-      return new View();
-    });
-    var vis = this.createNewVis({el: this.container});
-    this.mapConfig.overlays = [{type: 'jaja'}];
-    vis.load(new VizJSON(this.mapConfig));
-    expect(_map).not.toEqual(undefined);
-  });
-
-  it('when https is false all the urls should be transformed to http', function () {
-    this.visView.https = false;
-    this.mapConfig.layers = [{
-      type: 'tiled',
-      options: {
-        urlTemplate: 'https://dnv9my2eseobd.cloudfront.net/v3/{z}/{x}/{y}.png'
-      }
-    }];
-    this.visView.load(new VizJSON(this.mapConfig));
-    expect(this.visView.map.layers.at(0).get('urlTemplate')).toEqual(
-      'http://a.tiles.mapbox.com/v3/{z}/{x}/{y}.png'
-    );
-  });
-
-  it('should return the native map obj', function () {
-    expect(this.visView.getNativeMap()).toEqual(this.visView.mapView._leafletMap);
-  });
-
-  it('should create a google maps map when provider is google maps', function () {
-    this.mapConfig.map_provider = 'googlemaps';
-    this.visView.load(new VizJSON(this.mapConfig));
-    expect(this.visView.mapView._gmapsMap).not.toEqual(undefined);
-  });
-
-  it('should display/hide the loader when \'loading\' changes', function () {
+  it('should display/hide the loader while loading', function () {
     this.visView.addOverlay({
       type: 'loader'
     });
 
-    this.vis.set('loading', true);
+    this.visModel.set('loading', true);
 
     expect(this.visView.$el.find('.CDB-Loader.is-visible').length).toEqual(1);
 
-    this.vis.set('loading', false);
+    this.visModel.set('loading', false);
 
     expect(this.visView.$el.find('.CDB-Loader:not(.is-visible)').length).toEqual(1);
   });
 
-  describe('.centerMapToOrigin', function () {
-    it('should invalidate map size', function () {
-      spyOn(this.visView.mapView, 'invalidateSize');
-      this.visView.centerMapToOrigin();
-      expect(this.visView.mapView.invalidateSize).toHaveBeenCalled();
-    });
-
-    it('should re-center the map', function () {
-      spyOn(this.visView.map, 'reCenter');
-      this.visView.centerMapToOrigin();
-      expect(this.visView.map.reCenter).toHaveBeenCalled();
-    });
-  });
-
-  describe('dragging option', function () {
-    beforeEach(function () {
-      this.mapConfig = {
-        updated_at: 'cachebuster',
-        title: 'irrelevant',
-        description: 'not so irrelevant',
-        url: 'http://cartodb.com',
-        center: [40.044, -101.95],
-        zoom: 4,
-        bounds: [[1, 2], [3, 4]],
-        scrollwheel: true,
-        overlays: [],
-        user: {
-          fullname: 'Chuck Norris',
-          avatar_url: 'http://example.com/avatar.jpg'
-        },
-        datasource: {
-          user_name: 'wadus',
-          maps_api_template: 'https://{user}.example.com:443',
-          stat_tag: 'ece6faac-7271-11e5-a85f-04013fc66a01',
-          force_cors: true // This is sometimes set in the editor
-        }
-      };
-    });
-
-    it('should be enabled with zoom overlay and scrollwheel enabled', function () {
-      var container = $('<div>').css('height', '200px');
-      var vis = this.createNewVis({el: container});
-
-      this.mapConfig.overlays = [
-        {
-          type: 'zoom',
-          order: 6,
-          options: {
-            x: 20,
-            y: 20,
-            display: true
-          },
-          template: ''
-        }
-      ];
-
-      vis.load(new VizJSON(this.mapConfig));
-      expect(vis.map.get('drag')).toBeTruthy();
-    });
-
-    it('should be enabled with zoom overlay and scrollwheel disabled', function () {
-      var container = $('<div>').css('height', '200px');
-      var vis = this.createNewVis({el: container});
-
-      this.mapConfig.overlays = [
-        {
-          type: 'zoom',
-          order: 6,
-          options: {
-            x: 20,
-            y: 20,
-            display: true
-          },
-          template: ''
-        }
-      ];
-
-      vis.load(new VizJSON(this.mapConfig));
-      expect(vis.map.get('drag')).toBeTruthy();
-    });
-
-    it('should be enabled without zoom overlay and scrollwheel enabled', function () {
-      var container = $('<div>').css('height', '200px');
-      var vis = this.createNewVis({el: container});
-
-      this.mapConfig.scrollwheel = true;
-
-      vis.load(new VizJSON(this.mapConfig));
-      expect(vis.map.get('drag')).toBeTruthy();
-    });
-
-    it('should be disabled without zoom overlay and scrollwheel disabled', function () {
-      var container = $('<div>').css('height', '200px');
-      var vis = this.createNewVis({el: container});
-
-      this.mapConfig.scrollwheel = false;
-
-      vis.load(new VizJSON(this.mapConfig));
-      expect(vis.map.get('drag')).toBeFalsy();
-    });
-  });
-
-  describe('api', function () {
-    it('should respond to getLayers', function () {
+  describe('.getLayerViews', function () {
+    it('should return the layerViews', function () {
       this.mapConfig.layers = [{
         type: 'tiled',
         options: {
           urlTemplate: 'https://dnv9my2eseobd.cloudfront.net/v3/{z}/{x}/{y}.png'
         }
       }];
-      this.visView.load(new VizJSON(this.mapConfig));
-      expect(this.visView.getLayers().length).toBe(1);
-    });
-    it('should respond to getLayerViews', function () {
-      this.mapConfig.layers = [{
-        type: 'tiled',
-        options: {
-          urlTemplate: 'https://dnv9my2eseobd.cloudfront.net/v3/{z}/{x}/{y}.png'
-        }
-      }];
-      this.visView.load(new VizJSON(this.mapConfig));
+      this.visModel.load(new VizJSON(this.mapConfig));
       expect(this.visView.getLayerViews().length).toBe(1);
     });
   });
@@ -367,7 +196,7 @@ describe('vis/vis-view', function () {
           }
         }
       ];
-      this.visView.load(new VizJSON(this.mapConfig));
+      this.visModel.load(new VizJSON(this.mapConfig));
 
       expect(this.visView.legends.$('.cartodb-legend').length).toEqual(1);
       expect(this.visView.legends.$el.html()).toContain('visible legend item');
@@ -375,476 +204,34 @@ describe('vis/vis-view', function () {
     });
   });
 
-  it('should retrieve the overlays of a given type', function () {
-    Overlay.register('wadus', function (data, vis) {
-      return new View();
-    });
-
-    var tooltip1 = this.visView.addOverlay({
-      type: 'wadus'
-    });
-    var tooltip2 = this.visView.addOverlay({
-      type: 'wadus'
-    });
-    var tooltip3 = this.visView.addOverlay({
-      type: 'wadus'
-    });
-    var tooltips = this.visView.getOverlaysByType('wadus');
-    expect(tooltips.length).toEqual(3);
-    expect(tooltips[0]).toEqual(tooltip1);
-    expect(tooltips[1]).toEqual(tooltip2);
-    expect(tooltips[2]).toEqual(tooltip3);
-    tooltip1.clean();
-    tooltip2.clean();
-    tooltip3.clean();
-    expect(this.visView.getOverlaysByType('wadus').length).toEqual(0);
-  });
-
-  it('should initialize existing analyses', function () {
-    var vizjson = {
-      layers: [
-        {
-          type: 'tiled',
-          options: {
-            urlTemplate: ''
-          }
-        },
-        {
-          type: 'layergroup',
-          options: {
-            user_name: 'pablo',
-            maps_api_template: 'https://{user}.cartodb-staging.com:443',
-            layer_definition: {
-              stat_tag: 'ece6faac-7271-11e5-a85f-04013fc66a01',
-              layers: [{
-                type: 'CartoDB',
-                options: {
-                  source: 'a0'
-                }
-
-              }]
-            }
-          }
-        }
-      ],
-      user: {
-        fullname: 'Chuck Norris',
-        avatar_url: 'http://example.com/avatar.jpg'
-      },
-      datasource: {
-        user_name: 'wadus',
-        maps_api_template: 'https://{user}.example.com:443',
-        stat_tag: 'ece6faac-7271-11e5-a85f-04013fc66a01',
-        force_cors: true // This is sometimes set in the editor
-      },
-      analyses: [
-        {
-          id: 'a1',
-          type: 'buffer',
-          params: {
-            source: {
-              id: 'a0',
-              type: 'source',
-              params: {
-                'query': 'SELECT * FROM airbnb_listings'
-              }
-            },
-            radio: 300
-          }
-        }
-      ]
-    };
-
-    this.visView.load(new VizJSON(vizjson));
-
-    // Analyses have been indexed
-    expect(this.visView._analysisCollection.size()).toEqual(2);
-
-    var a1 = this.visView.analysis.findNodeById('a1');
-    var a0 = this.visView.analysis.findNodeById('a0');
-
-    // Analysis graph has been created correctly
-    expect(a1.get('source')).toEqual(a0);
-  });
-
-  describe('polling', function () {
-    beforeEach(function () {
-      spyOn(_, 'debounce').and.callFake(function (func) { return function () { func.apply(this, arguments); }; });
-
-      this.vizjson = {
-        'id': '70af2a72-0709-11e6-a834-080027880ca6',
-        'version': '3.0.0',
-        'title': 'Untitled Map 1',
-        'likes': 0,
-        'description': null,
-        'scrollwheel': false,
-        'legends': true,
-        'map_provider': 'leaflet',
-        'bounds': [
-          [
-            41.358088,
-            2.089675
-          ],
-          [
-            41.448257,
-            2.215129
-          ]
-        ],
-        'center': '[41.4031725,2.1524020000000004]',
-        'zoom': 11,
-        'updated_at': '2016-04-20T17:05:02+00:00',
-        'layers': [
-          {
-            'type': 'layergroup',
-            'options': {
-              'user_name': 'cdb',
-              'maps_api_template': 'http://{user}.localhost.lan:8181',
-              'sql_api_template': 'http://{user}.localhost.lan:8080',
-              'filter': 'mapnik',
-              'layer_definition': {
-                'stat_tag': '70af2a72-0709-11e6-a834-080027880ca6',
-                'version': '3.0.0',
-                'layers': [
-                  {
-                    'id': 'e0d06945-74cd-4421-8229-561c3cabc854',
-                    'type': 'CartoDB',
-                    'infowindow': {
-                      'fields': [],
-                      'template_name': 'table/views/infowindow_light',
-                      'template': '<div class=\'CDB-infowindow CDB-infowindow--light js-infowindow\'>\n  <div class=\'CDB-infowindow-container\'>\n    <div class=\'CDB-infowindow-bg\'>\n      <div class=\'CDB-infowindow-inner\'>\n        <ul class=\'CDB-infowindow-list js-content\'>\n          {{#loading}}\n            <div class=\'CDB-Loader js-loader is-visible\'></div>\n          {{/loading}}\n          {{#content.fields}}\n          <li class=\'CDB-infowindow-listItem\'>\n            {{#title}}<h5 class=\'CDB-infowindow-subtitle\'>{{title}}</h5>{{/title}}\n            {{#value}}<h4 class=\'CDB-infowindow-title\'>{{{ value }}}</h4>{{/value}}\n            {{^value}}<h4 class=\'CDB-infowindow-title\'>null</h4>{{/value}}\n          </li>\n          {{/content.fields}}\n        </ul>\n      </div>\n    </div>\n    <div class=\'CDB-hook\'>\n      <div class=\'CDB-hook-inner\'></div>\n    </div>\n  </div>\n</div>\n',
-                      'alternative_names': {},
-                      'width': 226,
-                      'maxHeight': 180
-                    },
-                    'tooltip': {
-                      'fields': [],
-                      'template_name': 'tooltip_light',
-                      'template': '<div class=\'CDB-Tooltip CDB-Tooltip--isLight\'>\n  <ul class=\'CDB-Tooltip-list\'>\n    {{#fields}}\n      <li class=\'CDB-Tooltip-listItem\'>\n        {{#title}}\n          <h3 class=\'CDB-Tooltip-listTitle\'>{{{ title }}}</h3>\n        {{/title}}\n        <h4 class=\'CDB-Tooltip-listText\'>{{{ value }}}</h4>\n      </li>\n    {{/fields}}\n  </ul>\n</div>\n',
-                      'alternative_names': {},
-                      'maxHeight': 180
-                    },
-                    'legend': {
-                      'type': 'none',
-                      'show_title': false,
-                      'title': '',
-                      'template': '',
-                      'visible': true
-                    },
-                    'order': 1,
-                    'visible': true,
-                    'options': {
-                      'layer_name': 'arboles',
-                      'cartocss': 'cartocss',
-                      'cartocss_version': '2.1.1',
-                      'interactivity': 'cartodb_id',
-                      'source': 'a2'
-                    }
-                  }
-                ]
-              },
-              'attribution': ''
-            }
-          }
-        ],
-        'overlays': [],
-        'widgets': [],
-        'datasource': {
-          'user_name': 'cdb',
-          'maps_api_template': 'http://{user}.localhost.lan:8181',
-          'stat_tag': '70af2a72-0709-11e6-a834-080027880ca6'
-        },
-        'user': {
-          'fullname': 'cdb',
-          'avatar_url': '//example.com/avatars/avatar_stars_blue.png'
-        },
-        'analyses': [
-          {
-            'id': 'a2',
-            'type': 'trade-area',
-            'params': {
-              'source': {
-                'id': 'a1',
-                'type': 'trade-area',
-                'params': {
-                  'source': {
-                    'id': 'a0',
-                    'type': 'source',
-                    'params': {
-                      'query': 'SELECT * FROM arboles'
-                    }
-                  },
-                  'kind': 'drive',
-                  'time': 10
-                }
-              },
-              'kind': 'drive',
-              'time': 10
-            }
-          }
-        ],
-        'vector': false
-      };
-      spyOn($, 'ajax');
-    });
-
-    it('should start polling for analyses that are not ready', function () {
-      this.visView.load(new VizJSON(this.vizjson));
-      this.visView.instantiateMap();
-
-      // Response from Maps API is received
-      $.ajax.calls.argsFor(0)[0].success({
-        'layergroupid': '9d7bf465e45113123bf9949c2a4f0395:0',
-        'metadata': {
-          'layers': [
-            {
-              'type': 'mapnik',
-              'meta': {
-                'stats': [],
-                'cartocss': 'cartocss'
-              }
-            }
-          ],
-          'dataviews': {
-            'cd065428-ed63-4d29-9a09-a9f8384fc8c9': {
-              'url': {
-                'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/dataview/cd065428-ed63-4d29-9a09-a9f8384fc8c9'
-              }
-            }
-          },
-          'analyses': [
-            {
-              'nodes': {
-                'a0': {
-                  'status': 'ready',
-                  'query': 'SELECT * FROM arboles',
-                  'url': {
-                    'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/5af683d5d8a6f67e11916a31cd76632884d4064f'
-                  }
-                },
-                'a1': {
-                  'status': 'pending',
-                  'query': 'select * from analysis_trade_area_e65b1ae05854aea96266808ec0686b91f3ee0a81',
-                  'url': {
-                    'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/e65b1ae05854aea96266808ec0686b91f3ee0a81'
-                  }
-                },
-                'a2': {
-                  'status': 'pending',
-                  'query': 'select * from analysis_trade_area_b35b1ae05854aea96266808ec0686b91f3ee0a81',
-                  'url': {
-                    'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/b75b1ae05854aea96266808ec0686b91f3ee0a81'
-                  }
-                }
-              }
-            }
-          ]
-        },
-        'last_updated': '1970-01-01T00:00:00.000Z'
-      });
-      expect(this.vis.trackLoadingObject).toHaveBeenCalled();
-
-      // Polling has started
-      expect($.ajax.calls.argsFor(1)[0].url).toEqual('http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/e65b1ae05854aea96266808ec0686b91f3ee0a81');
-      expect($.ajax.calls.argsFor(2)[0].url).toEqual('http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/b75b1ae05854aea96266808ec0686b91f3ee0a81');
-    });
-
-    it('should NOT start polling for analysis that are "ready" and are the source of a layer', function () {
-      this.visView.load(new VizJSON(this.vizjson));
-      this.visView.instantiateMap();
-
-      // Response from Maps API is received
-      $.ajax.calls.argsFor(0)[0].success({
-        'layergroupid': '9d7bf465e45113123bf9949c2a4f0395:0',
-        'metadata': {
-          'layers': [
-            {
-              'type': 'mapnik',
-              'meta': {
-                'stats': [],
-                'cartocss': 'cartocss'
-              }
-            }
-          ],
-          'dataviews': {
-            'cd065428-ed63-4d29-9a09-a9f8384fc8c9': {
-              'url': {
-                'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/dataview/cd065428-ed63-4d29-9a09-a9f8384fc8c9'
-              }
-            }
-          },
-          'analyses': [
-            {
-              'nodes': {
-                'a0': {
-                  'status': 'ready',
-                  'query': 'SELECT * FROM arboles',
-                  'url': {
-                    'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/5af683d5d8a6f67e11916a31cd76632884d4064f'
-                  }
-                },
-                'a1': {
-                  'status': 'ready',
-                  'query': 'select * from analysis_trade_area_e65b1ae05854aea96266808ec0686b91f3ee0a81',
-                  'url': {
-                    'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/e65b1ae05854aea96266808ec0686b91f3ee0a81'
-                  }
-                },
-                'a2': {
-                  'status': 'ready',
-                  'query': 'select * from analysis_trade_area_b35b1ae05854aea96266808ec0686b91f3ee0a81',
-                  'url': {
-                    'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/b75b1ae05854aea96266808ec0686b91f3ee0a81'
-                  }
-                }
-              }
-            }
-          ]
-        },
-        'last_updated': '1970-01-01T00:00:00.000Z'
+  describe('.getOverlaysByType', function () {
+    it('should retrieve the overlays of a given type', function () {
+      Overlay.register('wadus', function (data, vis) {
+        return new View();
       });
 
-      // Polling has NOT started, there was only one ajax call to instantiate the map
-      expect($.ajax.calls.count()).toEqual(1);
-    });
-
-    it("should NOT start polling for analyses that don't have a URL yet", function () {
-      this.visView.load(new VizJSON(this.vizjson));
-      this.visView.instantiateMap();
-
-      // Analysis node is created using analyse but node is not associated to any layer or dataview
-      this.visView.analysis.analyse({
-        id: 'something',
-        type: 'source',
-        params: {
-          query: 'SELECT * FROM people'
-        }
+      var tooltip1 = this.visView.addOverlay({
+        type: 'wadus'
       });
-
-      // Response from Maps API is received
-      $.ajax.calls.argsFor(0)[0].success({
-        'layergroupid': '9d7bf465e45113123bf9949c2a4f0395:0',
-        'metadata': {
-          'layers': [
-            {
-              'type': 'mapnik',
-              'meta': {
-                'stats': [],
-                'cartocss': 'cartocss'
-              }
-            }
-          ],
-          'dataviews': { },
-          'analyses': [
-            {
-              'nodes': {
-                'a0': {
-                  'status': 'ready',
-                  'query': 'SELECT * FROM arboles',
-                  'url': {
-                    'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/5af683d5d8a6f67e11916a31cd76632884d4064f'
-                  }
-                },
-                'a1': {
-                  'status': 'ready',
-                  'query': 'select * from analysis_trade_area_e65b1ae05854aea96266808ec0686b91f3ee0a81',
-                  'url': {
-                    'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/e65b1ae05854aea96266808ec0686b91f3ee0a81'
-                  }
-                },
-                'a2': {
-                  'status': 'ready',
-                  'query': 'select * from analysis_trade_area_b35b1ae05854aea96266808ec0686b91f3ee0a81',
-                  'url': {
-                    'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/b75b1ae05854aea96266808ec0686b91f3ee0a81'
-                  }
-                }
-              }
-            }
-          ]
-        },
-        'last_updated': '1970-01-01T00:00:00.000Z'
+      var tooltip2 = this.visView.addOverlay({
+        type: 'wadus'
       });
-
-      // Polling has NOT started, there was only one ajax call to instantiate the map
-      expect($.ajax.calls.count()).toEqual(1);
-    });
-
-    it('should reload the map when analysis is done', function () {
-      this.visView.load(new VizJSON(this.vizjson));
-      this.visView.instantiateMap();
-
-      // Response from Maps API is received
-      $.ajax.calls.argsFor(0)[0].success({
-        'layergroupid': '9d7bf465e45113123bf9949c2a4f0395:0',
-        'metadata': {
-          'layers': [
-            {
-              'type': 'mapnik',
-              'meta': {
-                'stats': [],
-                'cartocss': 'cartocss'
-              }
-            }
-          ],
-          'dataviews': {
-            'cd065428-ed63-4d29-9a09-a9f8384fc8c9': {
-              'url': {
-                'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/dataview/cd065428-ed63-4d29-9a09-a9f8384fc8c9'
-              }
-            }
-          },
-          'analyses': [
-            {
-              'nodes': {
-                'a0': {
-                  'status': 'ready',
-                  'query': 'SELECT * FROM arboles',
-                  'url': {
-                    'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/5af683d5d8a6f67e11916a31cd76632884d4064f'
-                  }
-                },
-                'a1': {
-                  'status': 'pending',
-                  'query': 'select * from analysis_trade_area_e65b1ae05854aea96266808ec0686b91f3ee0a81',
-                  'url': {
-                    'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/e65b1ae05854aea96266808ec0686b91f3ee0a81'
-                  }
-                },
-                'a2': {
-                  'status': 'pending',
-                  'query': 'select * from analysis_trade_area_b35b1ae05854aea96266808ec0686b91f3ee0a81',
-                  'url': {
-                    'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/b75b1ae05854aea96266808ec0686b91f3ee0a81'
-                  }
-                }
-              }
-            }
-          ]
-        },
-        'last_updated': '1970-01-01T00:00:00.000Z'
+      var tooltip3 = this.visView.addOverlay({
+        type: 'wadus'
       });
-      expect($.ajax.calls.argsFor(0)[0].url).toEqual('http://cdb.localhost.lan:8181/api/v1/map?stat_tag=70af2a72-0709-11e6-a834-080027880ca6');
-      expect($.ajax.calls.argsFor(1)[0].url).toEqual('http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/e65b1ae05854aea96266808ec0686b91f3ee0a81');
-      expect($.ajax.calls.argsFor(2)[0].url).toEqual('http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/b75b1ae05854aea96266808ec0686b91f3ee0a81');
-
-      expect($.ajax.calls.count()).toEqual(3);
-
-      // Analysis endpoint for a1 responds
-      $.ajax.calls.argsFor(1)[0].success({status: 'ready'});
-
-      // Map is not reloaded because a1 is not the source of a layer
-      expect($.ajax.calls.count()).toEqual(3);
-
-      // Analysis endpoint for a2 responds
-      $.ajax.calls.argsFor(2)[0].success({status: 'ready'});
-
-      // Map has been reloaded because a2 is the source of a layer
-      expect($.ajax.calls.count()).toEqual(4);
-      expect($.ajax.calls.argsFor(3)[0].url).toEqual('http://cdb.localhost.lan:8181/api/v1/map?stat_tag=70af2a72-0709-11e6-a834-080027880ca6');
+      var tooltips = this.visView.getOverlaysByType('wadus');
+      expect(tooltips.length).toEqual(3);
+      expect(tooltips[0]).toEqual(tooltip1);
+      expect(tooltips[1]).toEqual(tooltip2);
+      expect(tooltips[2]).toEqual(tooltip3);
+      tooltip1.clean();
+      tooltip2.clean();
+      tooltip3.clean();
+      expect(this.visView.getOverlaysByType('wadus').length).toEqual(0);
     });
   });
 
-  describe('addOverlay', function () {
+  describe('.addOverlay', function () {
     it('should throw an error if no layers are available', function () {
       expect(function () {
         this.visView.addOverlay({
@@ -905,7 +292,7 @@ describe('vis/vis-view', function () {
         }
       };
 
-      this.visView.load(new VizJSON(vizjson));
+      this.visModel.load(new VizJSON(vizjson));
       var tooltip = this.visView.addOverlay({
         type: 'tooltip',
         template: 'test'

--- a/test/spec/vis/vis-view.spec.js
+++ b/test/spec/vis/vis-view.spec.js
@@ -68,11 +68,7 @@ describe('vis/vis-view', function () {
     expect(this.visView.mapView._leafletMap).not.toEqual(undefined);
   });
 
-  // Skipping this test that is failing in CI for some issue inside the Google
-  // Maps API library:
-  //   -> TypeError: 'undefined' is not an object (evaluating 'a.addEventListener') in
-  //   http://maps.googleapis.com/maps/api/js?sensor=false&v=3.12 (line 88)
-  xit('should create a google maps map when provider is googlemaps', function () {
+  it('should create a google maps map when provider is googlemaps', function () {
     this.visModel.map.set('provider', 'googlemaps');
 
     this.visView.render();

--- a/test/spec/vis/vis-view.spec.js
+++ b/test/spec/vis/vis-view.spec.js
@@ -152,7 +152,7 @@ describe('vis/vis-view', function () {
   });
 
   describe('Legends', function () {
-    it('should only display legends for visible layers', function () {
+    beforeEach(function () {
       this.mapConfig.layers = [
         {
           type: 'tiled',
@@ -197,10 +197,24 @@ describe('vis/vis-view', function () {
         }
       ];
       this.visModel.load(new VizJSON(this.mapConfig));
+    });
 
-      expect(this.visView.legends.$('.cartodb-legend').length).toEqual(1);
-      expect(this.visView.legends.$el.html()).toContain('visible legend item');
-      expect(this.visView.legends.$el.html()).not.toContain('invisible legend item');
+    it('should NOT display legend if showLegends is false', function () {
+      this.visModel.set('showLegends', false);
+
+      this.visView.render();
+
+      expect(this.visView.$('.cartodb-legend').length).toEqual(0);
+    });
+
+    it('should only display legends for visible layers if showLegends is true', function () {
+      this.visModel.set('showLegends', true);
+
+      this.visView.render();
+
+      expect(this.visView.$('.cartodb-legend').length).toEqual(1);
+      expect(this.visView.$el.html()).toContain('visible legend item');
+      expect(this.visView.$el.html()).not.toContain('invisible legend item');
     });
   });
 

--- a/test/spec/vis/vis-view.spec.js
+++ b/test/spec/vis/vis-view.spec.js
@@ -68,7 +68,11 @@ describe('vis/vis-view', function () {
     expect(this.visView.mapView._leafletMap).not.toEqual(undefined);
   });
 
-  it('should create a google maps map when provider is googlemaps', function () {
+  // Skipping this test that is failing in CI for some issue inside the Google
+  // Maps API library:
+  //   -> TypeError: 'undefined' is not an object (evaluating 'a.addEventListener') in
+  //   http://maps.googleapis.com/maps/api/js?sensor=false&v=3.12 (line 88)
+  xit('should create a google maps map when provider is googlemaps', function () {
     this.visModel.map.set('provider', 'googlemaps');
 
     this.visView.render();

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -1,8 +1,223 @@
+var $ = require('jquery');
+var _ = require('underscore');
 var Vis = require('../../../src/vis/vis');
+var VizJSON = require('../../../src/api/vizjson');
+
+var fakeVizJSON = function () {
+  return {
+    'id': '03a89434-379e-11e6-b2e3-0e674067d321',
+    'version': '3.0.0',
+    'title': 'Untitled Map 6',
+    'likes': 0,
+    'description': null,
+    'scrollwheel': false,
+    'legends': true,
+    'map_provider': 'leaflet',
+    'bounds': [
+      [
+        -37.814,
+        -123.11934
+      ],
+      [
+        64,
+        153.02809
+      ]
+    ],
+    'center': '[13.093,14.954374999999999]',
+    'zoom': 1,
+    'updated_at': '2016-06-22T14:25:00+00:00',
+    'layers': [
+      {
+        'options': {
+          'default': 'true',
+          'url': 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
+          'subdomains': 'abcd',
+          'minZoom': '0',
+          'maxZoom': '18',
+          'name': 'Positron',
+          'className': 'positron_rainbow_labels',
+          'attribution': '&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors &copy; <a href=\"http://cartodb.com/attributions\">CartoDB</a>',
+          'labels': {
+            'url': 'http://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png'
+          },
+          'urlTemplate': 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png'
+        },
+        'infowindow': null,
+        'tooltip': null,
+        'id': 'bd329548-dfdf-4d05-95f5-4773d041b91d',
+        'order': 0,
+        'type': 'tiled'
+      },
+      {
+        'type': 'layergroup',
+        'options': {
+          'user_name': 'pabloalonso',
+          'maps_api_template': 'https://{user}.cartodb.com:443',
+          'sql_api_template': 'https://{user}.cartodb.com:443',
+          'filter': 'mapnik',
+          'layer_definition': {
+            'stat_tag': '03a89434-379e-11e6-b2e3-0e674067d321',
+            'version': '3.0.0',
+            'layers': [
+              {
+                'id': 'aefb9966-e587-40dc-8be7-6e85949f8ebe',
+                'type': 'CartoDB',
+                'infowindow': {
+                  'fields': [
+                    {
+                      'name': 'gnip',
+                      'title': true,
+                      'position': 0
+                    },
+                    {
+                      'name': 'actor_disp',
+                      'title': true,
+                      'position': 1
+                    }
+                  ],
+                  'template_name': 'table/views/infowindow_light',
+                  'template': '<div class=\"CDB-infowindow CDB-infowindow--light js-infowindow\">\n  <div class=\"CDB-infowindow-close js-close\"></div>\n  <div class=\"CDB-infowindow-container\">\n    <div class=\"CDB-infowindow-bg\">\n      <div class=\"CDB-infowindow-inner\">\n        {{#loading}}\n          <div class=\"CDB-Loader js-loader is-visible\"></div>\n        {{/loading}}\n        <ul class=\"CDB-infowindow-list js-content\">\n          {{#content.fields}}\n          <li class=\"CDB-infowindow-listItem\">\n            {{#title}}<h5 class=\"CDB-infowindow-subtitle\">{{title}}</h5>{{/title}}\n            {{#value}}<h4 class=\"CDB-infowindow-title\">{{{ value }}}</h4>{{/value}}\n            {{^value}}<h4 class=\"CDB-infowindow-title\">null</h4>{{/value}}\n          </li>\n          {{/content.fields}}\n        </ul>\n      </div>\n    </div>\n    <div class=\"CDB-hook\">\n      <div class=\"CDB-hook-inner\"></div>\n    </div>\n  </div>\n</div>\n',
+                  'alternative_names': {},
+                  'width': 226,
+                  'maxHeight': 180
+                },
+                'tooltip': {
+                  'fields': [],
+                  'template_name': 'tooltip_light',
+                  'template': '<div class=\"CDB-Tooltip CDB-Tooltip--isLight\">\n  <ul class=\"CDB-Tooltip-list\">\n    {{#fields}}\n      <li class=\"CDB-Tooltip-listItem\">\n        {{#title}}\n          <h3 class=\"CDB-Tooltip-listTitle\">{{{ title }}}</h3>\n        {{/title}}\n        <h4 class=\"CDB-Tooltip-listText\">{{{ value }}}</h4>\n      </li>\n    {{/fields}}\n  </ul>\n</div>\n',
+                  'alternative_names': {},
+                  'maxHeight': 180
+                },
+                'legend': {
+                  'type': 'none',
+                  'show_title': false,
+                  'title': '',
+                  'template': '',
+                  'visible': true
+                },
+                'order': 1,
+                'visible': true,
+                'options': {
+                  'layer_name': 'twitter_t3chfest_reduced',
+                  'cartocss': '/** simple visualization */\n\n#twitter_t3chfest_reduced{\n  marker-fill-opacity: 0.9;\n  marker-line-color: #FFF;\n  marker-line-width: 1;\n  marker-line-opacity: 1;\n  marker-placement: point;\n  marker-type: ellipse;\n  marker-width: 10;\n  marker-fill: #FF6600;\n  marker-allow-overlap: true;\n}',
+                  'cartocss_version': '2.1.1',
+                  'interactivity': 'cartodb_id',
+                  'source': 'a0'
+                }
+              }
+            ]
+          },
+          'attribution': ''
+        }
+      },
+      {
+        'options': {
+          'default': 'true',
+          'url': 'http://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png',
+          'subdomains': 'abcd',
+          'minZoom': '0',
+          'maxZoom': '18',
+          'attribution': '&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors &copy; <a href=\"http://cartodb.com/attributions\">CartoDB</a>',
+          'urlTemplate': 'http://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png',
+          'type': 'Tiled',
+          'name': 'Positron Labels'
+        },
+        'infowindow': null,
+        'tooltip': null,
+        'id': '2a0b6f3a-e11c-4ff8-b3d3-65366935341a',
+        'order': 2,
+        'type': 'tiled'
+      }
+    ],
+    'overlays': [
+      {
+        'type': 'share',
+        'order': 2,
+        'options': {
+          'display': true,
+          'x': 20,
+          'y': 20
+        },
+        'template': ''
+      },
+      {
+        'type': 'search',
+        'order': 3,
+        'options': {
+          'display': true,
+          'x': 60,
+          'y': 20
+        },
+        'template': ''
+      },
+      {
+        'type': 'zoom',
+        'order': 6,
+        'options': {
+          'display': true,
+          'x': 20,
+          'y': 20
+        },
+        'template': '<a href=\"#zoom_in\" class=\"zoom_in\">+</a> <a href=\"#zoom_out\" class=\"zoom_out\">-</a>'
+      },
+      {
+        'type': 'loader',
+        'order': 8,
+        'options': {
+          'display': true,
+          'x': 20,
+          'y': 150
+        },
+        'template': '<div class=\"loader\" original-title=\"\"></div>'
+      },
+      {
+        'type': 'logo',
+        'order': 9,
+        'options': {
+          'display': true,
+          'x': 10,
+          'y': 40
+        },
+        'template': ''
+      }
+    ],
+    'prev': null,
+    'next': null,
+    'transition_options': {
+      'time': 0
+    },
+    'widgets': [],
+    'datasource': {
+      'user_name': 'pabloalonso',
+      'maps_api_template': 'https://{user}.cartodb.com:443',
+      'stat_tag': '03a89434-379e-11e6-b2e3-0e674067d321'
+    },
+    'user': {
+      'fullname': 'Pablo',
+      'avatar_url': '//cartodb-libs.global.ssl.fastly.net/cartodbui/assets/unversioned/images/avatars/avatar_planet_green.png'
+    },
+    'analyses': [
+      {
+        'id': 'a0',
+        'type': 'source',
+        'params': {
+          'query': 'SELECT * FROM twitter_t3chfest_reduced limit 1'
+        },
+        'options': {
+          'table_name': 'twitter_t3chfest_reduced'
+        }
+      }
+    ],
+    'vector': false
+  };
+};
 
 describe('vis/vis', function () {
-  it('.trackLoadingObject .untrackLoadingObject and .clearLoadingObjects should change the loading attribute', function () {
+  beforeEach(function () {
     this.vis = new Vis();
+  });
+
+  it('.trackLoadingObject .untrackLoadingObject and .clearLoadingObjects should change the loading attribute', function () {
     var object = { id: 'id' };
 
     // 'loading' is false by default
@@ -17,5 +232,675 @@ describe('vis/vis', function () {
 
     // no objects are being loaded again so 'loading' is false
     expect(this.vis.get('loading')).toEqual(false);
+  });
+
+  describe('.load', function () {
+    beforeEach(function () {
+      this.vis.load(new VizJSON(fakeVizJSON()), {});
+    });
+
+    it('should correctly set some public properties', function () {
+      expect(this.vis.map).toBeDefined();
+      expect(this.vis.analysis).toBeDefined();
+      expect(this.vis.dataviews).toBeDefined();
+      expect(this.vis.layerGroupModel).toBeDefined();
+      expect(this.vis.overlaysCollection).toBeDefined();
+    });
+
+    it('should load the layers', function () {
+      expect(this.vis.map.layers.size()).toEqual(3);
+    });
+
+    it('should use given maxZoom and minZoom', function () {
+      var vizjson = fakeVizJSON();
+      vizjson.maxZoom = 10;
+      vizjson.minZoom = 5;
+
+      this.vis.load(new VizJSON(vizjson));
+
+      expect(this.vis.map.get('maxZoom')).toEqual(10);
+      expect(this.vis.map.get('minZoom')).toEqual(5);
+    });
+
+    it('should use the given provider', function () {
+      var vizjson = fakeVizJSON();
+      vizjson.map_provider = 'googlemaps';
+
+      this.vis.load(new VizJSON(vizjson));
+
+      expect(this.vis.map.get('provider')).toEqual('googlemaps');
+    });
+
+    describe('dragging option', function () {
+      beforeEach(function () {
+        this.vizjson = {
+          updated_at: 'cachebuster',
+          title: 'irrelevant',
+          description: 'not so irrelevant',
+          url: 'http://cartodb.com',
+          center: [40.044, -101.95],
+          zoom: 4,
+          bounds: [[1, 2], [3, 4]],
+          scrollwheel: true,
+          overlays: [],
+          user: {
+            fullname: 'Chuck Norris',
+            avatar_url: 'http://example.com/avatar.jpg'
+          },
+          datasource: {
+            user_name: 'wadus',
+            maps_api_template: 'https://{user}.example.com:443',
+            stat_tag: 'ece6faac-7271-11e5-a85f-04013fc66a01',
+            force_cors: true // This is sometimes set in the editor
+          }
+        };
+      });
+
+      it('should be enabled with zoom overlay and scrollwheel enabled', function () {
+        this.vizjson.overlays = [
+          {
+            type: 'zoom',
+            order: 6,
+            options: {
+              x: 20,
+              y: 20,
+              display: true
+            },
+            template: ''
+          }
+        ];
+
+        this.vis.load(new VizJSON(this.vizjson));
+        expect(this.vis.map.get('drag')).toBeTruthy();
+      });
+
+      it('should be enabled with zoom overlay and scrollwheel disabled', function () {
+        this.vizjson.overlays = [
+          {
+            type: 'zoom',
+            order: 6,
+            options: {
+              x: 20,
+              y: 20,
+              display: true
+            },
+            template: ''
+          }
+        ];
+
+        this.vis.load(new VizJSON(this.vizjson));
+        expect(this.vis.map.get('drag')).toBeTruthy();
+      });
+
+      it('should be enabled without zoom overlay and scrollwheel enabled', function () {
+        this.vizjson.scrollwheel = true;
+
+        this.vis.load(new VizJSON(this.vizjson));
+        expect(this.vis.map.get('drag')).toBeTruthy();
+      });
+
+      it('should be disabled without zoom overlay and scrollwheel disabled', function () {
+        this.vizjson.scrollwheel = false;
+
+        this.vis.load(new VizJSON(this.vizjson));
+        expect(this.vis.map.get('drag')).toBeFalsy();
+      });
+    });
+
+    it('when https is false all the urls should be transformed to http', function () {
+      var vizjson = fakeVizJSON();
+
+      vizjson.https = false;
+      vizjson.layers = [{
+        type: 'tiled',
+        options: {
+          urlTemplate: 'https://dnv9my2eseobd.cloudfront.net/v3/{z}/{x}/{y}.png'
+        }
+      }];
+
+      this.vis.load(new VizJSON(vizjson));
+
+      expect(this.vis.map.layers.at(0).get('urlTemplate')).toEqual(
+        'http://a.tiles.mapbox.com/v3/{z}/{x}/{y}.png'
+      );
+    });
+
+    it('when https is true all urls should NOT be transformed to http', function () {
+      var vizjson = fakeVizJSON();
+
+      vizjson.https = true;
+      vizjson.layers = [{
+        type: 'tiled',
+        options: {
+          urlTemplate: 'https://dnv9my2eseobd.cloudfront.net/v3/{z}/{x}/{y}.png'
+        }
+      }];
+
+      this.vis.load(new VizJSON(vizjson));
+
+      expect(this.vis.map.layers.at(0).get('urlTemplate')).toEqual(
+        'https://dnv9my2eseobd.cloudfront.net/v3/{z}/{x}/{y}.png'
+      );
+    });
+
+    it('should initialize existing analyses', function () {
+      this.vizjson = {
+        layers: [
+          {
+            type: 'tiled',
+            options: {
+              urlTemplate: ''
+            }
+          },
+          {
+            type: 'layergroup',
+            options: {
+              user_name: 'pablo',
+              maps_api_template: 'https://{user}.cartodb-staging.com:443',
+              layer_definition: {
+                stat_tag: 'ece6faac-7271-11e5-a85f-04013fc66a01',
+                layers: [{
+                  type: 'CartoDB',
+                  options: {
+                    source: 'a0'
+                  }
+
+                }]
+              }
+            }
+          }
+        ],
+        user: {
+          fullname: 'Chuck Norris',
+          avatar_url: 'http://example.com/avatar.jpg'
+        },
+        datasource: {
+          user_name: 'wadus',
+          maps_api_template: 'https://{user}.example.com:443',
+          stat_tag: 'ece6faac-7271-11e5-a85f-04013fc66a01',
+          force_cors: true // This is sometimes set in the editor
+        },
+        analyses: [
+          {
+            id: 'a1',
+            type: 'buffer',
+            params: {
+              source: {
+                id: 'a0',
+                type: 'source',
+                params: {
+                  'query': 'SELECT * FROM airbnb_listings'
+                }
+              },
+              radio: 300
+            }
+          }
+        ]
+      };
+
+      this.vis.load(new VizJSON(this.vizjson));
+
+      // Analyses have been indexed
+      expect(this.vis._analysisCollection.size()).toEqual(2);
+
+      var a1 = this.vis.analysis.findNodeById('a1');
+      var a0 = this.vis.analysis.findNodeById('a0');
+
+      // Analysis graph has been created correctly
+      expect(a1.get('source')).toEqual(a0);
+    });
+
+    describe('polling', function () {
+      beforeEach(function () {
+        spyOn(_, 'debounce').and.callFake(function (func) { return function () { func.apply(this, arguments); }; });
+
+        this.vizjson = {
+          'id': '70af2a72-0709-11e6-a834-080027880ca6',
+          'version': '3.0.0',
+          'title': 'Untitled Map 1',
+          'likes': 0,
+          'description': null,
+          'scrollwheel': false,
+          'legends': true,
+          'map_provider': 'leaflet',
+          'bounds': [
+            [
+              41.358088,
+              2.089675
+            ],
+            [
+              41.448257,
+              2.215129
+            ]
+          ],
+          'center': '[41.4031725,2.1524020000000004]',
+          'zoom': 11,
+          'updated_at': '2016-04-20T17:05:02+00:00',
+          'layers': [
+            {
+              'type': 'layergroup',
+              'options': {
+                'user_name': 'cdb',
+                'maps_api_template': 'http://{user}.localhost.lan:8181',
+                'sql_api_template': 'http://{user}.localhost.lan:8080',
+                'filter': 'mapnik',
+                'layer_definition': {
+                  'stat_tag': '70af2a72-0709-11e6-a834-080027880ca6',
+                  'version': '3.0.0',
+                  'layers': [
+                    {
+                      'id': 'e0d06945-74cd-4421-8229-561c3cabc854',
+                      'type': 'CartoDB',
+                      'infowindow': {
+                        'fields': [],
+                        'template_name': 'table/views/infowindow_light',
+                        'template': '<div class=\'CDB-infowindow CDB-infowindow--light js-infowindow\'>\n  <div class=\'CDB-infowindow-container\'>\n    <div class=\'CDB-infowindow-bg\'>\n      <div class=\'CDB-infowindow-inner\'>\n        <ul class=\'CDB-infowindow-list js-content\'>\n          {{#loading}}\n            <div class=\'CDB-Loader js-loader is-visible\'></div>\n          {{/loading}}\n          {{#content.fields}}\n          <li class=\'CDB-infowindow-listItem\'>\n            {{#title}}<h5 class=\'CDB-infowindow-subtitle\'>{{title}}</h5>{{/title}}\n            {{#value}}<h4 class=\'CDB-infowindow-title\'>{{{ value }}}</h4>{{/value}}\n            {{^value}}<h4 class=\'CDB-infowindow-title\'>null</h4>{{/value}}\n          </li>\n          {{/content.fields}}\n        </ul>\n      </div>\n    </div>\n    <div class=\'CDB-hook\'>\n      <div class=\'CDB-hook-inner\'></div>\n    </div>\n  </div>\n</div>\n',
+                        'alternative_names': {},
+                        'width': 226,
+                        'maxHeight': 180
+                      },
+                      'tooltip': {
+                        'fields': [],
+                        'template_name': 'tooltip_light',
+                        'template': '<div class=\'CDB-Tooltip CDB-Tooltip--isLight\'>\n  <ul class=\'CDB-Tooltip-list\'>\n    {{#fields}}\n      <li class=\'CDB-Tooltip-listItem\'>\n        {{#title}}\n          <h3 class=\'CDB-Tooltip-listTitle\'>{{{ title }}}</h3>\n        {{/title}}\n        <h4 class=\'CDB-Tooltip-listText\'>{{{ value }}}</h4>\n      </li>\n    {{/fields}}\n  </ul>\n</div>\n',
+                        'alternative_names': {},
+                        'maxHeight': 180
+                      },
+                      'legend': {
+                        'type': 'none',
+                        'show_title': false,
+                        'title': '',
+                        'template': '',
+                        'visible': true
+                      },
+                      'order': 1,
+                      'visible': true,
+                      'options': {
+                        'layer_name': 'arboles',
+                        'cartocss': 'cartocss',
+                        'cartocss_version': '2.1.1',
+                        'interactivity': 'cartodb_id',
+                        'source': 'a2'
+                      }
+                    }
+                  ]
+                },
+                'attribution': ''
+              }
+            }
+          ],
+          'overlays': [],
+          'widgets': [],
+          'datasource': {
+            'user_name': 'cdb',
+            'maps_api_template': 'http://{user}.localhost.lan:8181',
+            'stat_tag': '70af2a72-0709-11e6-a834-080027880ca6'
+          },
+          'user': {
+            'fullname': 'cdb',
+            'avatar_url': '//example.com/avatars/avatar_stars_blue.png'
+          },
+          'analyses': [
+            {
+              'id': 'a2',
+              'type': 'trade-area',
+              'params': {
+                'source': {
+                  'id': 'a1',
+                  'type': 'trade-area',
+                  'params': {
+                    'source': {
+                      'id': 'a0',
+                      'type': 'source',
+                      'params': {
+                        'query': 'SELECT * FROM arboles'
+                      }
+                    },
+                    'kind': 'drive',
+                    'time': 10
+                  }
+                },
+                'kind': 'drive',
+                'time': 10
+              }
+            }
+          ],
+          'vector': false
+        };
+        spyOn($, 'ajax');
+      });
+
+      it('should start polling for analyses that are not ready', function () {
+        spyOn(this.vis, 'trackLoadingObject');
+
+        this.vis.load(new VizJSON(this.vizjson));
+        this.vis.instantiateMap();
+
+        // Response from Maps API is received
+        $.ajax.calls.argsFor(0)[0].success({
+          'layergroupid': '9d7bf465e45113123bf9949c2a4f0395:0',
+          'metadata': {
+            'layers': [
+              {
+                'type': 'mapnik',
+                'meta': {
+                  'stats': [],
+                  'cartocss': 'cartocss'
+                }
+              }
+            ],
+            'dataviews': {
+              'cd065428-ed63-4d29-9a09-a9f8384fc8c9': {
+                'url': {
+                  'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/dataview/cd065428-ed63-4d29-9a09-a9f8384fc8c9'
+                }
+              }
+            },
+            'analyses': [
+              {
+                'nodes': {
+                  'a0': {
+                    'status': 'ready',
+                    'query': 'SELECT * FROM arboles',
+                    'url': {
+                      'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/5af683d5d8a6f67e11916a31cd76632884d4064f'
+                    }
+                  },
+                  'a1': {
+                    'status': 'pending',
+                    'query': 'select * from analysis_trade_area_e65b1ae05854aea96266808ec0686b91f3ee0a81',
+                    'url': {
+                      'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/e65b1ae05854aea96266808ec0686b91f3ee0a81'
+                    }
+                  },
+                  'a2': {
+                    'status': 'pending',
+                    'query': 'select * from analysis_trade_area_b35b1ae05854aea96266808ec0686b91f3ee0a81',
+                    'url': {
+                      'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/b75b1ae05854aea96266808ec0686b91f3ee0a81'
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          'last_updated': '1970-01-01T00:00:00.000Z'
+        });
+        expect(this.vis.trackLoadingObject).toHaveBeenCalled();
+
+        // Polling has started
+        expect($.ajax.calls.argsFor(1)[0].url).toEqual('http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/e65b1ae05854aea96266808ec0686b91f3ee0a81');
+        expect($.ajax.calls.argsFor(2)[0].url).toEqual('http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/b75b1ae05854aea96266808ec0686b91f3ee0a81');
+      });
+
+      it('should NOT start polling for analysis that are "ready" and are the source of a layer', function () {
+        this.vis.load(new VizJSON(this.vizjson));
+        this.vis.instantiateMap();
+
+        // Response from Maps API is received
+        $.ajax.calls.argsFor(0)[0].success({
+          'layergroupid': '9d7bf465e45113123bf9949c2a4f0395:0',
+          'metadata': {
+            'layers': [
+              {
+                'type': 'mapnik',
+                'meta': {
+                  'stats': [],
+                  'cartocss': 'cartocss'
+                }
+              }
+            ],
+            'dataviews': {
+              'cd065428-ed63-4d29-9a09-a9f8384fc8c9': {
+                'url': {
+                  'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/dataview/cd065428-ed63-4d29-9a09-a9f8384fc8c9'
+                }
+              }
+            },
+            'analyses': [
+              {
+                'nodes': {
+                  'a0': {
+                    'status': 'ready',
+                    'query': 'SELECT * FROM arboles',
+                    'url': {
+                      'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/5af683d5d8a6f67e11916a31cd76632884d4064f'
+                    }
+                  },
+                  'a1': {
+                    'status': 'ready',
+                    'query': 'select * from analysis_trade_area_e65b1ae05854aea96266808ec0686b91f3ee0a81',
+                    'url': {
+                      'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/e65b1ae05854aea96266808ec0686b91f3ee0a81'
+                    }
+                  },
+                  'a2': {
+                    'status': 'ready',
+                    'query': 'select * from analysis_trade_area_b35b1ae05854aea96266808ec0686b91f3ee0a81',
+                    'url': {
+                      'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/b75b1ae05854aea96266808ec0686b91f3ee0a81'
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          'last_updated': '1970-01-01T00:00:00.000Z'
+        });
+
+        // Polling has NOT started, there was only one ajax call to instantiate the map
+        expect($.ajax.calls.count()).toEqual(1);
+      });
+
+      it("should NOT start polling for analyses that don't have a URL yet", function () {
+        this.vis.load(new VizJSON(this.vizjson));
+        this.vis.instantiateMap();
+
+        // Analysis node is created using analyse but node is not associated to any layer or dataview
+        this.vis.analysis.analyse({
+          id: 'something',
+          type: 'source',
+          params: {
+            query: 'SELECT * FROM people'
+          }
+        });
+
+        // Response from Maps API is received
+        $.ajax.calls.argsFor(0)[0].success({
+          'layergroupid': '9d7bf465e45113123bf9949c2a4f0395:0',
+          'metadata': {
+            'layers': [
+              {
+                'type': 'mapnik',
+                'meta': {
+                  'stats': [],
+                  'cartocss': 'cartocss'
+                }
+              }
+            ],
+            'dataviews': { },
+            'analyses': [
+              {
+                'nodes': {
+                  'a0': {
+                    'status': 'ready',
+                    'query': 'SELECT * FROM arboles',
+                    'url': {
+                      'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/5af683d5d8a6f67e11916a31cd76632884d4064f'
+                    }
+                  },
+                  'a1': {
+                    'status': 'ready',
+                    'query': 'select * from analysis_trade_area_e65b1ae05854aea96266808ec0686b91f3ee0a81',
+                    'url': {
+                      'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/e65b1ae05854aea96266808ec0686b91f3ee0a81'
+                    }
+                  },
+                  'a2': {
+                    'status': 'ready',
+                    'query': 'select * from analysis_trade_area_b35b1ae05854aea96266808ec0686b91f3ee0a81',
+                    'url': {
+                      'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/b75b1ae05854aea96266808ec0686b91f3ee0a81'
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          'last_updated': '1970-01-01T00:00:00.000Z'
+        });
+
+        // Polling has NOT started, there was only one ajax call to instantiate the map
+        expect($.ajax.calls.count()).toEqual(1);
+      });
+
+      it('should reload the map when analysis is done', function () {
+        this.vis.load(new VizJSON(this.vizjson));
+        this.vis.instantiateMap();
+
+        // Response from Maps API is received
+        $.ajax.calls.argsFor(0)[0].success({
+          'layergroupid': '9d7bf465e45113123bf9949c2a4f0395:0',
+          'metadata': {
+            'layers': [
+              {
+                'type': 'mapnik',
+                'meta': {
+                  'stats': [],
+                  'cartocss': 'cartocss'
+                }
+              }
+            ],
+            'dataviews': {
+              'cd065428-ed63-4d29-9a09-a9f8384fc8c9': {
+                'url': {
+                  'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/dataview/cd065428-ed63-4d29-9a09-a9f8384fc8c9'
+                }
+              }
+            },
+            'analyses': [
+              {
+                'nodes': {
+                  'a0': {
+                    'status': 'ready',
+                    'query': 'SELECT * FROM arboles',
+                    'url': {
+                      'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/5af683d5d8a6f67e11916a31cd76632884d4064f'
+                    }
+                  },
+                  'a1': {
+                    'status': 'pending',
+                    'query': 'select * from analysis_trade_area_e65b1ae05854aea96266808ec0686b91f3ee0a81',
+                    'url': {
+                      'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/e65b1ae05854aea96266808ec0686b91f3ee0a81'
+                    }
+                  },
+                  'a2': {
+                    'status': 'pending',
+                    'query': 'select * from analysis_trade_area_b35b1ae05854aea96266808ec0686b91f3ee0a81',
+                    'url': {
+                      'http': 'http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/b75b1ae05854aea96266808ec0686b91f3ee0a81'
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          'last_updated': '1970-01-01T00:00:00.000Z'
+        });
+        expect($.ajax.calls.argsFor(0)[0].url).toEqual('http://cdb.localhost.lan:8181/api/v1/map?stat_tag=70af2a72-0709-11e6-a834-080027880ca6');
+        expect($.ajax.calls.argsFor(1)[0].url).toEqual('http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/e65b1ae05854aea96266808ec0686b91f3ee0a81');
+        expect($.ajax.calls.argsFor(2)[0].url).toEqual('http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/b75b1ae05854aea96266808ec0686b91f3ee0a81');
+
+        expect($.ajax.calls.count()).toEqual(3);
+
+        // Analysis endpoint for a1 responds
+        $.ajax.calls.argsFor(1)[0].success({status: 'ready'});
+
+        // Map is not reloaded because a1 is not the source of a layer
+        expect($.ajax.calls.count()).toEqual(3);
+
+        // Analysis endpoint for a2 responds
+        $.ajax.calls.argsFor(2)[0].success({status: 'ready'});
+
+        // Map has been reloaded because a2 is the source of a layer
+        expect($.ajax.calls.count()).toEqual(4);
+        expect($.ajax.calls.argsFor(3)[0].url).toEqual('http://cdb.localhost.lan:8181/api/v1/map?stat_tag=70af2a72-0709-11e6-a834-080027880ca6');
+      });
+    });
+  });
+
+  describe('.done', function () {
+    it('should invoke the callback when model triggers a `done` event', function () {
+      var callback = jasmine.createSpy('callback');
+      this.vis.done(callback);
+
+      this.vis.trigger('done');
+
+      expect(callback).toHaveBeenCalled();
+    });
+  });
+
+  describe('.error', function () {
+    it('should invoke the callback when model triggers an `error` event', function () {
+      var callback = jasmine.createSpy('callback');
+      this.vis.error(callback);
+
+      this.vis.trigger('error');
+
+      expect(callback).toHaveBeenCalled();
+    });
+  });
+
+  describe('when a vizjson has been loaded', function () {
+    beforeEach(function () {
+      this.vis = new Vis();
+    });
+
+    describe('.getLayers', function () {
+      it('should return layers from map', function () {
+        this.vis.load(new VizJSON(fakeVizJSON()));
+
+        expect(this.vis.getLayers().length).toEqual(3);
+      });
+    });
+
+    describe('.getLayer', function () {
+      it('should return the layer in the given index', function () {
+        var vizjson = fakeVizJSON();
+        this.vis.load(new VizJSON(vizjson));
+
+        expect(this.vis.getLayer(0).get('id')).toEqual(vizjson.layers[0].id);
+        expect(this.vis.getLayer(1).get('id')).toEqual(vizjson.layers[1].options.layer_definition.layers[0].id);
+        expect(this.vis.getLayer(2).get('id')).toEqual(vizjson.layers[2].id);
+      });
+    });
+
+    describe('.invalidateSize', function () {
+      it('should just trigger an event', function () {
+        var callback = jasmine.createSpy('callback');
+        this.vis.bind('invalidateSize', callback);
+
+        this.vis.invalidateSize();
+
+        expect(callback).toHaveBeenCalled();
+      });
+    });
+
+    describe('.centerMapToOrigin', function () {
+      it('should invalidate size and re-center the map', function () {
+        var callback = jasmine.createSpy('callback');
+        this.vis.bind('invalidateSize', callback);
+
+        this.vis.load(new VizJSON(fakeVizJSON()));
+
+        spyOn(this.vis.map, 'reCenter');
+
+        this.vis.centerMapToOrigin();
+
+        expect(this.vis.map.reCenter).toHaveBeenCalled();
+        expect(callback).toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -350,7 +350,6 @@ describe('vis/vis', function () {
     it('when https is false all the urls should be transformed to http', function () {
       var vizjson = fakeVizJSON();
 
-      vizjson.https = false;
       vizjson.layers = [{
         type: 'tiled',
         options: {
@@ -358,6 +357,7 @@ describe('vis/vis', function () {
         }
       }];
 
+      this.vis.set('https', false);
       this.vis.load(new VizJSON(vizjson));
 
       expect(this.vis.map.layers.at(0).get('urlTemplate')).toEqual(
@@ -368,7 +368,6 @@ describe('vis/vis', function () {
     it('when https is true all urls should NOT be transformed to http', function () {
       var vizjson = fakeVizJSON();
 
-      vizjson.https = true;
       vizjson.layers = [{
         type: 'tiled',
         options: {
@@ -376,6 +375,7 @@ describe('vis/vis', function () {
         }
       }];
 
+      this.vis.set('https', true);
       this.vis.load(new VizJSON(vizjson));
 
       expect(this.vis.map.layers.at(0).get('urlTemplate')).toEqual(


### PR DESCRIPTION
Prep work for https://github.com/CartoDB/cartodb/issues/7574.

Changes:
- `cdb.createVis` returns a vis model object that responds to `.done` and `.error`. I didn't change how this works and done callback will be called when the map is first instantiated.
- `vis` object triggers `.load` event when vizjson has been loaded so that apps that use `createVis` with `skipMapInstantiation` option can instantiate the map when thy need to when everything is loaded (eg: deep-insights.js -> see https://github.com/CartoDB/deep-insights.js/pull/380).
- To make ^^ happen, I moved model related stuff from `vis-view.js` to `vis.js` (everything related with loading the vizjson).

@viddo: could you please take a look? Thx!