### PR TITLE
Reloading map when widget with filter is removed

### DIFF
--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -229,7 +229,11 @@ module.exports = Model.extend({
 
   remove: function () {
     if (this.filter) {
+      var isFilterEmpty = this.filter.isEmpty();
       this.filter.remove();
+      if (!isFilterEmpty) {
+        this._reloadMap();
+      }
     }
     this.trigger('destroy', this);
     this.stopListening();

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -274,7 +274,9 @@ describe('dataviews/dataview-model-base', function () {
       this.removeSpy = jasmine.createSpy('remove');
       this.model.once('destroy', this.removeSpy);
       spyOn(this.model, 'stopListening');
-      this.model.filter = jasmine.createSpyObj('filter', ['remove']);
+      spyOn(this.model, '_reloadMap');
+      this.model.filter = jasmine.createSpyObj('filter', ['remove', 'isEmpty']);
+      this.model.filter.isEmpty.and.returnValue(false);
       this.model.remove();
     });
 
@@ -284,6 +286,10 @@ describe('dataviews/dataview-model-base', function () {
 
     it('should remove filter', function () {
       expect(this.model.filter.remove).toHaveBeenCalled();
+    });
+
+    it('should reload the map if there is a filter and it is not empty', function () {
+      expect(this.model._reloadMap).toHaveBeenCalled();
     });
 
     it('should stop listening to events', function () {


### PR DESCRIPTION
Filter and widget were removed correctly, but map was not reloaded. Now it checks if there was a filter applied and it reloads the map.

CR: @alonsogarciapablo 
Fixes https://github.com/CartoDB/cartodb/issues/7812.
cc @saleiva 