### PR TITLE
Remove add overlay logo forced

### DIFF
--- a/src/api/create-vis.js
+++ b/src/api/create-vis.js
@@ -29,21 +29,12 @@ var createVis = function (el, vizjson, options) {
 
   var isProtocolHTTPs = window && window.location.protocol && window.location.protocol === 'https:';
 
-  var showLogo = true;
-  if (options.logo === false) {
-    showLogo = false;
-  }
-  if (vizjson.logo === false && showLogo) {
-    showLogo = false;
-  }
-
   var visModel = new VisModel({
     title: options.title || vizjson.title,
     description: options.description || vizjson.description,
     apiKey: options.apiKey,
     authToken: vizjson.auth_tokens && vizjson.auth_tokens.length && vizjson.auth_tokens[0],
     showLegends: options.legends === true || vizjson.legends === true,
-    showLogo: showLogo,
     showEmptyInfowindowFields: options.show_empty_infowindow_fields === true,
     https: isProtocolHTTPs || options.https === true || vizjson.https === true
   });
@@ -103,9 +94,8 @@ var applyOptionsToVizJSON = function (vizjson, options) {
     vizjson.removeZoomOverlay();
   }
 
-  // if logo is not included, let add it :)
-  if (!vizjson.hasOverlay('logo')) {
-    vizjson.addLogoOverlay();
+  if (options.logo === false) {
+    vizjson.removeLogoOverlay();
   }
 
   // if bounds are present zoom and center will not taken into account

--- a/src/api/vizjson.js
+++ b/src/api/vizjson.js
@@ -43,14 +43,6 @@ VizJSON.prototype.getOverlayByType = function (overlayType) {
   });
 };
 
