### PR TITLE
Re-fetch dataviews when source is affected by some filtering

### DIFF
--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -176,16 +176,12 @@ module.exports = Model.extend({
 
     return this.get('sync_on_data_change') &&
       this.get('enabled') &&
-        (!sourceId || sourceId && this._sourceAffectsDataview(sourceId));
+        (!sourceId || sourceId && this._sourceAffectsMyOwnSource(sourceId));
   },
 
-  _sourceAffectsDataview: function (sourceId) {
+  _sourceAffectsMyOwnSource: function (sourceId) {
     var sourceAnalysis = this._analysisCollection.get(this.getSourceId());
     return sourceAnalysis && sourceAnalysis.findAnalysisById(sourceId);
-  },
-
-  _affectedByChangeInSource: function (sourceId) {
-
   },
 
   _shouldFetchOnBoundingBoxChange: function () {

--- a/src/dataviews/dataviews-factory.js
+++ b/src/dataviews/dataviews-factory.js
@@ -16,9 +16,11 @@ module.exports = Model.extend({
   initialize: function (attrs, opts) {
     if (!opts.map) throw new Error('map is required');
     if (!opts.dataviewsCollection) throw new Error('dataviewsCollection is required');
+    if (!opts.analysisCollection) throw new Error('analysisCollection is required');
 
     this._map = opts.map;
     this._dataviewsCollection = opts.dataviewsCollection;
+    this._analysisCollection = opts.analysisCollection;
   },
 
   createCategoryModel: function (layerModel, attrs) {
@@ -34,8 +36,9 @@ module.exports = Model.extend({
     return this._newModel(
       new CategoryDataviewModel(attrs, {
         map: this._map,
+        layer: layerModel,
         filter: categoryFilter,
-        layer: layerModel
+        analysisCollection: this._analysisCollection
       })
     );
   },
@@ -46,7 +49,8 @@ module.exports = Model.extend({
     return this._newModel(
       new FormulaDataviewModel(attrs, {
         map: this._map,
-        layer: layerModel
+        layer: layerModel,
+        analysisCollection: this._analysisCollection
       })
     );
   },
@@ -62,8 +66,9 @@ module.exports = Model.extend({
     return this._newModel(
       new HistogramDataviewModel(attrs, {
         map: this._map,
+        layer: layerModel,
         filter: rangeFilter,
-        layer: layerModel
+        analysisCollection: this._analysisCollection
       })
     );
   },
@@ -74,7 +79,8 @@ module.exports = Model.extend({
     return this._newModel(
       new ListDataviewModel(attrs, {
         map: this._map,
-        layer: layerModel
+        layer: layerModel,
+        analysisCollection: this._analysisCollection
       })
     );
   },

--- a/src/dataviews/dataviews-factory.js
+++ b/src/dataviews/dataviews-factory.js
@@ -37,7 +37,6 @@ module.exports = Model.extend({
 
     return this._newModel(
       new CategoryDataviewModel(attrs, {
-        analysisCollection: this._analysisCollection,
         map: this._map,
         layer: layerModel,
         filter: categoryFilter,
@@ -51,7 +50,6 @@ module.exports = Model.extend({
     attrs = this._generateAttrsForDataview(layerModel, attrs, FormulaDataviewModel.ATTRS_NAMES);
     return this._newModel(
       new FormulaDataviewModel(attrs, {
-        analysisCollection: this._analysisCollection,
         map: this._map,
         layer: layerModel,
         analysisCollection: this._analysisCollection
@@ -69,7 +67,6 @@ module.exports = Model.extend({
 
     return this._newModel(
       new HistogramDataviewModel(attrs, {
-        analysisCollection: this._analysisCollection,
         map: this._map,
         layer: layerModel,
         filter: rangeFilter,
@@ -83,7 +80,6 @@ module.exports = Model.extend({
     attrs = this._generateAttrsForDataview(layerModel, attrs, ListDataviewModel.ATTRS_NAMES);
     return this._newModel(
       new ListDataviewModel(attrs, {
-        analysisCollection: this._analysisCollection,
         map: this._map,
         layer: layerModel,
         analysisCollection: this._analysisCollection

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -64,7 +64,7 @@ var Map = Model.extend({
     // in the tests that depend on this to work
     this.reload = _.debounce(function (options) {
       options = options || {};
-      options = _.pick(options, 'sourceLayerId', 'forceFetch', 'success', 'error');
+      options = _.pick(options, 'sourceId', 'forceFetch', 'success', 'error');
       this._windshaftMap.createInstance(options);
     }.bind(this), this.RELOAD_DEBOUNCE_TIME);
   },
@@ -165,14 +165,14 @@ var Map = Model.extend({
 
   _onLayerAdded: function (layerModel) {
     this.reload({
-      sourceLayerId: layerModel.get('id')
+      sourceId: layerModel.get('id')
     });
     this._updateAttributions();
   },
 
   _onLayerRemoved: function (layerModel) {
     this.reload({
-      sourceLayerId: layerModel.get('id')
+      sourceId: layerModel.get('id')
     });
     this._updateAttributions();
   },

--- a/src/geo/map/cartodb-layer.js
+++ b/src/geo/map/cartodb-layer.js
@@ -49,7 +49,7 @@ var CartoDBLayer = LayerModelBase.extend({
 
   _reloadMap: function () {
     this._map.reload({
-      sourceLayerId: this.get('id')
+      sourceId: this.get('id')
     });
   },
 

--- a/src/geo/map/torque-layer.js
+++ b/src/geo/map/torque-layer.js
@@ -81,7 +81,7 @@ var TorqueLayer = LayerModelBase.extend({
 
   _reloadMap: function () {
     this._map.reload({
-      sourceLayerId: this.get('id')
+      sourceId: this.get('id')
     });
   },
 

--- a/src/vis/model-updater.js
+++ b/src/vis/model-updater.js
@@ -28,10 +28,10 @@ var ModelUpdater = function (deps) {
   this._analysisCollection = deps.analysisCollection;
 };
 
-ModelUpdater.prototype.updateModels = function (windhsaftMap, sourceLayerId, forceFetch) {
+ModelUpdater.prototype.updateModels = function (windhsaftMap, sourceId, forceFetch) {
   this._updateLayerGroupModel(windhsaftMap);
   this._updateLayerModels(windhsaftMap);
-  this._updateDataviewModels(windhsaftMap, sourceLayerId, forceFetch);
+  this._updateDataviewModels(windhsaftMap, sourceId, forceFetch);
   this._updateAnalysisModels(windhsaftMap);
 
   this._visModel.setOk();
@@ -57,14 +57,14 @@ ModelUpdater.prototype._updateLayerModels = function (windshaftMap) {
   }, this);
 };
 
-ModelUpdater.prototype._updateDataviewModels = function (windshaftMap, sourceLayerId, forceFetch) {
+ModelUpdater.prototype._updateDataviewModels = function (windshaftMap, sourceId, forceFetch) {
   this._dataviewsCollection.each(function (dataviewModel) {
     var dataviewMetadata = windshaftMap.getDataviewMetadata(dataviewModel.get('id'));
     if (dataviewMetadata) {
       dataviewModel.set({
         url: dataviewMetadata.url[this._getProtocol()]
       }, {
-        sourceLayerId: sourceLayerId,
+        sourceId: sourceId,
         forceFetch: forceFetch
       });
     }

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -171,8 +171,9 @@ var VisModel = Backbone.Model.extend({
       apiKey: this.get('apiKey'),
       authToken: this.get('authToken')
     }, {
+      map: this.map,
       dataviewsCollection: this._dataviewsCollection,
-      map: this.map
+      analysisCollection: this._analysisCollection
     });
 
     // Create the public Analysis Factory

--- a/src/windshaft/map-base.js
+++ b/src/windshaft/map-base.js
@@ -94,7 +94,7 @@ var WindshaftMap = Backbone.Model.extend({
       success: function (response) {
         this._trackRequest(request, response);
         this.set(response);
-        this._modelUpdater.updateModels(this, options.sourceLayerId, options.forceFetch);
+        this._modelUpdater.updateModels(this, options.sourceId, options.forceFetch);
         this.trigger('instanceCreated');
         options.success && options.success(this);
       }.bind(this),

--- a/test/spec/dataviews/category-dataview-model.spec.js
+++ b/test/spec/dataviews/category-dataview-model.spec.js
@@ -9,25 +9,28 @@ describe('dataviews/category-dataview-model', function () {
     this.map.getViewBounds = jasmine.createSpy();
     this.map.reload = jasmine.createSpy();
     this.map.getViewBounds.and.returnValue([[1, 2], [3, 4]]);
-    this.model = new CategoryDataviewModel(null, {
+    this.model = new CategoryDataviewModel({
+      source: { id: 'a0' }
+    }, {
       map: this.map,
       layer: jasmine.createSpyObj('layer', ['get', 'getDataProvider']),
-      filter: new WindshaftFiltersCategory()
+      filter: new WindshaftFiltersCategory(),
+      analysisCollection: new Backbone.Collection()
     });
   });
 
   it('should reload map and force fetch on changing attrs', function () {
     this.map.reload.calls.reset();
     this.model.set('column', 'random_col');
-    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceLayerId: undefined });
+    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: 'a0' });
 
     this.map.reload.calls.reset();
     this.model.set('aggregation', 'count');
-    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceLayerId: undefined });
+    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: 'a0' });
 
     this.map.reload.calls.reset();
     this.model.set('aggregation_column', 'other');
-    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceLayerId: undefined });
+    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: 'a0' });
   });
 
   it('should define several internal models/collections', function () {
@@ -38,11 +41,13 @@ describe('dataviews/category-dataview-model', function () {
 
   it('should set the api_key attribute on the internal models', function () {
     this.model = new CategoryDataviewModel({
-      apiKey: 'API_KEY'
+      source: { id: 'a0' },
+      apiKey: 'API_KEY',
     }, {
       map: this.map,
       layer: jasmine.createSpyObj('layer', ['get', 'getDataProvider']),
-      filter: new WindshaftFiltersCategory()
+      filter: new WindshaftFiltersCategory(),
+      analysisCollection: new Backbone.Collection()
     });
 
     expect(this.model._searchModel.get('apiKey')).toEqual('API_KEY');

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -179,6 +179,7 @@ describe('dataviews/dataview-model-base', function () {
 
     describe('when change:url has a sourceId option', function () {
       beforeEach(function () {
+        this.analysisCollection.reset([]);
         this.analysisFactory.analyse({
           id: 'a2',
           type: 'estimated-population',

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -358,9 +358,9 @@ describe('dataviews/dataview-model-base', function () {
 
     it('should reload the map by default when the filter changes', function () {
       var filter = new Backbone.Model();
-      new DataviewModelBase({
+      new DataviewModelBase({ // eslint-disable-line
         source: { id: 'a0' }
-      }, { // eslint-disable-line
+      }, {
         map: this.map,
         layer: this.layer,
         filter: filter,

--- a/test/spec/dataviews/histogram-dataview-model.spec.js
+++ b/test/spec/dataviews/histogram-dataview-model.spec.js
@@ -1,3 +1,5 @@
+var Backbone = require('backbone');
+
 var Model = require('../../../src/core/model');
 var RangeFilter = require('../../../src/windshaft/filters/range');
 var HistogramDataviewModel = require('../../../src/dataviews/histogram-dataview-model');
@@ -11,10 +13,13 @@ describe('dataviews/histogram-dataview-model', function () {
     this.layer.getDataProvider = function () {};
     spyOn(HistogramDataviewModel.prototype, 'listenTo').and.callThrough();
     spyOn(HistogramDataviewModel.prototype, 'fetch').and.callThrough();
-    this.model = new HistogramDataviewModel({}, {
+    this.model = new HistogramDataviewModel({
+      source: { id: 'a0' }
+    }, {
       map: this.map,
       layer: this.layer,
-      filter: this.filter
+      filter: this.filter,
+      analysisCollection: new Backbone.Collection()
     });
   });
 
@@ -31,11 +36,13 @@ describe('dataviews/histogram-dataview-model', function () {
 
   it('should set the api_key attribute on the internal models', function () {
     this.model = new HistogramDataviewModel({
-      apiKey: 'API_KEY'
+      apiKey: 'API_KEY',
+      source: { id: 'a0' }
     }, {
       map: this.map,
       layer: jasmine.createSpyObj('layer', ['get', 'getDataProvider']),
-      filter: this.filter
+      filter: this.filter,
+      analysisCollection: new Backbone.Collection()
     });
 
     expect(this.model._unfilteredData.get('apiKey')).toEqual('API_KEY');
@@ -136,7 +143,7 @@ describe('dataviews/histogram-dataview-model', function () {
     it('should reload map and force fetch', function () {
       this.map.reload.calls.reset();
       this.model.set('column', 'random_col');
-      expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceLayerId: undefined });
+      expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: 'a0' });
     });
   });
 

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -188,7 +188,7 @@ describe('core/geo/map', function() {
       map.layers.add({ id: 'layer1' });
 
       expect(map.reload).toHaveBeenCalledWith({
-        sourceLayerId: 'layer1'
+        sourceId: 'layer1'
       });
     });
 
@@ -200,7 +200,7 @@ describe('core/geo/map', function() {
       map.layers.remove(layer);
 
       expect(map.reload).toHaveBeenCalledWith({
-        sourceLayerId: 'layer1'
+        sourceId: 'layer1'
       });
     });
   });
@@ -235,14 +235,14 @@ describe('core/geo/map', function() {
       map.reload({
         a: 1,
         b: 2,
-        sourceLayerId: 'sourceLayerId',
+        sourceId: 'sourceId',
         forceFetch: 'forceFetch',
         success: 'success'
       });
 
       setTimeout(function () {
         expect(windshaftMap.createInstance).toHaveBeenCalledWith({
-          sourceLayerId: 'sourceLayerId',
+          sourceId: 'sourceId',
           forceFetch: 'forceFetch',
           success: 'success'
         });

--- a/test/spec/windshaft/anonymous-map.spec.js
+++ b/test/spec/windshaft/anonymous-map.spec.js
@@ -24,7 +24,6 @@ var createFakeDataview = function (attrs, windshaftMap, layer, analysisCollectio
   });
 
   return new HistogramDataviewModel(attrs, {
-    analysisCollection: analysisCollection,
     map: jasmine.createSpyObj('map', ['getViewBounds', 'bind', 'reload']),
     windshaftMap: windshaftMap,
     layer: layer,
@@ -245,7 +244,6 @@ describe('windshaft/anonymous-map', function () {
           id: 'a0'
         }
       }, {
-        analysisCollection: this.analysisCollection,
         map: jasmine.createSpyObj('map', ['getViewBounds', 'bind', 'reload']),
         windshaftMap: this.map,
         layer: this.cartoDBLayer1,
@@ -260,7 +258,6 @@ describe('windshaft/anonymous-map', function () {
           id: 'a1'
         }
       }, {
-        analysisCollection: this.analysisCollection,
         map: jasmine.createSpyObj('map', ['getViewBounds', 'bind', 'reload']),
         windshaftMap: this.map,
         layer: this.cartoDBLayer2,

--- a/test/spec/windshaft/anonymous-map.spec.js
+++ b/test/spec/windshaft/anonymous-map.spec.js
@@ -26,7 +26,8 @@ var createFakeDataview = function (attrs, windshaftMap, layer) {
   return new HistogramDataviewModel(attrs, {
     map: jasmine.createSpyObj('map', ['getViewBounds', 'bind', 'reload']),
     windshaftMap: windshaftMap,
-    layer: layer
+    layer: layer,
+    analysisCollection: new Backbone.Collection()
   });
 };
 
@@ -245,7 +246,8 @@ describe('windshaft/anonymous-map', function () {
       }, {
         map: jasmine.createSpyObj('map', ['getViewBounds', 'bind', 'reload']),
         windshaftMap: this.map,
-        layer: this.cartoDBLayer1
+        layer: this.cartoDBLayer1,
+        analysisCollection: new Backbone.Collection()
       });
 
       var dataview2 = new HistogramDataviewModel({
@@ -258,7 +260,8 @@ describe('windshaft/anonymous-map', function () {
       }, {
         map: jasmine.createSpyObj('map', ['getViewBounds', 'bind', 'reload']),
         windshaftMap: this.map,
-        layer: this.cartoDBLayer2
+        layer: this.cartoDBLayer2,
+        analysisCollection: new Backbone.Collection()
       });
 
       this.cartoDBLayer2.set('visible', false, { silent: true });

--- a/test/spec/windshaft/map-base.spec.js
+++ b/test/spec/windshaft/map-base.spec.js
@@ -89,12 +89,14 @@ describe('windshaft/map-base', function () {
 
       this.dataview = new HistogramDataviewModel({
         id: 'dataviewId',
-        type: 'list'
+        type: 'list',
+        source: { id: 'a0' }
       }, {
         map: this.map,
         windshaftMap: this.windshaftMap,
         layer: this.cartoDBLayer1,
-        filter: this.filter
+        filter: this.filter,
+        analysisCollection: new Backbone.Collection()
       });
 
       this.dataviewsCollection.add(this.dataview);
@@ -200,7 +202,7 @@ describe('windshaft/map-base', function () {
         spyOn(this.windshaftMap, 'toJSON').and.returnValue({ foo: 'bar' });
 
         this.windshaftMap.createInstance({
-          sourceLayerId: 'sourceLayerId'
+          sourceId: 'sourceId'
         });
 
         var args = this.client.instantiateMap.calls.mostRecent().args[0];
@@ -240,7 +242,7 @@ describe('windshaft/map-base', function () {
         spyOn(this.windshaftMap, 'toJSON').and.returnValue({ foo: 'bar' });
 
         this.windshaftMap.createInstance({
-          sourceLayerId: 'sourceLayerId'
+          sourceId: 'sourceId'
         });
         var args = this.client.instantiateMap.calls.mostRecent().args[0];
 
@@ -253,7 +255,7 @@ describe('windshaft/map-base', function () {
 
         // Recreate the instance again
         this.windshaftMap.createInstance({
-          sourceLayerId: 'sourceLayerId'
+          sourceId: 'sourceId'
         });
         args = this.client.instantiateMap.calls.mostRecent().args[0];
 
@@ -286,7 +288,7 @@ describe('windshaft/map-base', function () {
         });
 
         this.windshaftMap.createInstance({
-          sourceLayerId: 'sourceLayerId'
+          sourceId: 'sourceId'
         });
 
         var args = this.client.instantiateMap.calls.mostRecent().args[0];
@@ -312,7 +314,7 @@ describe('windshaft/map-base', function () {
         });
 
         this.windshaftMap.createInstance({
-          sourceLayerId: 'sourceLayerId'
+          sourceId: 'sourceId'
         });
 
         var args = this.client.instantiateMap.calls.mostRecent().args[0];
@@ -325,7 +327,7 @@ describe('windshaft/map-base', function () {
       it('should set the attributes of the new instance', function () {
         this.layersCollection.reset([ this.cartoDBLayer1, this.cartoDBLayer2, this.torqueLayer ]);
         this.windshaftMap.createInstance({
-          sourceLayerId: 'sourceLayerId'
+          sourceId: 'sourceId'
         });
 
         expect(this.windshaftMap.get('layergroupid')).toEqual('layergroupid');
@@ -334,11 +336,11 @@ describe('windshaft/map-base', function () {
 
       it('should use the modelUpdater to update internal models', function () {
         this.windshaftMap.createInstance({
-          sourceLayerId: 'sourceLayerId',
+          sourceId: 'sourceId',
           forceFetch: 'forceFetch'
         });
 
-        expect(this.modelUpdater.updateModels).toHaveBeenCalledWith(this.windshaftMap, 'sourceLayerId', 'forceFetch');
+        expect(this.modelUpdater.updateModels).toHaveBeenCalledWith(this.windshaftMap, 'sourceId', 'forceFetch');
       });
     });
 

--- a/test/unit/dataviews/formula-dataview-model.spec.js
+++ b/test/unit/dataviews/formula-dataview-model.spec.js
@@ -15,12 +15,12 @@ describe('dataviews/formula-dataview-model', function () {
   it('should reload map and force fetch on operation change', function () {
     this.map.reload.calls.reset();
     this.model.set('operation', 'avg');
-    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceLayerId: undefined });
+    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: undefined });
   });
 
   it('should reload map and force fetch on column change', function () {
     this.map.reload.calls.reset();
     this.model.set('column', 'other_col');
-    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceLayerId: undefined });
+    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: undefined });
   });
 });

--- a/test/unit/dataviews/list-dataview-model.spec.js
+++ b/test/unit/dataviews/list-dataview-model.spec.js
@@ -14,6 +14,6 @@ describe('dataviews/list-dataview-model', function () {
   it('should reload map and force fetch on columns change', function () {
     this.map.reload.calls.reset();
     this.model.set('columns', ['asd']);
-    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceLayerId: undefined });
+    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: undefined });
   });
 });

--- a/test/unit/vis/model-updater.spec.js
+++ b/test/unit/vis/model-updater.spec.js
@@ -103,12 +103,12 @@ describe('src/vis/model-updater', function () {
 
       spyOn(dataview1, 'set').and.callThrough();
 
-      this.modelUpdater.updateModels(this.windshaftMap, 'sourceLayerId', 'forceFetch');
+      this.modelUpdater.updateModels(this.windshaftMap, 'sourceId', 'forceFetch');
 
       expect(dataview1.set).toHaveBeenCalledWith({
         url: 'http://example1.com'
       }, {
-        sourceLayerId: 'sourceLayerId',
+        sourceId: 'sourceId',
         forceFetch: 'forceFetch'
       });
 


### PR DESCRIPTION
Hopefully fixes https://github.com/CartoDB/cartodb.js/issues/1345.

Imagine the following situation, where there's a layer with 2 analysis and there're 4 widgets:

```
Layer A:     <- widget3
  - a2       <- widget2
  - a1       <- widget1
  - a0       <- widget0
```

If the filter of widget0 changes, widget1, widget2 and widget3 need to fetch data again (because a0 affects a1 and a2). But, if the filter of widget1 changes, only widget1, widget2 and widget3 will need to fetch data again...

In summary: dataviews whose source is affected by the source of the dataview that caused the map to be re-instantiated, should fetch again.

@xavijam :+1: ?