### PR TITLE
Changes default CARTO attribution

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -134,7 +134,6 @@
 **/test/spec/geo/map/gmaps-base-layer.spec.js
 **/test/spec/geo/map/tile-layer.spec.js
 **/test/spec/geo/map-view.spec.js
-**/test/spec/geo/map.spec.js
 **/test/spec/geo/ui/header.spec.js
 **/test/spec/geo/ui/infobox.spec.js
 **/test/spec/geo/ui/infowindow.spec.js

--- a/examples/v4/gmaps-layergroup.html
+++ b/examples/v4/gmaps-layergroup.html
@@ -69,7 +69,7 @@
                 "read_only":true,
                 "minZoom":"0",
                 "maxZoom":"18",
-                "attribution":"\u00a9 <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors \u00a9 <a href= \"http://cartodb.com/attributions#basemaps\">CartoDB</a>",
+                "attribution":"&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
                 "subdomains":"abcd",
                 "category":"CartoDB"
               },

--- a/examples/v4/leaflet-layergroup-vector.html
+++ b/examples/v4/leaflet-layergroup-vector.html
@@ -66,7 +66,7 @@
                 "read_only":true,
                 "minZoom":"0",
                 "maxZoom":"18",
-                "attribution":"\u00a9 <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors \u00a9 <a href= \"http://cartodb.com/attributions#basemaps\">CartoDB</a>",
+                "attribution":"&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
                 "subdomains":"abcd",
                 "category":"CartoDB"
               },
@@ -263,7 +263,7 @@
                 "subdomains": "abcd",
                 "minZoom": "0",
                 "maxZoom": "18",
-                "attribution": "&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors &copy; <a href= \"http://cartodb.com/attributions\">CartoDB</a>",
+                "attribution":"&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
                 "urlTemplate": "http://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png",
                 "name": "Positron Labels",
                 "id": "bc054932-1ae8-4d4a-96d6-d49ce4247a59",

--- a/examples/v4/leaflet-layergroup.html
+++ b/examples/v4/leaflet-layergroup.html
@@ -65,7 +65,7 @@
                 "read_only":true,
                 "minZoom":"0",
                 "maxZoom":"18",
-                "attribution":"\u00a9 <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors \u00a9 <a href= \"http://cartodb.com/attributions#basemaps\">CartoDB</a>",
+                "attribution":"&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
                 "subdomains":"abcd",
                 "category":"CartoDB"
               },
@@ -263,7 +263,7 @@
                 "subdomains": "abcd",
                 "minZoom": "0",
                 "maxZoom": "18",
-                "attribution": "&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors &copy; <a href= \"http://cartodb.com/attributions\">CartoDB</a>",
+                "attribution": "&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
                 "urlTemplate": "http://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png",
                 "name": "Positron Labels",
                 "id": "bc054932-1ae8-4d4a-96d6-d49ce4247a59",

--- a/src/cdb.config.js
+++ b/src/cdb.config.js
@@ -2,7 +2,7 @@ var Config = require('./core/config');
 
 var config = new Config();
 config.set({
-  cartodb_attributions: 'CARTO <a href="https://carto.com/attributions" target="_blank">attribution</a>',
+  cartodb_attributions: '© <a href="https://carto.com/attributions" target="_blank">CARTO</a>',
   cartodb_logo_link: 'http://www.carto.com'
 });
 

--- a/test/spec/cartodb.spec.js
+++ b/test/spec/cartodb.spec.js
@@ -74,7 +74,7 @@ describe('cartodb.js bundle', function() {
     });
 
     it('config should contain links variables', function() {
-      expect(cdb.config.get('cartodb_attributions')).toEqual("CARTO <a href=\"https://carto.com/attributions\" target=\"_blank\">attribution</a>");
+      expect(cdb.config.get('cartodb_attributions')).toEqual("© <a href=\"https://carto.com/attributions\" target=\"_blank\">CARTO</a>");
       expect(cdb.config.get('cartodb_logo_link')).toEqual("http://www.carto.com");
     });
 

