### PR TITLE
Fixing search problem

### DIFF
--- a/src/vis/overlays.js
+++ b/src/vis/overlays.js
@@ -277,7 +277,7 @@ Overlay.register('share', function (data, vis) {});
 Overlay.register('search', function (data, vis) {
   var opts = _.extend(data, {
     mapView: vis.mapView,
-    model: vis.map
+    model: data.map
   });
 
   if (data.template) {


### PR DESCRIPTION
Vis model is not included within vis, now it is available under `data.map`.

cc @alonsogarciapablo 