### PR TITLE
Expose some errors from Maps API

### DIFF
--- a/src/analysis/analysis-model.js
+++ b/src/analysis/analysis-model.js
@@ -36,6 +36,14 @@ module.exports = Model.extend({
     }
   },
 
+  setOk: function () {
+    this.trigger('ok');
+  },
+
+  setError: function (error) {
+    this.trigger('error', error);
+  },
+
   _initBinds: function () {
     this.bind('change:type', function () {
       this.unbind(null, null, this);

--- a/src/geo/map/layer-model-base.js
+++ b/src/geo/map/layer-model-base.js
@@ -51,6 +51,14 @@ var MapLayer = Model.extend({
 
   // INTERNAL CartoDB.js METHODS
 
+  setOk: function () {
+    this.trigger('ok');
+  },
+
+  setError: function (error) {
+    this.trigger('error', error);
+  },
+
   /*
    * Compare the layer with the received one
    * @method isEqual

--- a/src/vis/model-updater.js
+++ b/src/vis/model-updater.js
@@ -81,6 +81,7 @@ ModelUpdater.prototype._updateAnalysisModels = function (windshaftMap) {
       };
       attrs = _.omit(attrs, analysisNode.getParamNames());
       analysisNode.set(attrs);
+      analysisNode.setOk();
     }
   }, this);
 };
@@ -99,12 +100,18 @@ ModelUpdater.prototype.setErrors = function (errors) {
 };
 
 var ERROR_TYPES = {
-  UNKNOWN: 'unknown'
+  UNKNOWN: 'unknown',
+  ANALYSIS: 'analysis'
 };
 
 ModelUpdater.prototype._setError = function (error) {
   if (error.type === ERROR_TYPES.UNKNOWN) {
     this._visModel.setError(error.message);
+  }
+  if (error.type === ERROR_TYPES.ANALYSIS) {
+    var analysisId = error.analysis.id;
+    var analysisModel = this._analysisCollection.get(analysisId);
+    analysisModel.setError(error.message);
   }
 };
 

--- a/src/vis/model-updater.js
+++ b/src/vis/model-updater.js
@@ -1,5 +1,4 @@
 var _ = require('underscore');
-var WindshaftError = require('../windshaft/error');
 
 /**
  * This class exposes a method that knows how to set/update the metadata on internal

--- a/src/vis/model-updater.js
+++ b/src/vis/model-updater.js
@@ -5,6 +5,9 @@ var _ = require('underscore');
  * CartoDB.js models that are linked to a "resource" in the Maps API.
  */
 var ModelUpdater = function (deps) {
+  if (!deps.visModel) {
+    throw new Error('visModel is required');
+  }
   if (!deps.layerGroupModel) {
     throw new Error('layerGroupModel is required');
   }
@@ -18,6 +21,7 @@ var ModelUpdater = function (deps) {
     throw new Error('analysisCollection is required');
   }
 
+  this._visModel = deps.visModel;
   this._layerGroupModel = deps.layerGroupModel;
   this._layersCollection = deps.layersCollection;
   this._dataviewsCollection = deps.dataviewsCollection;
@@ -29,6 +33,9 @@ ModelUpdater.prototype.updateModels = function (windhsaftMap, sourceLayerId, for
   this._updateLayerModels(windhsaftMap);
   this._updateDataviewModels(windhsaftMap, sourceLayerId, forceFetch);
   this._updateAnalysisModels(windhsaftMap);
+
+
+  this._visModel.setOk();
 };
 
 ModelUpdater.prototype._updateLayerGroupModel = function (windshaftMap) {
@@ -86,6 +93,20 @@ ModelUpdater.prototype._getProtocol = function () {
     return 'http';
   }
   return window.location.protocol.replace(':', '');
+};
+
+ModelUpdater.prototype.setErrors = function (errors) {
+  _.each(errors.errors_with_context, this._setError, this);
+};
+
+var ERROR_TYPES = {
+  UNKNOWN: 'unknown'
+};
+
+ModelUpdater.prototype._setError = function (error) {
+  if (error.type === ERROR_TYPES.UNKNOWN) {
+    this._visModel.setError(error.message);
+  }
 };
 
 module.exports = ModelUpdater;

--- a/src/vis/model-updater.js
+++ b/src/vis/model-updater.js
@@ -34,7 +34,6 @@ ModelUpdater.prototype.updateModels = function (windhsaftMap, sourceLayerId, for
   this._updateDataviewModels(windhsaftMap, sourceLayerId, forceFetch);
   this._updateAnalysisModels(windhsaftMap);
 
-
   this._visModel.setOk();
 };
 

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -15,11 +15,9 @@ var LayersCollection = require('../geo/map/layers');
 var AnalysisPoller = require('../analysis/analysis-poller');
 var Layers = require('./vis/layers');
 
-var STATES = {
-  INIT: 'init', // vis hasn't been sent to Windshaft
-  OK: 'ok', // vis has been sent to Windshaft and everything is ok
-  ERROR: 'error' // vis has been sent to Windshaft and there were some issues
-};
+var STATE_INIT = 'init'; // vis hasn't been sent to Windshaft
+var STATE_OK = 'ok'; // vis has been sent to Windshaft and everything is ok
+var STATE_ERROR = 'error'; // vis has been sent to Windshaft and there were some issues
 
 var VisModel = Backbone.Model.extend({
   defaults: {
@@ -27,7 +25,7 @@ var VisModel = Backbone.Model.extend({
     https: false,
     showLegends: false,
     showEmptyInfowindowFields: false,
-    state: STATES.INIT
+    state: STATE_INIT
   },
 
   initialize: function () {
@@ -42,12 +40,12 @@ var VisModel = Backbone.Model.extend({
 
   setOk: function () {
     this.trigger('ok');
-    this.set('state', STATES.OK);
+    this.set('state', STATE_OK);
   },
 
   done: function (callback) {
     this.once('ok', function () {
-      if (this.get('state') === STATES.INIT) {
+      if (this.get('state') === STATE_INIT) {
         callback(this);
       }
     }, this);
@@ -56,12 +54,12 @@ var VisModel = Backbone.Model.extend({
 
   setError: function (error) {
     this.trigger('error', error);
-    this.set('state', STATES.ERROR);
+    this.set('state', STATE_ERROR);
   },
 
   error: function (callback) {
     this.once('error', function (error) {
-      if (this.get('state') === STATES.INIT) {
+      if (this.get('state') === STATE_INIT) {
         callback(error);
       }
     }, this);

--- a/src/windshaft/anonymous-map.js
+++ b/src/windshaft/anonymous-map.js
@@ -22,6 +22,7 @@ var AnonymousMap = MapBase.extend({
   _calculateLayerJSON: function (layerModel) {
     if (layerModel.isVisible()) {
       return {
+        id: layerModel.get('id'),
         type: layerModel.get('type').toLowerCase(),
         options: this._calculateLayerOptions(layerModel)
       };

--- a/src/windshaft/client.js
+++ b/src/windshaft/client.js
@@ -54,13 +54,7 @@ WindshaftClient.prototype.instantiateMap = function (options) {
       // Ignore error if request was explicitly aborted
       if (textStatus === 'abort') return;
 
-      var errors = {
-        errors: [ 'Unknown error' ],
-        errors_with_context: [{
-          type: 'unknown',
-          message: 'Unknown error'
-        }]
-      };
+      var errors = {};
       try {
         errors = JSON.parse(xhr.responseText);
       } catch (e) {}

--- a/src/windshaft/client.js
+++ b/src/windshaft/client.js
@@ -45,17 +45,23 @@ WindshaftClient.prototype.instantiateMap = function (options) {
   var ajaxOptions = {
     success: function (data) {
       if (data.errors) {
-        errorCallback(data.errors[0]);
+        errorCallback(data);
       } else {
         successCallback(data);
       }
     },
     error: function (xhr) {
-      var err = { errors: ['Unknown error'] };
+      var errors = {
+        errors: [ 'Unknown error' ],
+        errors_with_context: [{
+          type: 'unknown',
+          message: 'Unknown error'
+        }]
+      };
       try {
-        err = JSON.parse(xhr.responseText);
+        errors = JSON.parse(xhr.responseText);
       } catch (e) {}
-      errorCallback(err.errors[0]);
+      errorCallback(errors);
     }
   };
 

--- a/src/windshaft/error.js
+++ b/src/windshaft/error.js
@@ -1,0 +1,37 @@
+var ERROR_TYPE_LAYER = 'layer';
+var ERROR_TYPE_ANALYSIS = 'analysis';
+
+var WindshaftError = function (error) {
+  this._error = error;
+
+  this.type = error.subtype;
+  this.message = error.message;
+  this.context = error.context;
+
+  if (this._isLayerError(error.type)) {
+    this.context = error.layer && error.layer.context;
+    this.layerId = error.layer.id;
+  }
+  if (this._isAnalysisError(error.type)) {
+    this.context = error.analysis && error.analysis.context;
+    this.analysisId = error.analysis.id;
+  }
+};
+
+WindshaftError.prototype.isLayerError = function () {
+  return this._isLayerError(this._error.type);
+};
+
+WindshaftError.prototype._isLayerError = function (errorType) {
+  return errorType === ERROR_TYPE_LAYER;
+};
+
+WindshaftError.prototype.isAnalysisError = function () {
+  return this._isAnalysisError(this._error.type);
+};
+
+WindshaftError.prototype._isAnalysisError = function (errorType) {
+  return errorType === ERROR_TYPE_ANALYSIS;
+};
+
+module.exports = WindshaftError;

--- a/src/windshaft/error.js
+++ b/src/windshaft/error.js
@@ -8,29 +8,23 @@ var WindshaftError = function (error) {
   this.message = error.message;
   this.context = error.context;
 
-  if (this._isLayerError(error.type)) {
+  if (this.isLayerError(error.type)) {
     this.context = error.layer && error.layer.context;
     this.layerId = error.layer.id;
   }
-  if (this._isAnalysisError(error.type)) {
+  if (this.isAnalysisError(error.type)) {
     this.context = error.analysis && error.analysis.context;
     this.analysisId = error.analysis.id;
   }
 };
 
-WindshaftError.prototype.isLayerError = function () {
-  return this._isLayerError(this._error.type);
-};
-
-WindshaftError.prototype._isLayerError = function (errorType) {
+WindshaftError.prototype.isLayerError = function (errorType) {
+  errorType = errorType || this._error.type;
   return errorType === ERROR_TYPE_LAYER;
 };
 
-WindshaftError.prototype.isAnalysisError = function () {
-  return this._isAnalysisError(this._error.type);
-};
-
-WindshaftError.prototype._isAnalysisError = function (errorType) {
+WindshaftError.prototype.isAnalysisError = function (errorType) {
+  errorType = errorType || this._error.type;
   return errorType === ERROR_TYPE_ANALYSIS;
 };
 

--- a/src/windshaft/map-base.js
+++ b/src/windshaft/map-base.js
@@ -95,11 +95,11 @@ var WindshaftMap = Backbone.Model.extend({
         this.trigger('instanceCreated');
         options.success && options.success(this);
       }.bind(this),
-      error: function (error) {
-        this._trackRequest(request, error);
-        var errorMsg = 'Request to Maps API failed: ' + error;
-        log.error(errorMsg);
-        options.error && options.error(errorMsg);
+      error: function (errors) {
+        this._trackRequest(request, errors);
+        log.error('Request to Maps API failed: ' + errors);
+        this._modelUpdater.setErrors(errors);
+        options.error && options.error();
       }.bind(this)
     });
   },

--- a/src/windshaft/map-base.js
+++ b/src/windshaft/map-base.js
@@ -5,6 +5,7 @@ var EMPTY_GIF = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAA
 var log = require('cdb.log');
 var Request = require('./request');
 var RequestTracker = require('./request-tracker');
+var WindshaftError = require('./error');
 
 var TILE_EXTENSIONS_BY_LAYER_TYPE = {
   'mapnik': '.png',
@@ -88,20 +89,38 @@ var WindshaftMap = Backbone.Model.extend({
     this.client.instantiateMap({
       mapDefinition: payload,
       params: params,
-      success: function (mapInstance) {
-        this._trackRequest(request, mapInstance);
-        this.set(mapInstance);
+      success: function (response) {
+        this._trackRequest(request, response);
+        this.set(response);
         this._modelUpdater.updateModels(this, options.sourceLayerId, options.forceFetch);
         this.trigger('instanceCreated');
         options.success && options.success(this);
       }.bind(this),
-      error: function (errors) {
-        this._trackRequest(request, errors);
-        log.error('Request to Maps API failed: ' + errors);
-        this._modelUpdater.setErrors(errors);
+      error: function (response) {
+        this._trackRequest(request, response);
+
+        var windshaftErrors = this._getErrorsFromResponse(response);
+        this._modelUpdater.setErrors(windshaftErrors);
+
+        log.error('Request to Maps API failed');
         options.error && options.error();
       }.bind(this)
     });
+  },
+
+  _getErrorsFromResponse: function (response) {
+    if (response.errors_with_context) {
+      return _.map(response.errors_with_context, function (error) {
+        return new WindshaftError(error);
+      });
+    }
+    if (response.errors) {
+      return [
+        new WindshaftError({ message: response.errors[0] })
+      ];
+    }
+
+    return [];
   },
 
   _getParams: function () {

--- a/test/spec/analysis/analysis-model.spec.js
+++ b/test/spec/analysis/analysis-model.spec.js
@@ -265,4 +265,26 @@ describe('src/analysis/analysis-model.js', function () {
       expect(this.analysisModel.isDone()).toEqual(false);
     });
   });
+
+  describe('.setOk', function () {
+    it("should trigger 'ok' event", function () {
+      var callback = jasmine.createSpy('callback');
+      this.analysisModel.on('ok', callback);
+
+      this.analysisModel.setOk();
+
+      expect(callback).toHaveBeenCalled();
+    });
+  });
+
+  describe('.setError', function () {
+    it("should trigger 'error' event", function () {
+      var callback = jasmine.createSpy('callback');
+      this.analysisModel.on('error', callback);
+
+      this.analysisModel.setError();
+
+      expect(callback).toHaveBeenCalled();
+    });
+  });
 });

--- a/test/spec/api/create-vis.spec.js
+++ b/test/spec/api/create-vis.spec.js
@@ -2,6 +2,7 @@ var _ = require('underscore');
 var $ = require('jquery');
 var Loader = require('../../../src/core/loader');
 var createVis = require('../../../src/api/create-vis');
+var VizJSON = require('../../../src/api/vizjson');
 var fakeVizJSON = require('./fake-vizjson');
 
 describe('src/api/create-vis', function () {
@@ -37,29 +38,27 @@ describe('src/api/create-vis', function () {
     }.bind(this)).not.toThrowError();
   });
 
-  it('should load the vizjson file from a URL', function (done) {
+  it('should load the vizjson file from a URL', function () {
     spyOn(Loader, 'get');
-    var vis = createVis(this.containerId, 'http://example.com/vizjson');
+    var vis = createVis(this.containerId, 'http://example.com/vizjson', {
+      skipMapInstantiation: true
+    });
+    spyOn(vis, 'load');
 
     // Simulate a successful response from Loader.get
     var loaderCallback = Loader.get.calls.mostRecent().args[1];
     loaderCallback(fakeVizJSON);
 
-    vis.done(function (vis, layers) {
-      expect(vis).toBeDefined();
-      expect(layers).toBeDefined();
-      done();
-    });
+    expect(vis.load).toHaveBeenCalledWith(jasmine.any(VizJSON));
   });
 
   it('should use the given vizjson object', function () {
     spyOn(Loader, 'get');
-    var vis = createVis(this.containerId, fakeVizJSON);
-    expect(Loader.get).not.toHaveBeenCalled();
-    vis.done(function (vis, layers) {
-      expect(vis).toBeDefined();
-      expect(layers).toBeDefined();
+    createVis(this.containerId, fakeVizJSON, {
+      skipMapInstantiation: true
     });
+
+    expect(Loader.get).not.toHaveBeenCalled();
   });
 
   it('should set the given center if values are correct', function () {

--- a/test/spec/vis/model-updater.spec.js
+++ b/test/spec/vis/model-updater.spec.js
@@ -47,7 +47,6 @@ describe('src/vis/model-updater', function () {
 
     it('should update layer models', function () {
       var layer0 = new Backbone.Model({ type: 'Tiled' });
-      layer0.setOk = jasmine.createSpy();
       var layer1 = new Backbone.Model({ type: 'CartoDB' });
       layer1.setOk = jasmine.createSpy();
       var layer2 = new Backbone.Model({ type: 'torque' });
@@ -71,7 +70,6 @@ describe('src/vis/model-updater', function () {
 
       this.modelUpdater.updateModels(this.windshaftMap);
 
-      expect(layer0.setOk).toHaveBeenCalled();
       expect(layer1.get('meta')).toEqual('metadataLayer0');
       expect(layer1.setOk).toHaveBeenCalled();
       expect(layer2.get('meta')).toEqual('metadataLayer1');

--- a/test/spec/vis/model-updater.spec.js
+++ b/test/spec/vis/model-updater.spec.js
@@ -1,5 +1,6 @@
 var Backbone = require('backbone');
 var ModelUpdater = require('../../../src/vis/model-updater');
+var WindshaftError = require('../../../src/windshaft/error');
 
 describe('src/vis/model-updater', function () {
   beforeEach(function () {
@@ -46,8 +47,11 @@ describe('src/vis/model-updater', function () {
 
     it('should update layer models', function () {
       var layer0 = new Backbone.Model({ type: 'Tiled' });
+      layer0.setOk = jasmine.createSpy();
       var layer1 = new Backbone.Model({ type: 'CartoDB' });
+      layer1.setOk = jasmine.createSpy();
       var layer2 = new Backbone.Model({ type: 'torque' });
+      layer2.setOk = jasmine.createSpy();
       this.layersCollection.reset([ layer0, layer1, layer2 ]);
 
       this.windshaftMap.getLayerMetadata = function (index) {
@@ -67,9 +71,12 @@ describe('src/vis/model-updater', function () {
 
       this.modelUpdater.updateModels(this.windshaftMap);
 
+      expect(layer0.setOk).toHaveBeenCalled();
       expect(layer1.get('meta')).toEqual('metadataLayer0');
+      expect(layer1.setOk).toHaveBeenCalled();
       expect(layer2.get('meta')).toEqual('metadataLayer1');
       expect(layer2.get('urls')).toEqual('tileURLS');
+      expect(layer2.setOk).toHaveBeenCalled();
     });
 
     it('should update dataview models', function () {
@@ -187,17 +194,19 @@ describe('src/vis/model-updater', function () {
 
   describe('.setErrors', function () {
     it('should set vis state to error', function () {
-      this.modelUpdater.setErrors({
-        errors: [],
-        errors_with_context: [
-          {
-            type: 'unknown',
-            message: 'something went wrong!'
-          }
-        ]
-      });
+      this.modelUpdater.setErrors([
+        new WindshaftError({
+          type: 'unknown',
+          message: 'something went wrong!'
+        })
+      ]);
 
-      expect(this.visModel.setError).toHaveBeenCalledWith('something went wrong!');
+      expect(this.visModel.setError).toHaveBeenCalled();
+      var error = this.visModel.setError.calls.argsFor(0)[0];
+
+      expect(error.type).toBeUndefined();
+      expect(error.message).toEqual('something went wrong!');
+      expect(error.context).toBeUndefined();
     });
 
     it('should "mark" analysis as erroneous', function () {
@@ -208,17 +217,83 @@ describe('src/vis/model-updater', function () {
 
       this.analysisCollection.reset([ analysis ]);
 
-      this.modelUpdater.setErrors({
-        errors_with_context: [{
+      this.modelUpdater.setErrors([
+        new WindshaftError({
           type: 'analysis',
           message: 'Missing required param "radius"',
           analysis: {
-            id: 'ANALYSIS_ID'
+            id: 'ANALYSIS_ID',
+            context: {
+              something: 'else'
+            }
           }
-        }]
-      });
+        })
+      ]);
 
-      expect(analysis.setError).toHaveBeenCalledWith('Missing required param "radius"');
+      expect(analysis.setError).toHaveBeenCalled();
+      var error = analysis.setError.calls.argsFor(0)[0];
+
+      expect(error.type).toBeUndefined();
+      expect(error.analysisId).toEqual('ANALYSIS_ID');
+      expect(error.message).toEqual('Missing required param "radius"');
+      expect(error.context).toEqual({
+        something: 'else'
+      });
+    });
+
+    it('should "mark" layer as erroroneus', function () {
+      var layer = new Backbone.Model({
+        id: 'LAYER_ID'
+      });
+      layer.setError = jasmine.createSpy('setError');
+
+      this.layersCollection.reset([ layer ]);
+
+      this.modelUpdater.setErrors([
+        new WindshaftError({
+          type: 'layer',
+          subtype: 'turbo-carto',
+          message: 'turbo-carto: something went wrong',
+          layer: {
+            index: 0,
+            id: 'LAYER_ID',
+            type: 'cartodb',
+            context: {
+              selector: '#layer',
+              source: {
+                start: {
+                  line: 1,
+                  column: 10
+                },
+                end: {
+                  line: 1,
+                  column: 61
+                }
+              }
+            }
+          }
+        })
+      ]);
+
+      expect(layer.setError).toHaveBeenCalled();
+      var error = layer.setError.calls.argsFor(0)[0];
+
+      expect(error.type).toEqual('turbo-carto');
+      expect(error.layerId).toEqual('LAYER_ID');
+      expect(error.message).toEqual('turbo-carto: something went wrong');
+      expect(error.context).toEqual({
+        selector: '#layer',
+        source: {
+          start: {
+            line: 1,
+            column: 10
+          },
+          end: {
+            line: 1,
+            column: 61
+          }
+        }
+      });
     });
   });
 });

--- a/test/spec/vis/model-updater.spec.js
+++ b/test/spec/vis/model-updater.spec.js
@@ -111,10 +111,12 @@ describe('src/vis/model-updater', function () {
       expect(dataview2.get('url')).toEqual('http://example2.com');
     });
 
-    it('should update analysis models', function () {
+    it('should update analysis models and "mark" them as ok', function () {
       var getParamNames = function () { return []; };
       var analysis1 = new Backbone.Model({ id: 'a1' });
+      analysis1.setOk = jasmine.createSpy('setOk');
       var analysis2 = new Backbone.Model({ id: 'a2' });
+      analysis2.setOk = jasmine.createSpy('setOk');
       this.analysisCollection.reset([ analysis1, analysis2 ]);
       analysis1.getParamNames = analysis2.getParamNames = getParamNames;
 
@@ -144,9 +146,11 @@ describe('src/vis/model-updater', function () {
       expect(analysis1.get('status')).toEqual('status_a1');
       expect(analysis1.get('query')).toEqual('query_a1');
       expect(analysis1.get('url')).toEqual('url_a1');
+      expect(analysis1.setOk).toHaveBeenCalled();
       expect(analysis2.get('status')).toEqual('status_a2');
       expect(analysis2.get('query')).toEqual('query_a2');
       expect(analysis2.get('url')).toEqual('url_a2');
+      expect(analysis2.setOk).toHaveBeenCalled();
     });
 
     it('should not update attributes that are original params (eg: query)', function () {
@@ -193,6 +197,27 @@ describe('src/vis/model-updater', function () {
       });
 
       expect(this.visModel.setError).toHaveBeenCalledWith('something went wrong!');
+    });
+
+    it('should "mark" analysis as erroneous', function () {
+      var analysis = new Backbone.Model({
+        id: 'ANALYSIS_ID'
+      });
+      analysis.setError = jasmine.createSpy('setError');
+
+      this.analysisCollection.reset([ analysis ]);
+
+      this.modelUpdater.setErrors({
+        errors_with_context: [{
+          type: 'analysis',
+          message: 'Missing required param "radius"',
+          analysis: {
+            id: 'ANALYSIS_ID'
+          }
+        }]
+      });
+
+      expect(analysis.setError).toHaveBeenCalledWith('Missing required param "radius"');
     });
   });
 });

--- a/test/spec/vis/model-updater.spec.js
+++ b/test/spec/vis/model-updater.spec.js
@@ -11,12 +11,16 @@ describe('src/vis/model-updater', function () {
       return 'tileJSON';
     };
 
+    this.visModel = new Backbone.Model();
+    this.visModel.setOk = jasmine.createSpy('setOk');
+    this.visModel.setError = jasmine.createSpy('setError');
     this.layerGroupModel = new Backbone.Model();
     this.layersCollection = new Backbone.Collection();
     this.analysisCollection = new Backbone.Collection();
     this.dataviewsCollection = new Backbone.Collection();
 
     this.modelUpdater = new ModelUpdater({
+      visModel: this.visModel,
       layerGroupModel: this.layerGroupModel,
       layersCollection: this.layersCollection,
       dataviewsCollection: this.dataviewsCollection,
@@ -167,6 +171,28 @@ describe('src/vis/model-updater', function () {
       expect(analysis1.get('status')).toEqual('new_status');
       expect(analysis1.get('query')).toEqual('original_query');
       expect(analysis1.get('url')).toEqual('new_url');
+    });
+
+    it('should set vis state to ok', function () {
+      this.modelUpdater.updateModels(this.windshaftMap);
+
+      expect(this.visModel.setOk).toHaveBeenCalled();
+    });
+  });
+
+  describe('.setErrors', function () {
+    it('should set vis state to error', function () {
+      this.modelUpdater.setErrors({
+        errors: [],
+        errors_with_context: [
+          {
+            type: 'unknown',
+            message: 'something went wrong!'
+          }
+        ]
+      });
+
+      expect(this.visModel.setError).toHaveBeenCalledWith('something went wrong!');
     });
   });
 });

--- a/test/spec/vis/model-updater.spec.js
+++ b/test/spec/vis/model-updater.spec.js
@@ -156,6 +156,7 @@ describe('src/vis/model-updater', function () {
     it('should not update attributes that are original params (eg: query)', function () {
       var analysis1 = new Backbone.Model({ id: 'a1', query: 'original_query' });
       analysis1.getParamNames = function () { return ['query']; };
+      analysis1.setOk = jasmine.createSpy('setOk');
       this.analysisCollection.reset([ analysis1 ]);
 
       this.windshaftMap.getAnalysisNodeMetadata = function (analysisId) {

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -831,24 +831,94 @@ describe('vis/vis', function () {
   });
 
   describe('.done', function () {
-    it('should invoke the callback when model triggers a `done` event', function () {
+    it('should invoke the callback once when model triggers the `ok` events and state is `init`', function () {
       var callback = jasmine.createSpy('callback');
       this.vis.done(callback);
 
-      this.vis.trigger('done');
+      this.vis.trigger('ok');
 
       expect(callback).toHaveBeenCalled();
+      callback.calls.reset();
+
+      this.vis.trigger('ok');
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should NOT invoke the callback when model triggers `ok` event and state is NOT `init`', function () {
+      var callback = jasmine.createSpy('callback');
+      this.vis.done(callback);
+      this.vis.setError(); // Map couldn't be previously instantiated
+
+      this.vis.trigger('ok'); // Everything is fine now
+
+      // Done callback is not invoked cause error callback was called before
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('state', function () {
+    it("should be initialized to the 'init' state", function () {
+      expect(this.vis.get('state')).toEqual('init');
+    });
+
+    describe('.setOk', function () {
+      it("should change state to 'ok'", function () {
+        this.vis.setOk();
+        expect(this.vis.get('state')).toEqual('ok');
+      });
+
+      it("should trigger 'ok' event", function () {
+        var callback = jasmine.createSpy('callback');
+        this.vis.on('ok', callback);
+
+        this.vis.setOk();
+
+        expect(callback).toHaveBeenCalledWith();
+      });
+    });
+
+    describe('.setError', function () {
+      it("should change state to 'error'", function () {
+        this.vis.setError();
+        expect(this.vis.get('state')).toEqual('error');
+      });
+
+      it("should trigger 'error' event", function () {
+        var callback = jasmine.createSpy('callback');
+        this.vis.on('error', callback);
+
+        this.vis.setError('something went wrong!');
+
+        expect(callback).toHaveBeenCalledWith('something went wrong!');
+      });
     });
   });
 
   describe('.error', function () {
-    it('should invoke the callback when model triggers an `error` event', function () {
+    it('should invoke the callback when model triggers the first `error` event and state is `init`', function () {
       var callback = jasmine.createSpy('callback');
       this.vis.error(callback);
 
       this.vis.trigger('error');
 
       expect(callback).toHaveBeenCalled();
+      callback.calls.reset();
+
+      this.vis.trigger('error');
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should NOT invoke the callback when model triggers `error` event and state is NOT `init`', function () {
+      var callback = jasmine.createSpy('callback');
+      this.vis.error(callback);
+      this.vis.setOk(); // Map was correctly instantiated
+
+      this.vis.trigger('error'); // There are some errors now
+
+      // Error callback is not invoked cause done callback was called before
+      expect(callback).not.toHaveBeenCalled();
     });
   });
 

--- a/test/spec/windshaft/anonymous-map.spec.js
+++ b/test/spec/windshaft/anonymous-map.spec.js
@@ -83,6 +83,7 @@ describe('windshaft/anonymous-map', function () {
       expect(this.map.toJSON()).toEqual({
         'layers': [
           {
+            'id': 'layer1',
             'type': 'cartodb',
             'options': {
               'cartocss': 'cartoCSS1',
@@ -92,6 +93,7 @@ describe('windshaft/anonymous-map', function () {
             }
           },
           {
+            'id': 'layer2',
             'type': 'cartodb',
             'options': {
               'cartocss': 'cartoCSS2',
@@ -101,6 +103,7 @@ describe('windshaft/anonymous-map', function () {
             }
           },
           {
+            'id': 'layer3',
             'type': 'cartodb',
             'options': {
               'cartocss': 'cartoCSS3',
@@ -122,6 +125,7 @@ describe('windshaft/anonymous-map', function () {
       expect(this.map.toJSON()).toEqual({
         'layers': [
           {
+            'id': 'layer2',
             'type': 'cartodb',
             'options': {
               'sql': 'sql2',
@@ -140,6 +144,7 @@ describe('windshaft/anonymous-map', function () {
       this.cartoDBLayer1.set('sql_wrap', 'sql_wrap_1', { silent: true });
 
       expect(this.map.toJSON().layers[0]).toEqual({
+        'id': 'layer1',
         'type': 'cartodb',
         'options': {
           'cartocss': 'cartoCSS1',
@@ -157,6 +162,7 @@ describe('windshaft/anonymous-map', function () {
       expect(this.map.toJSON()).toEqual({
         'layers': [
           {
+            'id': 'layer1',
             'type': 'cartodb',
             'options': {
               'cartocss': 'cartoCSS1',
@@ -173,6 +179,7 @@ describe('windshaft/anonymous-map', function () {
             }
           },
           {
+            'id': 'layer2',
             'type': 'cartodb',
             'options': {
               'cartocss': 'cartoCSS2',
@@ -182,6 +189,7 @@ describe('windshaft/anonymous-map', function () {
             }
           },
           {
+            'id': 'layer3',
             'type': 'cartodb',
             'options': {
               'cartocss': 'cartoCSS3',
@@ -198,6 +206,7 @@ describe('windshaft/anonymous-map', function () {
 
     it('should NOT include interactivity and attributes options for "torque" layers', function () {
       this.layersCollection.reset(new TorqueLayer({
+        id: 'torqueId',
         sql: 'sql',
         cartocss: 'cartocss'
       }));
@@ -205,6 +214,7 @@ describe('windshaft/anonymous-map', function () {
       expect(this.map.toJSON()).toEqual({
         'layers': [
           {
+            'id': 'torqueId',
             'type': 'torque',
             'options': {
               'sql': 'sql',

--- a/test/spec/windshaft/client.spec.js
+++ b/test/spec/windshaft/client.spec.js
@@ -88,11 +88,17 @@ describe('windshaft/client', function () {
         error: errorCallback
       });
 
-      this.ajaxParams.success({
-        errors: [ 'something went wrong!' ]
-      });
+      var errors = {
+        errors: [ 'the error message' ],
+        errors_with_context: {
+          type: 'unknown',
+          message: 'the error message'
+        }
+      };
 
-      expect(errorCallback).toHaveBeenCalledWith('something went wrong!');
+      this.ajaxParams.success(errors);
+
+      expect(errorCallback).toHaveBeenCalledWith(errors);
     });
 
     it('should invoke the error callback if ajax request goes wrong', function () {
@@ -106,7 +112,17 @@ describe('windshaft/client', function () {
 
       this.ajaxParams.error({ responseText: 'something went wrong!' });
 
-      expect(errorCallback).toHaveBeenCalledWith('Unknown error');
+      expect(errorCallback).toHaveBeenCalledWith(
+        {
+          errors: [ 'Unknown error' ],
+          errors_with_context: [
+            {
+              type: 'unknown',
+              message: 'Unknown error'
+            }
+          ]
+        }
+      );
     });
 
     it('should use POST if forceCors is true', function () {

--- a/test/spec/windshaft/client.spec.js
+++ b/test/spec/windshaft/client.spec.js
@@ -224,7 +224,7 @@ describe('windshaft/client', function () {
         });
 
         expect(this.fakeXHR.abort).toHaveBeenCalled();
-        
+
         expect(errorCallback).not.toHaveBeenCalled();
       });
 

--- a/test/spec/windshaft/client.spec.js
+++ b/test/spec/windshaft/client.spec.js
@@ -219,8 +219,11 @@ describe('windshaft/client', function () {
       });
 
       it('should cancel previous requests when using GET requests', function () {
+        var errorCallback = jasmine.createSpy('errorCallback');
+
         this.client.instantiateMap({
-          mapDefinition: { some: 'json that must be encoded' }
+          mapDefinition: { some: 'json that must be encoded' },
+          error: errorCallback
         });
 
         expect($.ajax.calls.argsFor(0)[0].method).toEqual('GET');
@@ -231,6 +234,8 @@ describe('windshaft/client', function () {
         });
 
         expect(this.fakeXHR.abort).toHaveBeenCalled();
+        
+        expect(errorCallback).not.toHaveBeenCalled();
       });
 
       it('should cancel previous requests when using POST requests', function () {

--- a/test/spec/windshaft/client.spec.js
+++ b/test/spec/windshaft/client.spec.js
@@ -110,19 +110,9 @@ describe('windshaft/client', function () {
         error: errorCallback
       });
 
-      this.ajaxParams.error({ responseText: 'something went wrong!' });
+      this.ajaxParams.error({ responseText: JSON.stringify({ something: 'else' }) });
 
-      expect(errorCallback).toHaveBeenCalledWith(
-        {
-          errors: [ 'Unknown error' ],
-          errors_with_context: [
-            {
-              type: 'unknown',
-              message: 'Unknown error'
-            }
-          ]
-        }
-      );
+      expect(errorCallback).toHaveBeenCalledWith({ something: 'else' });
     });
 
     it('should ignore the error callback if request was aborted', function () {

--- a/test/spec/windshaft/map-base.spec.js
+++ b/test/spec/windshaft/map-base.spec.js
@@ -309,7 +309,9 @@ describe('windshaft/map-base', function () {
     describe('when request fails', function () {
       beforeEach(function () {
         spyOn(this.client, 'instantiateMap').and.callFake(function (options) {
-          options.error('something went wrong');
+          options.error({
+            errors: ['something went wrong']
+          });
         });
         spyOn(log, 'error');
         this.errorCallback = jasmine.createSpy('errorCallback');
@@ -320,11 +322,44 @@ describe('windshaft/map-base', function () {
       });
 
       it('should log the error', function () {
-        expect(log.error).toHaveBeenCalledWith('Request to Maps API failed: something went wrong');
+        expect(log.error).toHaveBeenCalledWith('Request to Maps API failed');
       });
 
       it('should invoke a given error callback', function () {
         expect(this.errorCallback).toHaveBeenCalledWith();
+      });
+
+      it('should should update models and use first error message', function () {
+        expect(this.modelUpdater.setErrors).toHaveBeenCalled();
+        var errors = this.modelUpdater.setErrors.calls.argsFor(0)[0];
+
+        expect(errors.length).toEqual(1);
+        expect(errors[0].message).toEqual('something went wrong');
+      });
+
+      it('should use errors with context when present', function () {
+        this.modelUpdater.setErrors.calls.reset();
+        this.client.instantiateMap.and.callFake(function (options) {
+          options.error({
+            errors_with_context: [{
+              type: 'layer',
+              subtype: 'layer-subtype',
+              message: 'Something is wrong with this layer',
+              layer: {
+                id: 'layerID'
+              }
+            }]
+          });
+        });
+
+        this.windshaftMap.createInstance();
+
+        var errors = this.modelUpdater.setErrors.calls.argsFor(0)[0];
+
+        expect(errors.length).toEqual(1);
+        expect(errors[0].type).toEqual('layer-subtype');
+        expect(errors[0].message).toEqual('Something is wrong with this layer');
+        expect(errors[0].layerId).toEqual('layerID');
       });
     });
   });

--- a/test/spec/windshaft/map-base.spec.js
+++ b/test/spec/windshaft/map-base.spec.js
@@ -48,7 +48,7 @@ describe('windshaft/map-base', function () {
     this.dataviewsCollection = new Backbone.Collection();
     this.layersCollection = new Backbone.Collection();
     this.analysisCollection = new Backbone.Collection();
-    this.modelUpdater = jasmine.createSpyObj('modelUpdater', ['updateModels']);
+    this.modelUpdater = jasmine.createSpyObj('modelUpdater', ['updateModels', 'setErrors']);
     this.client = new WindshaftClient({
       endpoint: 'v1',
       urlTemplate: 'http://{user}.wadus.com',
@@ -324,7 +324,7 @@ describe('windshaft/map-base', function () {
       });
 
       it('should invoke a given error callback', function () {
-        expect(this.errorCallback).toHaveBeenCalledWith('Request to Maps API failed: something went wrong');
+        expect(this.errorCallback).toHaveBeenCalledWith();
       });
     });
   });


### PR DESCRIPTION
First iteration on https://github.com/CartoDB/cartodb/issues/7574.

So far:

- `vis` model triggers:
  - `ok` event when a new instance of the "map" is created successfully in the Maps API.
  - `error` event when an unknown error occured error occurred (other errors will be triggered by more specific models like layers). **Error event will only include an error message for now (we can iterate on this and send more info)**.
- `vis` model still supports `.done(callback)` and `.error(callback)`. One of these two callbacks will be invoked when `cdb.createVis` is used without the `skipMapInstantiation` option:

  ```
  var vis = createVis(...);
  vis.done(function () { ... });
  vis.error(function (error) { ... });

  // Also, we can listen to `ok` and `error` events
  vis.on('ok', function () { ... });
  vis.on('error'), function () { ... });
  ```

- When using `cdb.createVis` and setting `skipMapInstantiation` is set to true (only happening in `deep-insights.js` currently) `.done` or `.error` callback will be invoked once `vis.instantiateMap` has been executed:

  ```
  var vis = createVis(..., { skipMapInstantiation: true });
  vis.done(function () { ... });
  vis.error(function (error) { ... });
  vis.on('load', function (vis) { // Waits for the vizjson to be loaded
    vis.instantiateMap();
  )};

  // Also, we can listen to `ok` and `error` events
  vis.on('ok', function () { ... });
  vis.on('error'), function () { ... });
  ```

My plan is to follow a similar approach for layer, dataviews and analysis models:
  - models expose a `setOk` and `setError` methods, that basically trigger `ok` and `error` events.
  - `ModelUpdater#setErrors` knows how errors coming from the Maps API and "distribute" them to the corresponding models based on the error type.

@viddo I'd love to get some feedback on this, before following the same approach for other models. Thx!

UPDATE: I pushed https://github.com/CartoDB/cartodb.js/pull/1324/commits/1163bfc318b332a92228223b41e8bd4da3dccc51, which implements something similar for analysis models.

cc: @xavijam 