### PR TITLE
Fix attributions

### DIFF
--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -60,13 +60,72 @@ var Map = Model.extend({
       });
     }
 
+    this._instantiateMapWasCalled = false;
+
     // This method is declared here so that we can spyOn _.debounce
     // in the tests that depend on this to work
     this.reload = _.debounce(function (options) {
-      options = options || {};
-      options = _.pick(options, 'sourceId', 'forceFetch', 'success', 'error');
-      this._windshaftMap.createInstance(options);
+      if (this._instantiateMapWasCalled) {
+        options = options || {};
+        options = _.pick(options, 'sourceId', 'forceFetch', 'success', 'error');
+        this._windshaftMap.createInstance(options);
+      }
     }.bind(this), this.RELOAD_DEBOUNCE_TIME);
+
+    this._initBinds();
+  },
+
+  _initBinds: function () {
+    this.layers.bind('reset', this._onLayersResetted, this);
+    this.layers.bind('add', this._onLayerAdded, this);
+    this.layers.bind('remove', this._onLayerRemoved, this);
+    this.layers.bind('change:attribution', this._updateAttributions, this);
+
+    if (this._dataviewsCollection) {
+      // When new dataviews are defined, a new instance of the map needs to be created
+      this.listenTo(this._dataviewsCollection, 'add', _.debounce(this._onDataviewAdded.bind(this), 10));
+    }
+  },
+
+  _onLayersResetted: function () {
+    if (this.layers.size() >= 1) {
+      this._adjustZoomtoLayer(this.layers.models[0]);
+    }
+
+    this.reload();
+    this._updateAttributions();
+  },
+
+  _onLayerAdded: function (layerModel) {
+    this.reload({
+      sourceId: layerModel.get('id')
+    });
+    this._updateAttributions();
+  },
+
+  _onLayerRemoved: function (layerModel) {
+    this.reload({
+      sourceId: layerModel.get('id')
+    });
+    this._updateAttributions();
+  },
+
+  _onDataviewAdded: function (layerModel) {
+    this.reload();
+  },
+
+  _updateAttributions: function () {
+    var defaultCartoDBAttribution = this.defaults.attribution[0];
+    var attributions = _.chain(this.layers.models)
+      .map(function (layer) { return sanitize.html(layer.get('attribution')); })
+      .reject(function (attribution) { return attribution === defaultCartoDBAttribution; })
+      .compact()
+      .uniq()
+      .value();
+
+    attributions.push(defaultCartoDBAttribution);
+
+    this.set('attribution', attributions);
   },
 
   // PUBLIC API METHODS
