### PR TITLE
vis.instantiateMap supports success and error

### DIFF
--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -255,7 +255,7 @@ var VisModel = Backbone.Model.extend({
   instantiateMap: function (options) {
     options = options || {};
     this._dataviewsCollection.on('add reset remove', _.debounce(this.invalidateSize, 10), this);
-    this.map.instantiateMap();
+    this.map.instantiateMap(options);
   },
 
   invalidateSize: function () {


### PR DESCRIPTION
When `createVis` is used with `skipMapOptions:true` option, vis will have to be instantiated as follows:

```
vis.on('load', function () {
  vis.instantiateMap({
    success: function () { ... },
    error: function () { ... }
  });
});
```

@xavijam since you're already in the loop... will you give me a 👍? thx!