### PR TITLE
Replaced `ok` and `error` events by `error` attribute on vis, layer and analyses models

### DIFF
--- a/src/analysis/analysis-model.js
+++ b/src/analysis/analysis-model.js
@@ -39,11 +39,11 @@ module.exports = Model.extend({
   },
 
   setOk: function () {
-    this.trigger('ok');
+    this.unset('error');
   },
 
   setError: function (error) {
-    this.trigger('error', error);
+    this.set('error', error);
   },
 
   _initBinds: function () {

--- a/src/geo/map/layer-model-base.js
+++ b/src/geo/map/layer-model-base.js
@@ -52,11 +52,11 @@ var MapLayer = Model.extend({
   // INTERNAL CartoDB.js METHODS
 
   setOk: function () {
-    this.trigger('ok');
+    this.unset('error');
   },
 
   setError: function (error) {
-    this.trigger('error', error);
+    this.set('error', error);
   },
 
   /*

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -183,6 +183,7 @@ var VisModel = Backbone.Model.extend({
       map: this.map
     });
 
+    this._windshaftMap.bind('instanceRequested', this._onMapInstanceRequested, this);
     this._windshaftMap.bind('instanceCreated', this._onMapInstanceCreated, this);
 
     // Lastly: reset the layer models on the map
@@ -203,6 +204,10 @@ var VisModel = Backbone.Model.extend({
     _.defer(function () {
       this.trigger('load', this);
     }.bind(this));
+  },
+
+  _onMapInstanceRequested: function () {
+    this.trigger('reload');
   },
 
   _onMapInstanceCreated: function () {

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -38,32 +38,38 @@ var VisModel = Backbone.Model.extend({
     this.overlaysCollection = new Backbone.Collection();
   },
 
-  setOk: function () {
-    this.trigger('ok');
-    this.set('state', STATE_OK);
+  done: function (callback) {
+    this._doneCallback = callback;
+    return this;
   },
 
-  done: function (callback) {
-    this.once('ok', function () {
-      if (this.get('state') === STATE_INIT) {
-        callback(this);
-      }
-    }, this);
+  setOk: function () {
+    // Invoke this._doneCallback if present, the first time
+    // the vis is instantiated correctly
+    if (this.get('state') === STATE_INIT) {
+      this._doneCallback && this._doneCallback(this);
+    }
+
+    this.set('state', STATE_OK);
+    this.unset('error');
+  },
+
+  error: function (callback) {
+    this._errorCallback = callback;
     return this;
   },
 
   setError: function (error) {
-    this.trigger('error', error);
-    this.set('state', STATE_ERROR);
-  },
+    // Invoke this._errorCallback if present, the first time
+    // the vis is instantiated and the're some errors
+    if (this.get('state') === STATE_INIT) {
+      this._errorCallback && this._errorCallback(error);
+    }
 
-  error: function (callback) {
-    this.once('error', function (error) {
-      if (this.get('state') === STATE_INIT) {
-        callback(error);
-      }
-    }, this);
-    return this;
+    this.set({
+      state: STATE_ERROR,
+      error: error
+    });
   },
 
   /**

--- a/src/windshaft/map-base.js
+++ b/src/windshaft/map-base.js
@@ -86,6 +86,8 @@ var WindshaftMap = Backbone.Model.extend({
     var params = request.params;
     var options = request.options;
 
+    this.trigger('instanceRequested');
+
     this.client.instantiateMap({
       mapDefinition: payload,
       params: params,
@@ -98,10 +100,8 @@ var WindshaftMap = Backbone.Model.extend({
       }.bind(this),
       error: function (response) {
         this._trackRequest(request, response);
-
         var windshaftErrors = this._getErrorsFromResponse(response);
         this._modelUpdater.setErrors(windshaftErrors);
-
         log.error('Request to Maps API failed');
         options.error && options.error();
       }.bind(this)

--- a/test/spec/analysis/analysis-model.spec.js
+++ b/test/spec/analysis/analysis-model.spec.js
@@ -288,24 +288,18 @@ describe('src/analysis/analysis-model.js', function () {
   });
 
   describe('.setOk', function () {
-    it("should trigger 'ok' event", function () {
-      var callback = jasmine.createSpy('callback');
-      this.analysisModel.on('ok', callback);
-
+    it('should unset error attribute', function () {
+      this.analysisModel.set('error', 'error');
       this.analysisModel.setOk();
-
-      expect(callback).toHaveBeenCalled();
+      expect(this.analysisModel.get('error')).toBeUndefined();
     });
   });
 
   describe('.setError', function () {
-    it("should trigger 'error' event", function () {
-      var callback = jasmine.createSpy('callback');
-      this.analysisModel.on('error', callback);
+    it('should set error attribute', function () {
+      this.analysisModel.setError('wadus');
 
-      this.analysisModel.setError();
-
-      expect(callback).toHaveBeenCalled();
+      expect(this.analysisModel.get('error')).toEqual('wadus');
     });
   });
 });

--- a/test/spec/geo/map/layer-model-base.spec.js
+++ b/test/spec/geo/map/layer-model-base.spec.js
@@ -63,4 +63,20 @@ describe('geo/map/layer-model-base.js', function () {
       expect(this.layer.get('visible')).toBeFalsy();
     });
   });
+
+  describe('.setOk', function () {
+    it('should unset error attribute', function () {
+      this.layer.set('error', 'error');
+      this.layer.setOk();
+      expect(this.layer.get('error')).toBeUndefined();
+    });
+  });
+
+  describe('.setError', function () {
+    it('should set error attribute', function () {
+      this.layer.setError('wadus');
+
+      expect(this.layer.get('error')).toEqual('wadus');
+    });
+  });
 });

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -453,6 +453,8 @@ describe('vis/vis', function () {
 
     describe('polling', function () {
       beforeEach(function () {
+        spyOn(_, 'debounce').and.callFake(function (func) { return function () { func.apply(this, arguments); }; });
+
         this.vizjson = {
           'id': '70af2a72-0709-11e6-a834-080027880ca6',
           'version': '3.0.0',
@@ -878,6 +880,10 @@ describe('vis/vis', function () {
   });
 
   describe('.instantiateMap', function () {
+    beforeEach(function () {
+      spyOn(_, 'debounce').and.callFake(function (func) { return function () { func.apply(this, arguments); }; });
+    });
+
     it('should trigger a `reload` event', function () {
       var reloadCallback = jasmine.createSpy('reloadCallback');
 

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -215,6 +215,7 @@ var fakeVizJSON = function () {
 describe('vis/vis', function () {
   beforeEach(function () {
     this.vis = new Vis();
+    spyOn(_, 'debounce').and.callFake(function (func) { return function () { func.apply(this, arguments); }; });
   });
 
   it('.trackLoadingObject .untrackLoadingObject and .clearLoadingObjects should change the loading attribute', function () {
@@ -452,8 +453,6 @@ describe('vis/vis', function () {
 
     describe('polling', function () {
       beforeEach(function () {
-        spyOn(_, 'debounce').and.callFake(function (func) { return function () { func.apply(this, arguments); }; });
-
         this.vizjson = {
           'id': '70af2a72-0709-11e6-a834-080027880ca6',
           'version': '3.0.0',
@@ -875,6 +874,19 @@ describe('vis/vis', function () {
       this.vis.setError('something');
 
       expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('.instantiateMap', function () {
+    it('should trigger a `reload` event', function () {
+      var reloadCallback = jasmine.createSpy('reloadCallback');
+
+      this.vis.load(new VizJSON(fakeVizJSON()));
+      this.vis.on('reload', reloadCallback);
+
+      this.vis.instantiateMap();
+
+      expect(reloadCallback).toHaveBeenCalled();
     });
   });
 

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -830,94 +830,50 @@ describe('vis/vis', function () {
     });
   });
 
-  describe('.done', function () {
-    it('should invoke the callback once when model triggers the `ok` events and state is `init`', function () {
-      var callback = jasmine.createSpy('callback');
-      this.vis.done(callback);
+  describe('.setOk', function () {
+    it('should unset the error attribute', function () {
+      this.vis.set('error', 'error');
 
-      this.vis.trigger('ok');
+      this.vis.setOk();
 
-      expect(callback).toHaveBeenCalled();
-      callback.calls.reset();
-
-      this.vis.trigger('ok');
-
-      expect(callback).not.toHaveBeenCalled();
+      expect(this.vis.get('error')).toBeUndefined();
     });
 
-    it('should NOT invoke the callback when model triggers `ok` event and state is NOT `init`', function () {
+    it('should invoke the done callback only the first time', function () {
       var callback = jasmine.createSpy('callback');
       this.vis.done(callback);
-      this.vis.setError(); // Map couldn't be previously instantiated
 
-      this.vis.trigger('ok'); // Everything is fine now
+      this.vis.setOk();
 
-      // Done callback is not invoked cause error callback was called before
+      expect(callback).toHaveBeenCalled();
+
+      callback.calls.reset();
+
+      this.vis.setOk();
+
       expect(callback).not.toHaveBeenCalled();
     });
   });
 
-  describe('state', function () {
-    it("should be initialized to the 'init' state", function () {
-      expect(this.vis.get('state')).toEqual('init');
+  describe('.setError', function () {
+    it('should set the error attribute', function () {
+      this.vis.setError('something');
+
+      expect(this.vis.get('error')).toEqual('something');
     });
 
-    describe('.setOk', function () {
-      it("should change state to 'ok'", function () {
-        this.vis.setOk();
-        expect(this.vis.get('state')).toEqual('ok');
-      });
-
-      it("should trigger 'ok' event", function () {
-        var callback = jasmine.createSpy('callback');
-        this.vis.on('ok', callback);
-
-        this.vis.setOk();
-
-        expect(callback).toHaveBeenCalledWith();
-      });
-    });
-
-    describe('.setError', function () {
-      it("should change state to 'error'", function () {
-        this.vis.setError();
-        expect(this.vis.get('state')).toEqual('error');
-      });
-
-      it("should trigger 'error' event", function () {
-        var callback = jasmine.createSpy('callback');
-        this.vis.on('error', callback);
-
-        this.vis.setError('something went wrong!');
-
-        expect(callback).toHaveBeenCalledWith('something went wrong!');
-      });
-    });
-  });
-
-  describe('.error', function () {
-    it('should invoke the callback when model triggers the first `error` event and state is `init`', function () {
+    it('should invoke the error callback only the first time', function () {
       var callback = jasmine.createSpy('callback');
       this.vis.error(callback);
 
-      this.vis.trigger('error');
+      this.vis.setError('something');
 
       expect(callback).toHaveBeenCalled();
+
       callback.calls.reset();
 
-      this.vis.trigger('error');
+      this.vis.setError('something');
 
-      expect(callback).not.toHaveBeenCalled();
-    });
-
-    it('should NOT invoke the callback when model triggers `error` event and state is NOT `init`', function () {
-      var callback = jasmine.createSpy('callback');
-      this.vis.error(callback);
-      this.vis.setOk(); // Map was correctly instantiated
-
-      this.vis.trigger('error'); // There are some errors now
-
-      // Error callback is not invoked cause done callback was called before
       expect(callback).not.toHaveBeenCalled();
     });
   });

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -215,7 +215,6 @@ var fakeVizJSON = function () {
 describe('vis/vis', function () {
   beforeEach(function () {
     this.vis = new Vis();
-    spyOn(_, 'debounce').and.callFake(function (func) { return function () { func.apply(this, arguments); }; });
   });
 
   it('.trackLoadingObject .untrackLoadingObject and .clearLoadingObjects should change the loading attribute', function () {

--- a/test/spec/windshaft/map-base.spec.js
+++ b/test/spec/windshaft/map-base.spec.js
@@ -21,9 +21,8 @@ describe('windshaft/map-base', function () {
   beforeEach(function () {
     jasmine.clock().install();
 
-    // Disable ajax and debounce for these tests
+    // Disable ajax for these tests
     spyOn($, 'ajax').and.callFake(function () {});
-    spyOn(_, 'debounce').and.callFake(function (func) { return function () { func.apply(this, arguments); }; });
 
     this.windshaftMapInstance = {
       layergroupid: 'layergroupid',

--- a/test/spec/windshaft/map-base.spec.js
+++ b/test/spec/windshaft/map-base.spec.js
@@ -218,6 +218,14 @@ describe('windshaft/map-base', function () {
         expect(successCallback).toHaveBeenCalledWith(this.windshaftMap);
       });
 
+      it('should trigger the `instanceRequested` event', function () {
+        var instanceRequestedCallback = jasmine.createSpy('instanceRequestedCallback');
+        this.windshaftMap.bind('instanceRequested', instanceRequestedCallback);
+        this.windshaftMap.createInstance();
+
+        expect(instanceRequestedCallback).toHaveBeenCalled();
+      });
+
       it('should trigger the `instanceCreated` event', function () {
         var instanceCreatedCallback = jasmine.createSpy('instanceCreatedCallback');
         this.windshaftMap.bind('instanceCreated', instanceCreatedCallback);


### PR DESCRIPTION
The "API" for errors that we implemented initially (see https://github.com/CartoDB/cartodb.js/pull/1324#issuecomment-229647295) is not working properly because we might need to access the errors after the `error` event has been triggered (eg: right after the editor has been loaded).

This PR replaces `ok` and `error` events triggered by vis, layers and analyses by an `error` attribute that we can 'query' at any time. (this was suggested by @viddo at some point).

@viddo 👍 ?