@@ -133,70 +192,9 @@ var Map = Model.extend({
 
   // INTERNAL CartoDB.js METHODS
 
-  _initBinds: function () {
-    this.layers.bind('reset', function () {
-      if (this.layers.size() >= 1) {
-        this._adjustZoomtoLayer(this.layers.models[0]);
-      }
-    }, this);
-
-    // TODO: When the order of the layers change, the instance of the map needs
-    // to be re-recreated
-    this.layers.bind('reset', this._onLayersResetted, this);
-    this.layers.bind('add', this._onLayerAdded, this);
-    this.layers.bind('remove', this._onLayerRemoved, this);
-    this.layers.bind('change:attribution', this._updateAttributions, this);
-
-    if (this._dataviewsCollection) {
-      // When new dataviews are defined, a new instance of the map needs to be created
-      this.listenTo(this._dataviewsCollection, 'add', _.debounce(this._onDataviewAdded.bind(this), 10));
-    }
-  },
-
   instantiateMap: function (options) {
-    this._initBinds();
+    this._instantiateMapWasCalled = true;
     this.reload(_.pick(options, ['success', 'error']));
-  },
-
-  _onLayersResetted: function () {
-    this.reload();
-    this._updateAttributions();
-  },
-
-  _onLayerAdded: function (layerModel) {
-    this.reload({
-      sourceId: layerModel.get('id')
-    });
-    this._updateAttributions();
-  },
-
-  _onLayerRemoved: function (layerModel) {
-    this.reload({
-      sourceId: layerModel.get('id')
-    });
-    this._updateAttributions();
-  },
-
-  _onDataviewAdded: function (layerModel) {
-    this.reload();
-  },
-
-  _updateAttributions: function () {
-    var defaultCartoDBAttribution = this.defaults.attribution[0];
-    var attributions = _.chain(this.layers.models)
-      .map(function (layer) { return sanitize.html(layer.get('attribution')); })
-      .reject(function (attribution) { return attribution === defaultCartoDBAttribution; })
-      .compact()
-      .uniq()
-      .value();
-
-    attributions.push(defaultCartoDBAttribution);
-
-    this.set('attribution', attributions);
-  },
-
-  getWindshaftMap: function () {
-    return this._windshaftMap;
   },
 
   setView: function (latlng, zoom) {

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -143,11 +143,9 @@ var VisModel = Backbone.Model.extend({
     // Create the Map
     var allowDragging = util.isMobileDevice() || vizjson.hasZoomOverlay() || vizjson.scrollwheel;
 
-    var mapConfig = {
+    this.map = new Map({
       title: vizjson.title,
       description: vizjson.description,
-      maxZoom: vizjson.maxZoom,
-      minZoom: vizjson.minZoom,
       bounds: vizjson.bounds,
       center: vizjson.center,
       zoom: vizjson.zoom,
@@ -155,9 +153,7 @@ var VisModel = Backbone.Model.extend({
       drag: allowDragging,
       provider: vizjson.map_provider,
       vector: vizjson.vector
-    };
-
-    this.map = new Map(mapConfig, {
+    }, {
       layersCollection: this._layersCollection,
       windshaftMap: this._windshaftMap,
       dataviewsCollection: this._dataviewsCollection

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -206,49 +206,64 @@ describe('core/geo/map', function() {
   });
 
   describe('reload', function () {
-    it('should be debounced', function (done) {
-      var windshaftMap = jasmine.createSpyObj('windshaftMap', ['createInstance']);
-      var map = new Map({}, {
-        windshaftMap: windshaftMap
+    beforeEach(function () {
+      this.windshaftMap = jasmine.createSpyObj('windshaftMap', ['createInstance']);
+      this.map = new Map({}, {
+        windshaftMap: this.windshaftMap
       });
-
-      // Reload the map 1000 times in a row
-      for (var i = 0; i < 1000; i++) {
-        map.reload();
-      }
-
-      setTimeout(function () {
-        expect(windshaftMap.createInstance).toHaveBeenCalled();
-
-        // windshaftMap.createInstance is debounced and has only been called once
-        expect(windshaftMap.createInstance.calls.count()).toEqual(1);
-        done();
-      }, 25);
     });
 
-    it('should forward options', function (done) {
-      var windshaftMap = jasmine.createSpyObj('windshaftMap', ['createInstance']);
-      var map = new Map({}, {
-        windshaftMap: windshaftMap
+    describe("when map hasn't been instantiated yet", function () {
+      it('should NOT instantiate map', function (done) {
+        this.map.reload({});
+
+        setTimeout(function () {
+          expect(this.windshaftMap.createInstance).not.toHaveBeenCalled();
+
+          done();
+        }.bind(this), 25);
+      });
+    });
+
+    describe('when map has been instantiated once', function () {
+      beforeEach(function () {
+        this.map.instantiateMap();
       });
 
-      map.reload({
-        a: 1,
-        b: 2,
-        sourceId: 'sourceId',
-        forceFetch: 'forceFetch',
-        success: 'success'
-      });
-
-      setTimeout(function () {
-        expect(windshaftMap.createInstance).toHaveBeenCalledWith({
+      it('should instantiate map and forward options', function (done) {
+        this.map.reload({
+          a: 1,
+          b: 2,
           sourceId: 'sourceId',
           forceFetch: 'forceFetch',
           success: 'success'
         });
 
-        done();
-      }, 25);
+        setTimeout(function () {
+          expect(this.windshaftMap.createInstance).toHaveBeenCalledWith({
+            sourceId: 'sourceId',
+            forceFetch: 'forceFetch',
+            success: 'success'
+          });
+
+          done();
+        }.bind(this), 25);
+      });
+
+      it('should be debounced', function (done) {
+        // Reload the map 1000 times in a row
+        for (var i = 0; i < 1000; i++) {
+          this.map.reload();
+        }
+
+        setTimeout(function () {
+          expect(this.windshaftMap.createInstance).toHaveBeenCalled();
+
+          // windshaftMap.createInstance is debounced and has only been called once
+          expect(this.windshaftMap.createInstance.calls.count()).toEqual(1);
+          done();
+        }.bind(this), 25);
+      });
     });
   });
 

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -251,17 +251,6 @@ describe('vis/vis', function () {
       expect(this.vis.map.layers.size()).toEqual(3);
     });
 
-    it('should use given maxZoom and minZoom', function () {
-      var vizjson = fakeVizJSON();
-      vizjson.maxZoom = 10;
-      vizjson.minZoom = 5;
-
-      this.vis.load(new VizJSON(vizjson));
-
-      expect(this.vis.map.get('maxZoom')).toEqual(10);
-      expect(this.vis.map.get('minZoom')).toEqual(5);
-    });
-
     it('should use the given provider', function () {
       var vizjson = fakeVizJSON();
       vizjson.map_provider = 'googlemaps';


### PR DESCRIPTION
Closes https://github.com/CartoDB/cartodb/issues/8959.

Events were being bound every time `map.instantiateMap` was called and this was causing:

1. `_updateAttributions` not being called right after the layers are reseted.
2. event callbacks probably being executed multiple times every time `map.instantiateMap` was called.

Also, `map.reload` does nothing until `map.instantiateMap`has been called at least once now.

@xavijam 👍 or 👎 ?