### PR TITLE
Ensure new requests to Windshaft can be performed when request limit has been reached

### DIFF
--- a/src/windshaft/map-base.js
+++ b/src/windshaft/map-base.js
@@ -74,7 +74,7 @@ var WindshaftMap = Backbone.Model.extend({
   },
 
   _canPerformRequest: function (request) {
-    return !this._requestTracker.maxNumberOfRequestsReached();
+    return this._requestTracker.canRequestBePerformed(request);
   },
 
   _trackRequest: function (request, response) {

--- a/src/windshaft/request-tracker.js
+++ b/src/windshaft/request-tracker.js
@@ -27,6 +27,11 @@ RequestTracker.prototype.reset = function () {
   this._numberOfRequests = 0;
 };
 
+RequestTracker.prototype.canRequestBePerformed = function (request) {
+  return !this.maxNumberOfRequestsReached() ||
+    (this.maxNumberOfRequestsReached() && !this.lastRequestEquals(request));
+};
+
 RequestTracker.prototype.maxNumberOfRequestsReached = function () {
   return this._numberOfRequests === this._maxNumberOfRequests;
 };

--- a/test/spec/windshaft/map-base.spec.js
+++ b/test/spec/windshaft/map-base.spec.js
@@ -153,12 +153,14 @@ describe('windshaft/map-base', function () {
 
         describe('when max number of subsecuent identical requests (with identical responses) have been performed', function () {
           beforeEach(function () {
-            for (var i = 0; i < 3; i++) {
-              this.windshaftMap.createInstance(this.options);
-            }
             spyOn(this.client, 'instantiateMap').and.callFake(function (options) {
               options[result]({ a: 'b' });
             });
+            for (var i = 0; i < 3; i++) {
+              this.windshaftMap.createInstance(this.options);
+            }
+
+            this.client.instantiateMap.calls.reset();
           });
 
           it('should make a request if payload has changed', function () {


### PR DESCRIPTION
Ensure that new requests to Windshaft can be performed after the max number of subsequent request has been reached, when the request is different.

@xavijam 👍 ?