--- a/test/spec/geo/leaflet/leaflet-map-view.spec.js
+++ b/test/spec/geo/leaflet/leaflet-map-view.spec.js
@@ -391,7 +391,7 @@ describe('geo/leaflet/leaflet-map-view', function () {
       map.addLayer(layer);
 
       var attributions = mapView.$el.find('.leaflet-control-attribution').text();
-      expect(attributions).toEqual('Leaflet | Stamen, CARTO attribution, custom attribution');
+      expect(attributions).toEqual('Leaflet | Stamen, © CARTO, custom attribution');
     });
 
     it('should not render attributions when the Leaflet map has attributionControl disabled', function () {

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -8,10 +8,10 @@ var GMapsBaseLayer = require('../../../src/geo/map/gmaps-base-layer');
 
 var Map = require('../../../src/geo/map');
 
-describe('core/geo/map', function() {
+describe('core/geo/map', function () {
   var map;
 
-  beforeEach(function() {
+  beforeEach(function () {
     map = new Map();
     map.instantiateMap();
   });
@@ -57,32 +57,32 @@ describe('core/geo/map', function() {
     });
   });
 
-  it("should raise only one change event on setBounds", function() {
+  it('should raise only one change event on setBounds', function () {
     var c = 0;
-    map.bind('change:view_bounds_ne', function() {
+    map.bind('change:view_bounds_ne', function () {
       c++;
     });
-    map.setBounds([[1,2],[1,2]]);
+    map.setBounds([[1, 2], [1, 2]]);
     expect(c).toEqual(1);
   });
 
-  it("should not change center or zoom when the bounds are not ok", function() {
+  it('should not change center or zoom when the bounds are not ok', function () {
     var c = 0;
-    map.bind('change:center', function() {
+    map.bind('change:center', function () {
       c++;
     });
-    map.setBounds([[1,2],[1,2]]);
+    map.setBounds([[1, 2], [1, 2]]);
     expect(c).toEqual(0);
   });
 
-  it("should not change bounds when map size is 0", function() {
+  it('should not change bounds when map size is 0', function () {
     map.set('zoom', 10);
-    var bounds = [[43.100982876188546, 35.419921875], [60.23981116999893, 69.345703125]]
+    var bounds = [[43.100982876188546, 35.419921875], [60.23981116999893, 69.345703125]];
     map.fitBounds(bounds, {x: 0, y: 0});
     expect(map.get('zoom')).toEqual(10);
   });
 
-  it("should adjust zoom to layer", function() {
+  it('should adjust zoom to layer', function () {
     expect(map.get('maxZoom')).toEqual(map.defaults.maxZoom);
     expect(map.get('minZoom')).toEqual(map.defaults.minZoom);
 
@@ -92,14 +92,14 @@ describe('core/geo/map', function() {
     expect(map.get('maxZoom')).toEqual(25);
     expect(map.get('minZoom')).toEqual(5);
 
-    var layer = new PlainLayer({ minZoom: "7", maxZoom: "31" });
+    layer = new PlainLayer({ minZoom: '7', maxZoom: '31' });
     map.layers.reset(layer);
 
     expect(map.get('maxZoom')).toEqual(31);
     expect(map.get('minZoom')).toEqual(7);
   });
 
-  it("shouldn't set a NaN zoom", function() {
+  it("shouldn't set a NaN zoom", function () {
     var layer = new PlainLayer({ minZoom: NaN, maxZoom: NaN });
     map.layers.reset(layer);
 
@@ -107,13 +107,13 @@ describe('core/geo/map', function() {
     expect(map.get('minZoom')).toEqual(map.defaults.minZoom);
   });
 
-  it('should update the attributions of the map when layers are reset/added/removed', function() {
+  it('should update the attributions of the map when layers are reset/added/removed', function () {
     map = new Map();
     map.instantiateMap();
 
     // Map has the default CartoDB attribution
     expect(map.get('attribution')).toEqual([
-      "CARTO <a href=\"https://carto.com/attributions\" target=\"_blank\">attribution</a>"
+      '© <a href="https://carto.com/attributions" target="_blank">CARTO</a>'
     ]);
 
     var layer1 = new CartoDBLayer({ attribution: 'attribution1' });
@@ -125,9 +125,9 @@ describe('core/geo/map', function() {
 
     // Attributions have been updated removing duplicated and empty attributions
     expect(map.get('attribution')).toEqual([
-      "attribution1",
-      "wadus",
-      "CARTO <a href=\"https://carto.com/attributions\" target=\"_blank\">attribution</a>",
+      'attribution1',
+      'wadus',
+      '© <a href="https://carto.com/attributions" target="_blank">CARTO</a>'
     ]);
 
     var layer = new CartoDBLayer({ attribution: 'attribution2' });
@@ -136,40 +136,40 @@ describe('core/geo/map', function() {
 
     // The attribution of the new layer has been appended before the default CartoDB attribution
     expect(map.get('attribution')).toEqual([
-      "attribution1",
-      "wadus",
-      "attribution2",
-      "CARTO <a href=\"https://carto.com/attributions\" target=\"_blank\">attribution</a>",
+      'attribution1',
+      'wadus',
+      'attribution2',
+      '© <a href="https://carto.com/attributions" target="_blank">CARTO</a>'
     ]);
 
     layer.set('attribution', 'new attribution');
 
     // The attribution of the layer has been updated in the map
     expect(map.get('attribution')).toEqual([
-      "attribution1",
-      "wadus",
-      "new attribution",
-      "CARTO <a href=\"https://carto.com/attributions\" target=\"_blank\">attribution</a>",
+      'attribution1',
+      'wadus',
+      'new attribution',
+      '© <a href="https://carto.com/attributions" target="_blank">CARTO</a>'
     ]);
 
     map.layers.remove(layer);
 
     expect(map.get('attribution')).toEqual([
-      "attribution1",
-      "wadus",
-      "CARTO <a href=\"https://carto.com/attributions\" target=\"_blank\">attribution</a>",
+      'attribution1',
+      'wadus',
+      '© <a href="https://carto.com/attributions" target="_blank">CARTO</a>'
     ]);
 
     // Addind a layer with the default attribution
-    var layer = new CartoDBLayer();
+    layer = new CartoDBLayer();
 
     map.layers.add(layer, { at: 0 });
 
     // Default CartoDB only appears once and it's the last one
     expect(map.get('attribution')).toEqual([
-      "attribution1",
-      "wadus",
-      "CARTO <a href=\"https://carto.com/attributions\" target=\"_blank\">attribution</a>",
+      'attribution1',
+      'wadus',
+      '© <a href="https://carto.com/attributions" target="_blank">CARTO</a>'
     ]);
   });
 


### PR DESCRIPTION
This is part of https://github.com/CartoDB/cartodb/issues/8984.

Basically replaced:

`CARTO <a href="https://carto.com/attributions" target="_blank">attribution</a>`

by

`© <a href="https://carto.com/attributions" target="_blank">CARTO</a>`.

@xavijam 👍 ?
