### PR TITLE
Requests to Windshaft include auth_token param

### DIFF
--- a/src/analysis/analysis-factory.js
+++ b/src/analysis/analysis-factory.js
@@ -14,6 +14,7 @@ var AnalysisFactory = function (opts) {
   this._camshaftReference = opts.camshaftReference || camshaftReference;
   this._analysisCollection = opts.analysisCollection;
   this._apiKey = opts.apiKey;
+  this._authToken = opts.authToken;
   this._map = opts.map;
 };
 
@@ -33,6 +34,9 @@ AnalysisFactory.prototype.analyse = function (analysisDefinition) {
   } else {
     if (this._apiKey) {
       analysisAttrs.apiKey = this._apiKey;
+    }
+    if (this._authToken) {
+      analysisAttrs.authToken = this._authToken;
     }
     analysis = new Analysis(analysisAttrs, {
       camshaftReference: this._camshaftReference,

--- a/src/analysis/analysis-model.js
+++ b/src/analysis/analysis-model.js
@@ -31,6 +31,8 @@ module.exports = Model.extend({
     if (url) {
       if (this.get('apiKey')) {
         url += '?api_key=' + this.get('apiKey');
+      } else if (this.get('authToken')) {
+        url += '?auth_token=' + this.get('authToken');
       }
       return url;
     }

--- a/src/api/create-vis.js
+++ b/src/api/create-vis.js
@@ -32,6 +32,7 @@ var createVis = function (el, vizjson, options) {
     title: options.title || vizjson.title,
     description: options.description || vizjson.description,
     apiKey: options.apiKey,
+    authToken: vizjson.auth_tokens && vizjson.auth_tokens.length && vizjson.auth_tokens[0],
     showLegends: options.legends === true || vizjson.legends === true,
     showEmptyInfowindowFields: options.show_empty_infowindow_fields === true,
     https: isProtocolHTTPs || options.https === true || vizjson.https === true

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -24,6 +24,8 @@ module.exports = Model.extend({
 
     if (this.get('apiKey')) {
       params.push('api_key=' + this.get('apiKey'));
+    } else if (this.get('authToken')) {
+      params.push('auth_token=' + this.get('authToken'));
     }
     return this.get('url') + '?' + params.join('&');
   },

--- a/src/dataviews/dataviews-factory.js
+++ b/src/dataviews/dataviews-factory.js
@@ -23,14 +23,9 @@ module.exports = Model.extend({
 
   createCategoryModel: function (layerModel, attrs) {
     _checkProperties(attrs, ['column']);
-
-    attrs = _.pick(attrs, CategoryDataviewModel.ATTRS_NAMES);
+    attrs = this._generateAttrsForDataview(layerModel, attrs, CategoryDataviewModel.ATTRS_NAMES);
     attrs.aggregation = attrs.aggregation || 'count';
     attrs.aggregation_column = attrs.aggregation_column || attrs.column;
-    attrs.source = attrs.source || { id: layerModel.id };
-    if (this.get('apiKey')) {
-      attrs.apiKey = this.get('apiKey');
-    }
 
     var categoryFilter = new CategoryFilter({
       layer: layerModel
@@ -47,12 +42,7 @@ module.exports = Model.extend({
 
   createFormulaModel: function (layerModel, attrs) {
     _checkProperties(attrs, ['column', 'operation']);
-    attrs = _.pick(attrs, FormulaDataviewModel.ATTRS_NAMES);
-    attrs.source = attrs.source || { id: layerModel.id };
-    if (this.get('apiKey')) {
-      attrs.apiKey = this.get('apiKey');
-    }
-
+    attrs = this._generateAttrsForDataview(layerModel, attrs, FormulaDataviewModel.ATTRS_NAMES);
     return this._newModel(
       new FormulaDataviewModel(attrs, {
         map: this._map,
@@ -63,11 +53,7 @@ module.exports = Model.extend({
 
   createHistogramModel: function (layerModel, attrs) {
     _checkProperties(attrs, ['column']);
-    attrs = _.pick(attrs, HistogramDataviewModel.ATTRS_NAMES);
-    attrs.source = attrs.source || { id: layerModel.id };
-    if (this.get('apiKey')) {
-      attrs.apiKey = this.get('apiKey');
-    }
+    attrs = this._generateAttrsForDataview(layerModel, attrs, HistogramDataviewModel.ATTRS_NAMES);
 
     var rangeFilter = new RangeFilter({
       layer: layerModel
@@ -84,18 +70,25 @@ module.exports = Model.extend({
 
   createListModel: function (layerModel, attrs) {
     _checkProperties(attrs, ['columns']);
-    attrs = _.pick(attrs, ListDataviewModel.ATTRS_NAMES);
-    attrs.source = attrs.source || { id: layerModel.id };
-    if (this.get('apiKey')) {
-      attrs.apiKey = this.get('apiKey');
-    }
-
+    attrs = this._generateAttrsForDataview(layerModel, attrs, ListDataviewModel.ATTRS_NAMES);
     return this._newModel(
       new ListDataviewModel(attrs, {
         map: this._map,
         layer: layerModel
       })
     );
+  },
+
+  _generateAttrsForDataview: function (layerModel, attrs, whitelistedAttrs) {
+    attrs = _.pick(attrs, whitelistedAttrs);
+    attrs.source = attrs.source || { id: layerModel.id };
+    if (this.get('apiKey')) {
+      attrs.apiKey = this.get('apiKey');
+    }
+    if (this.get('authToken')) {
+      attrs.authToken = this.get('authToken');
+    }
+    return attrs;
   },
 
   _newModel: function (m) {

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -124,6 +124,7 @@ var VisModel = Backbone.Model.extend({
     // Create the WindshaftMap
     this._windshaftMap = new WindshaftMapClass({
       apiKey: this.get('apiKey'),
+      authToken: this.get('authToken'),
       statTag: datasource.stat_tag
     }, {
       client: windshaftClient,
@@ -161,7 +162,8 @@ var VisModel = Backbone.Model.extend({
 
     // Create the public Dataview Factory
     this.dataviews = new DataviewsFactory({
-      apiKey: this.get('apiKey')
+      apiKey: this.get('apiKey'),
+      authToken: this.get('authToken')
     }, {
       dataviewsCollection: this._dataviewsCollection,
       map: this.map
@@ -170,6 +172,7 @@ var VisModel = Backbone.Model.extend({
     // Create the public Analysis Factory
     this.analysis = new AnalysisFactory({
       apiKey: this.get('apiKey'),
+      authToken: this.get('authToken'),
       analysisCollection: this._analysisCollection,
       map: this.map
     });

--- a/test/spec/analysis/analysis-factory.spec.js
+++ b/test/spec/analysis/analysis-factory.spec.js
@@ -3,7 +3,7 @@ var AnalysisFactory = require('../../../src/analysis/analysis-factory');
 
 describe('src/analysis/analysis-factory.js', function () {
   beforeEach(function () {
-    var fakeCamshaftReference = {
+    this.fakeCamshaftReference = {
       getSourceNamesForAnalysisType: function (analysisType) {
         var map = {
           'trade-area': ['source'],
@@ -21,7 +21,7 @@ describe('src/analysis/analysis-factory.js', function () {
     };
     this.analysisCollection = new Backbone.Collection();
     this.analysisFactory = new AnalysisFactory({
-      camshaftReference: fakeCamshaftReference,
+      camshaftReference: this.fakeCamshaftReference,
       analysisCollection: this.analysisCollection,
       map: jasmine.createSpyObj('map', ['reload'])
     });
@@ -40,6 +40,25 @@ describe('src/analysis/analysis-factory.js', function () {
         type: 'source',
         query: 'SELECT * FROM subway_stops'
       });
+    });
+
+    it('should set attrs on the analysis models', function () {
+      this.analysisFactory = new AnalysisFactory({
+        apiKey: 'THE_API_KEY',
+        authToken: 'THE_AUTH_TOKEN',
+        camshaftReference: this.fakeCamshaftReference,
+        analysisCollection: this.analysisCollection,
+        map: jasmine.createSpyObj('map', ['reload'])
+      });
+
+      var analysisModel = this.analysisFactory.analyse({
+        id: 'a0',
+        type: 'source',
+        query: 'SELECT * FROM subway_stops'
+      });
+
+      expect(analysisModel.get('apiKey')).toEqual('THE_API_KEY');
+      expect(analysisModel.get('authToken')).toEqual('THE_AUTH_TOKEN');
     });
 
     it('should add new analysis to the collection of analysis', function () {

--- a/test/spec/analysis/analysis-model.spec.js
+++ b/test/spec/analysis/analysis-model.spec.js
@@ -31,6 +31,27 @@ describe('src/analysis/analysis-model.js', function () {
     });
   });
 
+  describe('.url', function () {
+    it('should append the api_key param if present (and not use the authToken)', function () {
+      this.analysisModel.set({
+        url: 'http://example.com',
+        apiKey: 'THE_API_KEY',
+        authToken: 'THE_AUTH_TOKEN'
+      });
+
+      expect(this.analysisModel.url()).toEqual('http://example.com?api_key=THE_API_KEY');
+    });
+
+    it('should append the auth_token param if present (and not use the authToken)', function () {
+      this.analysisModel.set({
+        url: 'http://example.com',
+        authToken: 'THE_AUTH_TOKEN'
+      });
+
+      expect(this.analysisModel.url()).toEqual('http://example.com?auth_token=THE_AUTH_TOKEN');
+    });
+  });
+
   describe('bindings', function () {
     describe('on params change', function () {
       it('should reload the map', function () {

--- a/test/spec/api/create-vis.spec.js
+++ b/test/spec/api/create-vis.spec.js
@@ -61,6 +61,28 @@ describe('src/api/create-vis', function () {
     expect(Loader.get).not.toHaveBeenCalled();
   });
 
+  it('should initialize the visModel correctly', function () {
+    var vizJSON = _.extend(fakeVizJSON, {
+      title: 'TITLE',
+      description: 'DESCRIPTION',
+      auth_tokens: ['AUTH_TOKEN'],
+      legends: true,
+      https: true
+    });
+    var visModel = createVis(this.containerId, vizJSON, {
+      apiKey: 'API_KEY',
+      show_empty_infowindow_fields: true,
+      skipMapInstantiation: true
+    });
+
+    expect(visModel.get('title')).toEqual('TITLE');
+    expect(visModel.get('description')).toEqual('DESCRIPTION');
+    expect(visModel.get('authToken')).toEqual('AUTH_TOKEN');
+    expect(visModel.get('showLegends')).toEqual(true);
+    expect(visModel.get('showEmptyInfowindowFields')).toEqual(true);
+    expect(visModel.get('https')).toEqual(true);
+  });
+
   it('should set the given center if values are correct', function () {
     var opts = {
       center_lat: 43.3,

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -37,17 +37,31 @@ describe('dataviews/dataview-model-base', function () {
       expect(this.model.url()).toEqual('http://example.com?bbox=west,south,east,north&a=b&c=d');
     });
 
-    it('should append an api_key param', function () {
+    it('should append an api_key param if apiKey attr is present (and not use the auth_token)', function () {
       this.map.getViewBounds.and.returnValue([['south', 'west'], ['north', 'east']]);
 
       this.model.set({
         url: 'http://example.com',
-        apiKey: 'THE_API_KEY'
+        apiKey: 'THE_API_KEY',
+        authToken: 'THE_AUTH_TOKEN'
       });
 
       spyOn(this.model, '_getDataviewSpecificURLParams').and.returnValue([ 'a=b', 'c=d' ]);
 
       expect(this.model.url()).toEqual('http://example.com?bbox=west,south,east,north&a=b&c=d&api_key=THE_API_KEY');
+    });
+
+    it('should append an auth_token param if authToken is present', function () {
+      this.map.getViewBounds.and.returnValue([['south', 'west'], ['north', 'east']]);
+
+      this.model.set({
+        url: 'http://example.com',
+        authToken: 'THE_AUTH_TOKEN'
+      });
+
+      spyOn(this.model, '_getDataviewSpecificURLParams').and.returnValue([ 'a=b', 'c=d' ]);
+
+      expect(this.model.url()).toEqual('http://example.com?bbox=west,south,east,north&a=b&c=d&auth_token=THE_AUTH_TOKEN');
     });
   });
 

--- a/test/spec/dataviews/dataviews-factory.spec.js
+++ b/test/spec/dataviews/dataviews-factory.spec.js
@@ -2,6 +2,13 @@ var _ = require('underscore');
 var Backbone = require('backbone');
 var DataviewsFactory = require('../../../src/dataviews/dataviews-factory');
 
+var generateFakeAttributes = function (attrNames) {
+  return _.reduce(attrNames, function (object, attributeName) {
+    object[attributeName] = 'something';
+    return object;
+  }, {});
+};
+
 describe('dataviews/dataviews-factory', function () {
   beforeEach(function () {
     this.dataviewsCollection = new Backbone.Collection();
@@ -9,6 +16,7 @@ describe('dataviews/dataviews-factory', function () {
       dataviewsCollection: this.dataviewsCollection,
       map: {}
     });
+    this.layer = jasmine.createSpyObj('layer', ['getDataProvider']);
   });
 
   it('should create the factory as expected', function () {
@@ -31,10 +39,8 @@ describe('dataviews/dataviews-factory', function () {
     var requiredAttributes = element[1];
 
     it(factoryMethod + ' should throw an error if required attributes are not set', function () {
-      var layer = jasmine.createSpyObj('layer', ['getDataProvider']);
-
       expect(function () {
-        this.factory[factoryMethod](layer, {});
+        this.factory[factoryMethod](this.layer, {});
       }.bind(this)).toThrowError(requiredAttributes[0] + ' is required');
     });
 
@@ -46,14 +52,8 @@ describe('dataviews/dataviews-factory', function () {
         map: {}
       });
 
-      var layer = jasmine.createSpyObj('layer', ['getDataProvider']);
-
-      // Set fake attributes
-      var attributes = _.reduce(requiredAttributes, function (object, attributeName) {
-        object[attributeName] = 'something';
-        return object;
-      }, {});
-      var model = this.factory[factoryMethod](layer, attributes);
+      var attributes = generateFakeAttributes(requiredAttributes);
+      var model = this.factory[factoryMethod](this.layer, attributes);
 
       expect(model.get('apiKey')).toEqual('THE_API_KEY');
     });
@@ -66,16 +66,32 @@ describe('dataviews/dataviews-factory', function () {
         map: {}
       });
 
-      var layer = jasmine.createSpyObj('layer', ['getDataProvider']);
+      var attributes = generateFakeAttributes(requiredAttributes);
+      var model = this.factory[factoryMethod](this.layer, attributes);
 
-      // Set fake attributes
-      var attributes = _.reduce(requiredAttributes, function (object, attributeName) {
-        object[attributeName] = 'something';
-        return object;
-      }, {});
-      var model = this.factory[factoryMethod](layer, attributes);
+      expect(model.get('source')).toEqual({ id: this.layer.id });
+    });
 
-      expect(model.get('source')).toEqual({ id: layer.id });
+    it(factoryMethod + ' should set the authToken', function () {
+      this.factory.set({
+        authToken: 'AUTH_TOKEN'
+      });
+
+      var attributes = generateFakeAttributes(requiredAttributes);
+      var model = this.factory[factoryMethod](this.layer, attributes);
+
+      expect(model.get('authToken')).toEqual('AUTH_TOKEN');
+    });
+
+    it(factoryMethod + ' should set the apiKey', function () {
+      this.factory.set({
+        apiKey: 'API_KEY'
+      });
+
+      var attributes = generateFakeAttributes(requiredAttributes);
+      var model = this.factory[factoryMethod](this.layer, attributes);
+
+      expect(model.get('apiKey')).toEqual('API_KEY');
     });
   }, this);
 });

--- a/test/spec/windshaft/map-base.spec.js
+++ b/test/spec/windshaft/map-base.spec.js
@@ -266,6 +266,7 @@ describe('windshaft/map-base', function () {
 
         this.windshaftMap = new WindshaftMap({
           apiKey: 'API_KEY',
+          authToken: 'AUTH_TOKEN',
           statTag: 'stat_tag'
         }, { // eslint-disable-line
           client: this.client,
@@ -283,6 +284,32 @@ describe('windshaft/map-base', function () {
         expect(args.params).toEqual({
           stat_tag: 'stat_tag',
           api_key: 'API_KEY'
+        });
+      });
+
+      it('should use the given AUTH_TOKEN when creating a new instance of the windshaft map', function () {
+        this.layersCollection.reset([ this.cartoDBLayer1, this.cartoDBLayer2, this.torqueLayer ]);
+        spyOn(this.windshaftMap, 'toJSON').and.returnValue({ foo: 'bar' });
+
+        this.windshaftMap = new WindshaftMap({
+          authToken: 'AUTH_TOKEN',
+          statTag: 'stat_tag'
+        }, { // eslint-disable-line
+          client: this.client,
+          modelUpdater: this.modelUpdater,
+          dataviewsCollection: this.dataviewsCollection,
+          layersCollection: this.layersCollection,
+          analysisCollection: this.analysisCollection
+        });
+
+        this.windshaftMap.createInstance({
+          sourceLayerId: 'sourceLayerId'
+        });
+
+        var args = this.client.instantiateMap.calls.mostRecent().args[0];
+        expect(args.params).toEqual({
+          stat_tag: 'stat_tag',
+          auth_token: 'AUTH_TOKEN'
         });
       });
 
@@ -694,9 +721,10 @@ describe('windshaft/map-base', function () {
       });
     });
 
-    it('should encode and include the API key in the URLs if apiKey is set', function () {
+    it('should include the API key in the URLs', function () {
       var windshaftMap = new WindshaftMap({
         'apiKey': 'API_KEY',
+        'authToken': 'AUTH_TOKEN',
         'layergroupid': '0123456789',
         'metadata': {
           'layers': [
@@ -726,6 +754,42 @@ describe('windshaft/map-base', function () {
         tiles: [ 'https://rambo.example.com:443/api/v1/map/0123456789/0/{z}/{x}/{y}.png?api_key=API_KEY' ],
         grids: [
           [ 'https://rambo.example.com:443/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json?api_key=API_KEY' ]
+        ]
+      });
+    });
+
+    it('should include the AUTH token in the URLs', function () {
+      var windshaftMap = new WindshaftMap({
+        'authToken': 'AUTH_TOKEN',
+        'layergroupid': '0123456789',
+        'metadata': {
+          'layers': [
+            {
+              'type': 'mapnik',
+              'meta': {}
+            },
+            {
+              'type': 'torque',
+              'meta': {}
+            }
+          ]
+        }
+      }, {
+        client: new WindshaftClient({
+          urlTemplate: 'https://{user}.example.com:443',
+          userName: 'rambo',
+          endpoint: 'v2'
+        }),
+        modelUpdater: this.modelUpdater,
+        dataviewsCollection: this.dataviewsCollection,
+        layersCollection: this.layersCollection,
+        analysisCollection: this.analysisCollection
+      });
+
+      expect(windshaftMap.getTiles()).toEqual({
+        tiles: [ 'https://rambo.example.com:443/api/v1/map/0123456789/0/{z}/{x}/{y}.png?auth_token=AUTH_TOKEN' ],
+        grids: [
+          [ 'https://rambo.example.com:443/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json?auth_token=AUTH_TOKEN' ]
         ]
       });
     });


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb.js/issues/1226.
Fixes https://github.com/CartoDB/cartodb/issues/7859.

When the vizjson has an auth_token (this will be true for maps that are password protected), the following requests to Windshaft will use it in the query string:

- Requests to instantiate the map
- Requests to get the tiles
- Requests to get the grids
- Requests for dataviews
- Requests for analyses

NOTE: If apiKey and authToken are present these (☝️ ) requests will only include the api_key param.

@xavijam PTAL! Thank you! 💋 