### PR TITLE
Fix dataviews pointing to a layer that has a source

### DIFF
--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -228,7 +228,7 @@ module.exports = Model.extend({
   getSourceId: function () {
     // Dataview is pointing to a layer that has a source, so its
     // source is actually the the layers's source
-    if (this.hasLayerAsSource() && this.layer.get('source')) {
+    if (this.hasLayerAsSource() && this.layer.has('source')) {
       return this.layer.get('source');
     }
 

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -226,7 +226,20 @@ module.exports = Model.extend({
   },
 
   getSourceId: function () {
+    // Dataview is pointing to a layer that has a source, so its
+    // source is actually the the layers's source
+    if (this.hasLayerAsSource() && this.layer.get('source')) {
+      return this.layer.get('source');
+    }
+
+    // Dataview is pointing to a layer with `sql` or an analysis
+    // node directly, so just return the id that has been set by
+    // dataviews-factory.js
     return this.get('source').id;
+  },
+
+  hasLayerAsSource: function () {
+    return this.get('source').id === this.layer.id;
   },
 
   remove: function () {

--- a/src/windshaft/anonymous-map.js
+++ b/src/windshaft/anonymous-map.js
@@ -87,9 +87,17 @@ var AnonymousMap = MapBase.extend({
         if (!this._isAnalysisPartOfOtherAnalyses(sourceAnalysis)) {
           analyses.push(sourceAnalysis.toJSON());
         }
-      } else {
-        if (this._getLayerById(sourceId)) {
-          analyses.push(this._getSourceAnalysisForLayer(this._getLayerById(sourceId)));
+      } else { // sourceId might be the ID of a layer
+        var layerModel = this._getLayerById(sourceId);
+        if (layerModel) {
+          if (layerModel.get('sql')) {
+            analyses.push(this._getSourceAnalysisForLayer(this._getLayerById(sourceId)));
+          } else {
+            // layerModel has a source, so the analysis will be included
+            // in the payload when we get to that sourceId in this loop
+          }
+        } else {
+          throw new Error("sourceId '" + sourceId + "' doesn't exist");
         }
       }
     }, this);

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -473,6 +473,26 @@ describe('dataviews/dataview-model-base', function () {
 
       expect(dataview.getSourceId()).toEqual('THE_SOURCE_ID');
     });
+
+    it("should return the id of the layer's source", function () {
+      var layer = new Backbone.Model({
+        id: 'layerId',
+        source: 'a1'
+      });
+      layer.getDataProvider = jasmine.createSpy('getDataProvider').and.returnValue(undefined);
+
+      var dataview = new DataviewModelBase({
+        source: {
+          id: layer.id
+        }
+      }, { // eslint-disable-line
+        map: this.map,
+        windshaftMap: this.windshaftMap,
+        layer: layer
+      });
+
+      expect(dataview.getSourceId()).toEqual('a1');
+    });
   });
 
   describe('.hasSameSourceAsLayer', function () {

--- a/test/spec/windshaft/anonymous-map.spec.js
+++ b/test/spec/windshaft/anonymous-map.spec.js
@@ -340,12 +340,11 @@ describe('windshaft/anonymous-map', function () {
         expect(this.map.toJSON().analyses).toEqual([ analysis ]);
       });
 
-      it('should include a source analysis for dataviews whose source is a layer', function () {
+      it('should include a source analysis for dataviews whose source is a layer that has sql', function () {
+        // Create a dataview whose source is the layer
         var dataview = createFakeDataview({
           id: 'dataviewId1',
-          source: {
-            id: this.cartoDBLayer1.id
-          }
+          source: { id: this.cartoDBLayer1.id }
         }, this.map, this.cartoDBLayer1);
 
         this.dataviewsCollection.add(dataview);
@@ -358,6 +357,30 @@ describe('windshaft/anonymous-map', function () {
               query: this.cartoDBLayer1.get('sql')
             }
           }
+        ]);
+      });
+
+      it('should include a source analysis for dataviews whose source is a layer that has a source', function () {
+        var analysis = { id: 'c1' };
+        this.analysisCollection.add(analysis);
+
+        // CartoDB layer points to an analysis and has no sql
+        this.cartoDBLayer1.update({
+          source: 'c1',
+          sql: undefined,
+          cartocss: '#trade_area { ... }'
+        }, { silent: true });
+
+        // Create a dataview whose source is the layer
+        var dataview = createFakeDataview({
+          id: 'dataviewId1',
+          source: { id: this.cartoDBLayer1.id }
+        }, this.map, this.cartoDBLayer1);
+
+        this.dataviewsCollection.add(dataview);
+
+        expect(this.map.toJSON().analyses).toEqual([
+          analysis
         ]);
       });
 


### PR DESCRIPTION
@javisantana this fixes the issue you encountered. Basically, if a dataview "points" to a layer, and that layer doesn't have `sql`, it means that it's pointing to an analysis node, and the dataview should point to the layers's source in the payload that is sen't to the Maps API. 👍 ?