### PR TITLE
Ensure dataviews are re-fetched when map is reloaded

### DIFF
--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -136,7 +136,7 @@ module.exports = Model.extend({
   _onChangeBinds: function () {
     this.listenTo(this._map, 'change:center change:zoom', _.debounce(this._onMapBoundsChanged.bind(this), BOUNDING_BOX_FILTER_WAIT));
 
-    this.on('change:url', function (mdl, attrs, opts) {
+    this.on('change:url', function (model, value, opts) {
       if (this.get('sync_on_data_change')) {
         this._newDataAvailable = true;
       }
@@ -165,7 +165,7 @@ module.exports = Model.extend({
 
   _shouldFetchOnURLChange: function (sourceLayerId) {
     var urlChangeTriggeredBySameLayer = sourceLayerId && sourceLayerId === this.layer.get('id');
-    return this.get('sync_on_data_change') && this.get('enabled') && urlChangeTriggeredBySameLayer;
+    return this.get('sync_on_data_change') && this.get('enabled') && (!sourceLayerId || urlChangeTriggeredBySameLayer);
   },
 
   _shouldFetchOnBoundingBoxChange: function () {

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -121,11 +121,20 @@ describe('dataviews/dataview-model-base', function () {
       expect(this.model.fetch).toHaveBeenCalled();
     });
 
+    it('should fetch if url changes and sourceLayerId is not defined', function () {
+      this.model.layer.get.and.returnValue('layerID');
+      spyOn(this.model, 'fetch');
+
+      this.model.set('url', 'http://somethingelese.com');
+
+      expect(this.model.fetch).toHaveBeenCalled();
+    });
+
     it('should not fetch if url changes and event was initiated by a different layer', function () {
       this.model.layer.get.and.returnValue('layerID');
       spyOn(this.model, 'fetch');
 
-      this.model.trigger('change:url', this.model, {
+      this.model.set('url', 'http://somethingelese.com', {
         sourceLayerId: 'differentLayerId'
       });
 


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb.js/issues/1322.

We're only re-fetching dataviews that were associated to the same layer of the dataview that changed (eg: filter changed).

@viddo :+1: ?