### PR TITLE
Fixes number of bins not being sent to tiler

### DIFF
--- a/src/dataviews/histogram-dataview-model.js
+++ b/src/dataviews/histogram-dataview-model.js
@@ -29,7 +29,7 @@ module.exports = DataviewModelBase.extend({
       if (_.isNumber(this.get('end'))) {
         params.push('end=' + this.get('end'));
       }
-      if (_.isNumber(this.get('bins'))) {
+      if (_.isNumber(parseInt(this.get('bins'), 10))) {
         params.push('bins=' + this.get('bins'));
       }
     }


### PR DESCRIPTION
We were just omitting the bins attribute because we were checking if it was a number, when the attribute is stored as a string.

@rochoa 