### PR TITLE
Fix infowindow issues 

### DIFF
--- a/src/geo/cartodb-layer-group-base.js
+++ b/src/geo/cartodb-layer-group-base.js
@@ -17,22 +17,14 @@ var CartoDBLayerGroupBase = Backbone.Model.extend({
 
     this.layers = new Backbone.Collection(options.layers || []);
 
-    this._layersCollection.bind('reset', function () {
-      var cartoDBLayers = this._layersCollection.select(function (layerModel) { return layerModel.get('type') === 'CartoDB'; });
-      this.layers.reset(cartoDBLayers);
-    }, this);
+    this._layersCollection.bind('reset', this._resetLayers, this);
+    this._layersCollection.bind('add', this._resetLayers, this);
+    this._layersCollection.bind('remove', this._resetLayers, this);
+  },
 
-    this._layersCollection.bind('add', function (layerModel) {
-      if (layerModel.get('type') === 'CartoDB') {
-        this.layers.add(layerModel);
-      }
-    }, this);
-
-    this._layersCollection.bind('remove', function (layerModel) {
-      if (layerModel.get('type') === 'CartoDB') {
-        this.layers.remove(layerModel);
-      }
-    }, this);
+  _resetLayers: function () {
+    var cartoDBLayers = this._layersCollection.getCartoDBLayers();
+    this.layers.reset(cartoDBLayers);
   },
 
   getIndexOf: function (layerModel) {

--- a/src/geo/map/layers.js
+++ b/src/geo/map/layers.js
@@ -51,6 +51,24 @@ var Layers = Backbone.Collection.extend({
     }
 
     this.sort();
+  },
+
+  getCartoDBLayers: function () {
+    return this._getLayersByType(CARTODB_LAYER_TYPE);
+  },
+
+  getTiledLayers: function () {
+    return this._getLayersByType(TILED_LAYER_TYPE);
+  },
+
+  getTorqueLayers: function () {
+    return this._getLayersByType(TORQUE_LAYER_TYPE);
+  },
+
+  _getLayersByType: function (layerType) {
+    return this.select(function (layerModel) {
+      return layerModel.get('type') === layerType;
+    });
   }
 });
 

--- a/src/vis/infowindow-manager.js
+++ b/src/vis/infowindow-manager.js
@@ -107,19 +107,15 @@ InfowindowManager.prototype._fetchAttributes = function (layerView, layerModel, 
 
 InfowindowManager.prototype._bindInfowindowModel = function (layerView, layerModel) {
   layerModel.infowindow.bind('change', function () {
-    if (this._infowindowModel.hasInfowindowTemplate(layerModel.infowindow) && this._infowindowModel.get('visibility') === true) {
-      this._updateInfowindowModel(layerModel.infowindow);
-    }
+    this._updateInfowindowModel(layerModel.infowindow);
   }, this);
 
   layerModel.infowindow.fields.bind('reset', function () {
     if (layerModel.infowindow.hasFields()) {
-      if (this._infowindowModel.hasInfowindowTemplate(layerModel.infowindow)) {
-        this._updateInfowindowModel(layerModel.infowindow);
-        if (this._infowindowModel.get('visibility')) {
-          this._reloadMapAndFetchAttributes(layerView, layerModel);
-          return;
-        }
+      this._updateInfowindowModel(layerModel.infowindow);
+      if (this._infowindowModel.get('visibility')) {
+        this._reloadMapAndFetchAttributes(layerView, layerModel);
+        return;
       }
 
       this._reloadMap();

--- a/test/spec/geo/cartodb-layer-group-anonymous-map.spec.js
+++ b/test/spec/geo/cartodb-layer-group-anonymous-map.spec.js
@@ -1,11 +1,11 @@
 var $ = require('jquery');
-var Backbone = require('backbone');
+var Layers = require('../../../src/geo/map/layers');
 var CartoDBLayer = require('../../../src/geo/map/cartodb-layer');
 var CartoDBLayerGroupAnonymousMap = require('../../../src/geo/cartodb-layer-group-anonymous-map');
 
 describe('geo/layer-group-anonymous-map', function () {
   beforeEach(function () {
-    this.layersCollection = new Backbone.Collection();
+    this.layersCollection = new Layers();
   });
 
   // TODO: This test is a bit useless

--- a/test/spec/geo/cartodb-layer-group-base.spec.js
+++ b/test/spec/geo/cartodb-layer-group-base.spec.js
@@ -1,6 +1,7 @@
 var $ = require('jquery');
 var Backbone = require('backbone');
 var CartoDBLayer = require('../../../src/geo/map/cartodb-layer');
+var Layers = require('../../../src/geo/map/layers');
 var CartoDBLayerGroupBase = require('../../../src/geo/cartodb-layer-group-base');
 
 var MyCartoDBLayerGroup = CartoDBLayerGroupBase.extend({
@@ -9,7 +10,7 @@ var MyCartoDBLayerGroup = CartoDBLayerGroupBase.extend({
 
 describe('geo/cartodb-layer-group-base', function () {
   beforeEach(function () {
-    this.layersCollection = new Backbone.Collection();
+    this.layersCollection = new Layers();
   });
 
   describe('internal collection of CartoDB layers', function () {

--- a/test/spec/geo/cartodb-layer-group-named-map.spec.js
+++ b/test/spec/geo/cartodb-layer-group-named-map.spec.js
@@ -1,11 +1,11 @@
 var $ = require('jquery');
-var Backbone = require('backbone');
+var Layers = require('../../../src/geo/map/layers');
 var CartoDBLayer = require('../../../src/geo/map/cartodb-layer');
 var CartoDBLayerGroupNamed = require('../../../src/geo/cartodb-layer-group-named-map');
 
 describe('geo/cartodb-layer-group-named-map', function () {
   beforeEach(function () {
-    this.layersCollection = new Backbone.Collection();
+    this.layersCollection = new Layers();
   });
 
   // TODO: This test is a bit useless


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/8558

- Infowindow was only being updated when it had been clicked before and it was visible.
- Internal collection of layers of the "LayerGroupModel" wasn't being updated correctly (the order wasn't right) when new layers were added/removed.

cc: @matallo 