-VizJSON.prototype.addLogoOverlay = function (overlayType) {
-  if (!this.hasOverlay(VizJSON.OVERLAY_TYPES.LOGO)) {
-    this.overlays.push({
-      type: VizJSON.OVERLAY_TYPES.LOGO
-    });
-  }
-};
-
 VizJSON.prototype.addHeaderOverlay = function (showTitle, showDescription, isShareable) {
   if (!this.hasOverlay(VizJSON.OVERLAY_TYPES.HEADER)) {
     this.overlays.unshift({
@@ -106,6 +98,10 @@ VizJSON.prototype.removeZoomOverlay = function () {
 
 VizJSON.prototype.removeSearchOverlay = function () {
   this.removeOverlay(VizJSON.OVERLAY_TYPES.SEARCH);
+};
+
+VizJSON.prototype.removeLogoOverlay = function (overlayType) {
+  this.removeOverlay(VizJSON.OVERLAY_TYPES.LOGO);
 };
 
 VizJSON.prototype._addAttributionOverlay = function () {

--- a/src/vis/vis-view.js
+++ b/src/vis/vis-view.js
@@ -33,7 +33,7 @@ var Vis = View.extend({
 
     this.model.once('load', this.render, this);
     this.model.on('invalidateSize', this._invalidateSize, this);
-    this.model.overlaysCollection.on('add remove', this._resetOverlays, this);
+    this.model.overlaysCollection.on('add remove change', this._resetOverlays, this);
 
     this.overlays = [];
 
@@ -273,7 +273,7 @@ var Vis = View.extend({
       }
 
       if (type === 'logo') {
-        overlay[this.model.get('showLogo') ? 'show' : 'hide']();
+        overlay[this.model.get('showLogo') === false || opt.display === false ? 'hide' : 'show']();
       }
 
       if (type === 'header') {

--- a/src/vis/vis-view.js
+++ b/src/vis/vis-view.js
@@ -272,10 +272,6 @@ var Vis = View.extend({
         overlay.show();
       }
 
-      if (type === 'logo') {
-        overlay[this.model.get('showLogo') === false || opt.display === false ? 'hide' : 'show']();
-      }
-
       if (type === 'header') {
         var m = overlay.model;
 

--- a/test/spec/api/create-vis.spec.js
+++ b/test/spec/api/create-vis.spec.js
@@ -264,6 +264,21 @@ describe('src/api/create-vis', function () {
     }.bind(this));
   });
 
+  it("should disable logo if it's specified by logo", function (done) {
+    fakeVizJSON.overlays = [{ type: 'logo' }];
+
+    var opts = {
+      logo: false
+    };
+
+    createVis(this.containerId, fakeVizJSON, opts);
+
+    _.defer(function () {
+      expect(this.container.find('.CDB-Logo').length).toEqual(0);
+      done();
+    }.bind(this));
+  });
+
   var mapInstantiationRequestDone = function () {
     return _.any($.ajax.calls.allArgs(), function (args) {
       var expectedURLRegexp = /(http|https):\/\/cdb.localhost.lan:8181\/api\/v1\/map\/named\/tpl_6a31d394_7c8e_11e5_8e42_080027880ca6\?stat_tag=6a31d394-7c8e-11e5-8e42-080027880ca6/;

--- a/test/spec/vis/vis-view.spec.js
+++ b/test/spec/vis/vis-view.spec.js
@@ -25,7 +25,6 @@ describe('vis/vis-view', function () {
       url: 'http://cartodb.com',
       center: [40.044, -101.95],
       zoom: 4,
-      logo: true,
       bounds: [
         [1, 2],
         [3, 4]
@@ -139,39 +138,6 @@ describe('vis/vis-view', function () {
     this.visModel.set('loading', false);
 
     expect(this.visView.$el.find('.CDB-Loader:not(.is-visible)').length).toEqual(1);
-  });
-
-  it('should display the logo if vizjson say so', function () {
-    this.visView.model.overlaysCollection.add({
-      type: 'logo'
-    });
-
-    expect(this.visView.$el.find('.CDB-Logo').css('display')).not.toEqual('none');
-  });
-
-  it('should not display the logo if option display is false', function () {
-    this.visView.model.overlaysCollection.add({
-      type: 'logo',
-      options: {
-        display: false
-      }
-    });
-
-    expect(this.visView.$el.find('.CDB-Logo').css('display')).toEqual('none');
-  });
-
-  it('should render overlays on change', function () {
-    var overlay = this.visView.model.overlaysCollection.add({
-      type: 'logo'
-    });
-
-    spyOn(this.visView, '_createOverlays').and.callThrough();
-
-    expect(this.visView.$el.find('.CDB-Logo').css('display')).not.toEqual('none');
-
-    overlay.set('options', {display: false});
-    expect(this.visView._createOverlays).toHaveBeenCalled();
-    expect(this.visView.$el.find('.CDB-Logo').css('display')).toEqual('none');
   });
 
   describe('.getLayerViews', function () {

--- a/test/spec/vis/vis-view.spec.js
+++ b/test/spec/vis/vis-view.spec.js
@@ -25,6 +25,7 @@ describe('vis/vis-view', function () {
       url: 'http://cartodb.com',
       center: [40.044, -101.95],
       zoom: 4,
+      logo: true,
       bounds: [
         [1, 2],
         [3, 4]
@@ -41,7 +42,9 @@ describe('vis/vis-view', function () {
       }
     };
 
-    this.visModel = new VisModel();
+    this.visModel = new VisModel({
+      showLogo: true
+    });
 
     this.createNewVis = function (attrs) {
       attrs.widgets = new Backbone.Collection();
@@ -136,6 +139,39 @@ describe('vis/vis-view', function () {
     this.visModel.set('loading', false);
 
     expect(this.visView.$el.find('.CDB-Loader:not(.is-visible)').length).toEqual(1);
+  });
+
+  it('should display the logo if vizjson say so', function () {
+    this.visView.model.overlaysCollection.add({
+      type: 'logo'
+    });
+
+    expect(this.visView.$el.find('.CDB-Logo').css('display')).not.toEqual('none');
+  });
+
+  it('should not display the logo if option display is false', function () {
+    this.visView.model.overlaysCollection.add({
+      type: 'logo',
+      options: {
+        display: false
+      }
+    });
+
+    expect(this.visView.$el.find('.CDB-Logo').css('display')).toEqual('none');
+  });
+
+  it('should render overlays on change', function () {
+    var overlay = this.visView.model.overlaysCollection.add({
+      type: 'logo'
+    });
+
+    spyOn(this.visView, '_createOverlays').and.callThrough();
+
+    expect(this.visView.$el.find('.CDB-Logo').css('display')).not.toEqual('none');
+
+    overlay.set('options', {display: false});
+    expect(this.visView._createOverlays).toHaveBeenCalled();
+    expect(this.visView.$el.find('.CDB-Logo').css('display')).toEqual('none');
   });
 
   describe('.getLayerViews', function () {


### PR DESCRIPTION
This PR changes the way we handle the logo in cartodb.js. From the builder we are going to update (not create/remove) the logo overlay.

cc @xavijam @alonsogarciapablo 