### PR TITLE
Remove map.reload, in favor of vis.reload

### DIFF
--- a/src/analysis/analysis-factory.js
+++ b/src/analysis/analysis-factory.js
@@ -7,15 +7,15 @@ var AnalysisFactory = function (opts) {
   if (!opts.analysisCollection) {
     throw new Error('analysisCollection option is required');
   }
-  if (!opts.map) {
-    throw new Error('map option is required');
+  if (!opts.vis) {
+    throw new Error('vis option is required');
   }
 
   this._camshaftReference = opts.camshaftReference || camshaftReference;
   this._analysisCollection = opts.analysisCollection;
   this._apiKey = opts.apiKey;
   this._authToken = opts.authToken;
-  this._map = opts.map;
+  this._vis = opts.vis;
 };
 
 /**
@@ -40,7 +40,7 @@ AnalysisFactory.prototype.analyse = function (analysisDefinition) {
     }
     analysis = new Analysis(analysisAttrs, {
       camshaftReference: this._camshaftReference,
-      map: this._map
+      vis: this._vis
     });
     this._addAnalysisToCollection(analysis);
     analysis.bind('destroy', this._onAnalysisRemoved, this);

--- a/src/analysis/analysis-model.js
+++ b/src/analysis/analysis-model.js
@@ -53,15 +53,15 @@ module.exports = Model.extend({
     this.bind('change:type', function () {
       this.unbind(null, null, this);
       this._initBinds();
-      this._reloadMap();
+      this._reloadVis();
     }, this);
 
     _.each(this.getParamNames(), function (paramName) {
-      this.bind('change:' + paramName, this._reloadMap, this);
+      this.bind('change:' + paramName, this._reloadVis, this);
     }, this);
   },
 
-  _reloadMap: function (opts) {
+  _reloadVis: function (opts) {
     opts = opts || {};
     opts.error = this._onMapReloadError.bind(this);
     this._vis.reload(opts);

--- a/src/analysis/analysis-model.js
+++ b/src/analysis/analysis-model.js
@@ -17,12 +17,12 @@ module.exports = Model.extend({
       throw new Error('chamshaftReference is required');
     }
 
-    if (!opts.map) {
-      throw new Error('map is required');
+    if (!opts.vis) {
+      throw new Error('vis is required');
     }
 
     this._camshaftReference = opts.camshaftReference;
-    this._map = opts.map;
+    this._vis = opts.vis;
     this._initBinds();
   },
 
@@ -64,7 +64,7 @@ module.exports = Model.extend({
   _reloadMap: function (opts) {
     opts = opts || {};
     opts.error = this._onMapReloadError.bind(this);
-    this._map.reload(opts);
+    this._vis.reload(opts);
   },
 
   _onMapReloadError: function () {

--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -42,7 +42,7 @@ module.exports = DataviewModelBase.extend({
       apiKey: this.get('apiKey')
     });
 
-    this.on('change:column change:aggregation change:aggregation_column', this._reloadMapAndForceFetch, this);
+    this.on('change:column change:aggregation change:aggregation_column', this._reloadVisAndForceFetch, this);
 
     this.bind('change:url', function () {
       this._searchModel.set({

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -138,14 +138,14 @@ module.exports = Model.extend({
     if (layerDataProvider && layerDataProvider.canApplyFilterTo(this)) {
       layerDataProvider.applyFilter(this, filter);
     } else {
-      this._reloadMap();
+      this._reloadVis();
     }
   },
 
   /**
    * @protected
    */
-  _reloadMap: function (opts) {
+  _reloadVis: function (opts) {
     opts = opts || {};
     this._vis.reload(
       _.extend(
@@ -156,8 +156,8 @@ module.exports = Model.extend({
     );
   },
 
-  _reloadMapAndForceFetch: function () {
-    this._reloadMap({
+  _reloadVisAndForceFetch: function () {
+    this._reloadVis({
       forceFetch: true
     });
   },
@@ -305,7 +305,7 @@ module.exports = Model.extend({
       var isFilterEmpty = this.filter.isEmpty();
       this.filter.remove();
       if (!isFilterEmpty) {
-        this._reloadMap();
+        this._reloadVis();
       }
     }
 

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -49,6 +49,7 @@ module.exports = Model.extend({
     opts = opts || {};
 
     if (!opts.map) throw new Error('map is required');
+    if (!opts.vis) throw new Error('vis is required');
     if (!opts.analysisCollection) throw new Error('analysisCollection is required');
     if (!attrs.source) throw new Error('source is a required attr');
 
@@ -58,6 +59,7 @@ module.exports = Model.extend({
 
     this.layer = opts.layer;
     this._map = opts.map;
+    this._vis = opts.vis;
     this._analysisCollection = opts.analysisCollection;
 
     this.sync = BackboneCancelSync.bind(this);
@@ -145,7 +147,7 @@ module.exports = Model.extend({
    */
   _reloadMap: function (opts) {
     opts = opts || {};
-    this._map.reload(
+    this._vis.reload(
       _.extend(
         opts, {
           sourceId: this.getSourceId()

--- a/src/dataviews/dataviews-factory.js
+++ b/src/dataviews/dataviews-factory.js
@@ -15,11 +15,13 @@ module.exports = Model.extend({
 
   initialize: function (attrs, opts) {
     if (!opts.map) throw new Error('map is required');
+    if (!opts.vis) throw new Error('vis is required');
     if (!opts.analysisCollection) throw new Error('analysisCollection is required');
     if (!opts.dataviewsCollection) throw new Error('dataviewsCollection is required');
     if (!opts.analysisCollection) throw new Error('analysisCollection is required');
 
     this._map = opts.map;
+    this._vis = opts.vis;
     this._analysisCollection = opts.analysisCollection;
     this._dataviewsCollection = opts.dataviewsCollection;
     this._analysisCollection = opts.analysisCollection;
@@ -38,6 +40,7 @@ module.exports = Model.extend({
     return this._newModel(
       new CategoryDataviewModel(attrs, {
         map: this._map,
+        vis: this._vis,
         layer: layerModel,
         filter: categoryFilter,
         analysisCollection: this._analysisCollection
@@ -51,6 +54,7 @@ module.exports = Model.extend({
     return this._newModel(
       new FormulaDataviewModel(attrs, {
         map: this._map,
+        vis: this._vis,
         layer: layerModel,
         analysisCollection: this._analysisCollection
       })
@@ -68,6 +72,7 @@ module.exports = Model.extend({
     return this._newModel(
       new HistogramDataviewModel(attrs, {
         map: this._map,
+        vis: this._vis,
         layer: layerModel,
         filter: rangeFilter,
         analysisCollection: this._analysisCollection
@@ -81,6 +86,7 @@ module.exports = Model.extend({
     return this._newModel(
       new ListDataviewModel(attrs, {
         map: this._map,
+        vis: this._vis,
         layer: layerModel,
         analysisCollection: this._analysisCollection
       })

--- a/src/dataviews/formula-dataview-model.js
+++ b/src/dataviews/formula-dataview-model.js
@@ -12,7 +12,7 @@ module.exports = DataviewModelBase.extend({
 
   initialize: function () {
     DataviewModelBase.prototype.initialize.apply(this, arguments);
-    this.on('change:column change:operation', this._reloadMapAndForceFetch, this);
+    this.on('change:column change:operation', this._reloadVisAndForceFetch, this);
   },
 
   parse: function (r) {

--- a/src/dataviews/histogram-dataview-model.js
+++ b/src/dataviews/histogram-dataview-model.js
@@ -60,7 +60,7 @@ module.exports = DataviewModelBase.extend({
     }, this);
 
     this.listenTo(this.layer, 'change:meta', this._onChangeLayerMeta);
-    this.on('change:column', this._reloadMapAndForceFetch, this);
+    this.on('change:column', this._reloadVisAndForceFetch, this);
     this.on('change:bins change:start change:end', this._fetchAndResetFilter, this);
     if (attrs && (attrs.min || attrs.max)) {
       this.filter.setRange(this.get('min'), this.get('max'));

--- a/src/dataviews/list-dataview-model.js
+++ b/src/dataviews/list-dataview-model.js
@@ -15,7 +15,7 @@ module.exports = DataviewModelBase.extend({
   initialize: function (attrs, opts) {
     DataviewModelBase.prototype.initialize.call(this, attrs, opts);
     this._data = new Backbone.Collection(this.get('data'));
-    this.on('change:columns', this._reloadMapAndForceFetch, this);
+    this.on('change:columns', this._reloadVisAndForceFetch, this);
   },
 
   getData: function () {

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -149,12 +149,6 @@ var Map = Model.extend({
 
   // INTERNAL CartoDB.js METHODS
 
-  // TODO: Get rid of this
-  reload: function (options) {
-    options = options || {};
-    this.vis.reload(options);
-  },
-
   setView: function (latlng, zoom) {
     this.set({
       center: latlng,

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -23,15 +23,13 @@ var Map = Model.extend({
     vector: false
   },
 
-  RELOAD_DEBOUNCE_TIME: 10,
-
   initialize: function (attrs, options) {
     options = options || {};
     this.layers = options.layersCollection || new Layers();
-    // Update attributions after layers instantiation
     this._updateAttributions();
     this.geometries = new Backbone.Collection();
 
+    // TODO: Remove this
     this._windshaftMap = options.windshaftMap;
     this._dataviewsCollection = options.dataviewsCollection;
 
@@ -60,22 +58,17 @@ var Map = Model.extend({
       });
     }
 
-    this._instantiateMapWasCalled = false;
-
-    // This method is declared here so that we can spyOn _.debounce
-    // in the tests that depend on this to work
-    this.reload = _.debounce(function (options) {
-      if (this._instantiateMapWasCalled) {
-        options = options || {};
-        options = _.pick(options, 'sourceId', 'forceFetch', 'success', 'error');
-        this._windshaftMap.createInstance(options);
-      }
-    }.bind(this), this.RELOAD_DEBOUNCE_TIME);
-
     this.layers.bind('reset', this._updateAttributions, this);
     this.layers.bind('add', this._updateAttributions, this);
     this.layers.bind('remove', this._updateAttributions, this);
     this.layers.bind('change:attribution', this._updateAttributions, this);
+    this.layers.bind('reset', this._onLayersResetted, this);
+  },
+
+  _onLayersResetted: function () {
+    if (this.layers.size() >= 1) {
+      this._adjustZoomtoLayer(this.layers.first());
+    }
   },
 
   _updateAttributions: function () {
@@ -156,53 +149,12 @@ var Map = Model.extend({
 
   // INTERNAL CartoDB.js METHODS
 
-  instantiateMap: function (options) {
-    options = _.pick(options, ['success', 'error']);
-    if (!this._instantiateMapWasCalled) {
-      var successCallback = options.success;
-      options.success = function () {
-        this._initBindsAfterFirstMapInstantiation();
-        successCallback && successCallback();
-      }.bind(this);
-    }
-    this._instantiateMapWasCalled = true;
-    this.reload(options);
+  // TODO: Get rid of this
+  reload: function (options) {
+    options = options || {};
+    this.vis.reload(options);
   },
 
-  _initBindsAfterFirstMapInstantiation: function () {
-    this.layers.bind('reset', this._onLayersResetted, this);
-    this.layers.bind('add', this._onLayerAdded, this);
-    this.layers.bind('remove', this._onLayerRemoved, this);
-
-    if (this._dataviewsCollection) {
-      // When new dataviews are defined, a new instance of the map needs to be created
-      this.listenTo(this._dataviewsCollection, 'add', _.debounce(this._onDataviewAdded.bind(this), 10));
-    }
-  },
-
-  _onLayersResetted: function () {
-    if (this.layers.size() >= 1) {
-      this._adjustZoomtoLayer(this.layers.models[0]);
-    }
-
-    this.reload();
-  },
-
-  _onLayerAdded: function (layerModel) {
-    this.reload({
-      sourceId: layerModel.get('id')
-    });
-  },
-
-  _onLayerRemoved: function (layerModel) {
-    this.reload({
-      sourceId: layerModel.get('id')
-    });
-  },
-
-  _onDataviewAdded: function (layerModel) {
-    this.reload();
-  },
   setView: function (latlng, zoom) {
     this.set({
       center: latlng,

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -30,7 +30,7 @@ var Map = Model.extend({
     this.geometries = new Backbone.Collection();
 
     // TODO: Remove this
-    this._windshaftMap = options.windshaftMap;
+    if (options.windshaftMap) throw new Error('remove windshaftMap');
     this._dataviewsCollection = options.dataviewsCollection;
 
     attrs = attrs || {};

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -25,15 +25,11 @@ var Map = Model.extend({
 
   initialize: function (attrs, options) {
     options = options || {};
-    this.layers = options.layersCollection || new Layers();
-    this._updateAttributions();
-    this.geometries = new Backbone.Collection();
-
-    // TODO: Remove this
-    if (options.windshaftMap) throw new Error('remove windshaftMap');
-    this._dataviewsCollection = options.dataviewsCollection;
-
     attrs = attrs || {};
+
+    this.layers = options.layersCollection || new Layers();
+    this.geometries = new Backbone.Collection();
+    this._vis = options.vis;
 
     var center = attrs.center || this.defaults.center;
     if (typeof center === 'string') {
@@ -63,6 +59,8 @@ var Map = Model.extend({
     this.layers.bind('remove', this._updateAttributions, this);
     this.layers.bind('change:attribution', this._updateAttributions, this);
     this.layers.bind('reset', this._onLayersResetted, this);
+
+    this._updateAttributions();
   },
 
   _onLayersResetted: function () {
@@ -132,7 +130,8 @@ var Map = Model.extend({
   _addNewLayerModel: function (type, attrs, options) {
     options = options || {};
     var layerModel = LayersFactory.create(type, attrs, {
-      map: this
+      map: this,
+      vis: this._vis
     });
     this.listenTo(layerModel, 'destroy', this._removeLayerModelFromCollection);
     this.layers.add(layerModel, {

--- a/src/geo/map/cartodb-layer.js
+++ b/src/geo/map/cartodb-layer.js
@@ -11,7 +11,7 @@ var CartoDBLayer = LayerModelBase.extend({
     visible: true
   },
 
-  ATTRIBUTES_THAT_TRIGGER_MAP_RELOAD: ['visible', 'sql', 'source', 'sql_wrap', 'cartocss'],
+  ATTRIBUTES_THAT_TRIGGER_VIS_RELOAD: ['visible', 'sql', 'source', 'sql_wrap', 'cartocss'],
 
   initialize: function (attrs, options) {
     attrs = attrs || {};
@@ -35,7 +35,7 @@ var CartoDBLayer = LayerModelBase.extend({
   },
 
   _onAttributeChanged: function () {
-    var reloadMap = _.any(this.ATTRIBUTES_THAT_TRIGGER_MAP_RELOAD, function (attr) {
+    var reloadVis = _.any(this.ATTRIBUTES_THAT_TRIGGER_VIS_RELOAD, function (attr) {
       if (this.hasChanged(attr)) {
         if (attr === 'cartocss' && this._dataProvider) {
           return false;
@@ -44,13 +44,12 @@ var CartoDBLayer = LayerModelBase.extend({
       }
     }, this);
 
-    if (reloadMap) {
-      this._reloadMap();
+    if (reloadVis) {
+      this._reloadVis();
     }
   },
 
-  // TODO: Rename
-  _reloadMap: function () {
+  _reloadVis: function () {
     this._vis.reload({
       sourceId: this.get('id')
     });

--- a/src/geo/map/cartodb-layer.js
+++ b/src/geo/map/cartodb-layer.js
@@ -14,14 +14,10 @@ var CartoDBLayer = LayerModelBase.extend({
   ATTRIBUTES_THAT_TRIGGER_MAP_RELOAD: ['visible', 'sql', 'source', 'sql_wrap', 'cartocss'],
 
   initialize: function (attrs, options) {
+    attrs = attrs || {};
+    options = options || {};
     if (!options.vis) throw new Error('vis is required');
 
-    attrs = attrs || {};
-    LayerModelBase.prototype.initialize.apply(this, arguments);
-
-    options = options || {};
-
-    // TODO: Make this "required"
     this._vis = options.vis;
     if (attrs && attrs.cartocss) {
       this.set('initialStyle', attrs.cartocss);
@@ -34,6 +30,8 @@ var CartoDBLayer = LayerModelBase.extend({
     this.unset('tooltip');
 
     this.bind('change', this._onAttributeChanged, this);
+
+    LayerModelBase.prototype.initialize.apply(this, arguments);
   },
 
   _onAttributeChanged: function () {

--- a/src/geo/map/cartodb-layer.js
+++ b/src/geo/map/cartodb-layer.js
@@ -14,11 +14,15 @@ var CartoDBLayer = LayerModelBase.extend({
   ATTRIBUTES_THAT_TRIGGER_MAP_RELOAD: ['visible', 'sql', 'source', 'sql_wrap', 'cartocss'],
 
   initialize: function (attrs, options) {
+    if (!options.vis) throw new Error('vis is required');
+
     attrs = attrs || {};
     LayerModelBase.prototype.initialize.apply(this, arguments);
+
     options = options || {};
 
-    this._map = options.map;
+    // TODO: Make this "required"
+    this._vis = options.vis;
     if (attrs && attrs.cartocss) {
       this.set('initialStyle', attrs.cartocss);
     }
@@ -47,8 +51,9 @@ var CartoDBLayer = LayerModelBase.extend({
     }
   },
 
+  // TODO: Rename
   _reloadMap: function () {
-    this._map.reload({
+    this._vis.reload({
       sourceId: this.get('id')
     });
   },

--- a/src/geo/map/torque-layer.js
+++ b/src/geo/map/torque-layer.js
@@ -19,7 +19,7 @@ var TorqueLayer = LayerModelBase.extend({
     time: undefined // should be a Date instance
   },
 
-  ATTRIBUTES_THAT_TRIGGER_MAP_RELOAD: ['visible', 'sql', 'source', 'cartocss'],
+  ATTRIBUTES_THAT_TRIGGER_VIS_RELOAD: ['visible', 'sql', 'source', 'cartocss'],
 
   TORQUE_LAYER_CARTOCSS_PROPS: [
     '-torque-frame-count',
@@ -42,7 +42,7 @@ var TorqueLayer = LayerModelBase.extend({
   },
 
   _onAttributeChanged: function () {
-    var reloadMap = _.any(this.ATTRIBUTES_THAT_TRIGGER_MAP_RELOAD, function (attr) {
+    var reloadVis = _.any(this.ATTRIBUTES_THAT_TRIGGER_VIS_RELOAD, function (attr) {
       if (this.hasChanged(attr)) {
         if (attr === 'cartocss') {
           return this.previous('cartocss') && this._torqueCartoCSSPropsChanged();
@@ -51,8 +51,8 @@ var TorqueLayer = LayerModelBase.extend({
       }
     }, this);
 
-    if (reloadMap) {
-      this._reloadMap();
+    if (reloadVis) {
+      this._reloadVis();
     }
   },
 
@@ -81,7 +81,7 @@ var TorqueLayer = LayerModelBase.extend({
     return properties;
   },
 
-  _reloadMap: function () {
+  _reloadVis: function () {
     this._vis.reload({
       sourceId: this.get('id')
     });

--- a/src/geo/map/torque-layer.js
+++ b/src/geo/map/torque-layer.js
@@ -32,10 +32,13 @@ var TorqueLayer = LayerModelBase.extend({
   LAYER_NAME_IN_CARTO_CSS: 'Map',
 
   initialize: function (attrs, options) {
+    if (!options.vis) throw new Error('vis is required');
+
     LayerModelBase.prototype.initialize.apply(this, arguments);
     options = options || {};
 
-    this._map = options.map;
+    // TODO: Make this "required"
+    this._vis = options.vis;
     this.bind('change', this._onAttributeChanged, this);
   },
 
@@ -80,7 +83,7 @@ var TorqueLayer = LayerModelBase.extend({
   },
 
   _reloadMap: function () {
-    this._map.reload({
+    this._vis.reload({
       sourceId: this.get('id')
     });
   },

--- a/src/geo/map/torque-layer.js
+++ b/src/geo/map/torque-layer.js
@@ -32,14 +32,13 @@ var TorqueLayer = LayerModelBase.extend({
   LAYER_NAME_IN_CARTO_CSS: 'Map',
 
   initialize: function (attrs, options) {
+    options = options || {};
     if (!options.vis) throw new Error('vis is required');
 
-    LayerModelBase.prototype.initialize.apply(this, arguments);
-    options = options || {};
-
-    // TODO: Make this "required"
     this._vis = options.vis;
     this.bind('change', this._onAttributeChanged, this);
+
+    LayerModelBase.prototype.initialize.apply(this, arguments);
   },
 
   _onAttributeChanged: function () {

--- a/src/vis/infowindow-manager.js
+++ b/src/vis/infowindow-manager.js
@@ -7,6 +7,8 @@ var Overlay = require('./vis/overlay');
  */
 var InfowindowManager = function (vis, options) {
   options = options || {};
+  if (!vis) throw new Error('vis is required');
+
   this._vis = vis;
   this._showEmptyFields = options.showEmptyFields;
 };
@@ -114,11 +116,11 @@ InfowindowManager.prototype._bindInfowindowModel = function (layerView, layerMod
     if (layerModel.infowindow.hasFields()) {
       this._updateInfowindowModel(layerModel.infowindow);
       if (this._infowindowModel.get('visibility')) {
-        this._reloadMapAndFetchAttributes(layerView, layerModel);
+        this._reloadVisAndFetchAttributes(layerView, layerModel);
         return;
       }
 
-      this._reloadMap();
+      this._reloadVis();
     } else {
       if (this._infowindowModel.hasInfowindowTemplate(layerModel.infowindow)) {
         this._infowindowModel.set('visibility', false);
@@ -127,13 +129,13 @@ InfowindowManager.prototype._bindInfowindowModel = function (layerView, layerMod
   }, this);
 };
 
-InfowindowManager.prototype._reloadMap = function (options) {
+InfowindowManager.prototype._reloadVis = function (options) {
   options = options || {};
-  this._map.reload(options);
+  this._vis.reload(options);
 };
 
-InfowindowManager.prototype._reloadMapAndFetchAttributes = function (layerView, layerModel) {
-  this._reloadMap({
+InfowindowManager.prototype._reloadVisAndFetchAttributes = function (layerView, layerModel) {
+  this._reloadVis({
     success: function () {
       this._fetchAttributes(layerView, layerModel);
     }.bind(this)

--- a/src/vis/layers.js
+++ b/src/vis/layers.js
@@ -47,8 +47,6 @@ Layers.register('tilejson', function (data, options) {
   }
   return new TileLayer({
     urlTemplate: url
-  }, {
-    map: options.map
   });
 });
 
@@ -83,7 +81,7 @@ Layers.register('background', function (data, options) {
 Layers.register('cartodb', function (data, options) {
   normalizeOptions(data, options);
   return new CartoDBLayer(data, {
-    map: options.map
+    vis: options.vis
   });
 });
 
@@ -99,7 +97,7 @@ Layers.register('torque', function (data, options) {
     }
   }
   return new TorqueLayer(data, {
-    map: options.map
+    vis: options.vis
   });
 });
 

--- a/src/vis/tooltip-manager.js
+++ b/src/vis/tooltip-manager.js
@@ -25,7 +25,7 @@ TooltipManager.prototype._addTooltipForLayer = function (layerModel) {
     var layerView = this._mapView.getLayerViewByLayerCid(layerModel.cid);
 
     layerModel.tooltip.fields.bind('reset', function () {
-      this._reloadMap();
+      this._reloadVis();
     }, this);
 
     if (!layerView.tooltipView) {
@@ -35,9 +35,9 @@ TooltipManager.prototype._addTooltipForLayer = function (layerModel) {
   }
 };
 
-TooltipManager.prototype._reloadMap = function (options) {
+TooltipManager.prototype._reloadVis = function (options) {
   options = options || {};
-  this._map.reload(options);
+  this._vis.reload(options);
 };
 
 TooltipManager.prototype._addTooltipOverlay = function (layerView, layerModel) {

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -172,6 +172,7 @@ var VisModel = Backbone.Model.extend({
       authToken: this.get('authToken')
     }, {
       map: this.map,
+      vis: this,
       dataviewsCollection: this._dataviewsCollection,
       analysisCollection: this._analysisCollection
     });

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -189,7 +189,7 @@ var VisModel = Backbone.Model.extend({
     this._windshaftMap.bind('instanceCreated', this._onMapInstanceCreated, this);
 
     // Lastly: reset the layer models on the map
-    var layerModels = this._newLayerModels(vizjson, this.map);
+    var layerModels = this._newLayerModels(vizjson);
     this.map.layers.reset(layerModels);
 
     // "Load" existing analyses from the viz.json. This will generate
@@ -327,11 +327,11 @@ var VisModel = Backbone.Model.extend({
     this.map.reCenter();
   },
 
-  _newLayerModels: function (vizjson, map) {
+  _newLayerModels: function (vizjson) {
     var layerModels = [];
     var layersOptions = {
       https: this.get('https'),
-      map: map
+      vis: this
     };
     _.each(vizjson.layers, function (layerData) {
       if (layerData.type === 'layergroup' || layerData.type === 'namedmap') {

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -155,8 +155,8 @@ var VisModel = Backbone.Model.extend({
       provider: vizjson.map_provider,
       vector: vizjson.vector
     }, {
-      layersCollection: this._layersCollection,
-      dataviewsCollection: this._dataviewsCollection
+      vis: this,
+      layersCollection: this._layersCollection
     });
 
     // Reset the collection of overlays

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -181,7 +181,7 @@ var VisModel = Backbone.Model.extend({
       apiKey: this.get('apiKey'),
       authToken: this.get('authToken'),
       analysisCollection: this._analysisCollection,
-      map: this.map
+      vis: this
     });
 
     this._windshaftMap.bind('instanceRequested', this._onMapInstanceRequested, this);

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -156,7 +156,6 @@ var VisModel = Backbone.Model.extend({
       vector: vizjson.vector
     }, {
       layersCollection: this._layersCollection,
-      windshaftMap: this._windshaftMap,
       dataviewsCollection: this._dataviewsCollection
     });
 

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -159,9 +159,6 @@ var VisModel = Backbone.Model.extend({
       dataviewsCollection: this._dataviewsCollection
     });
 
-    // TODO: Temporary hack so that we can forward map.reload to vis.reload
-    this.map.vis = this;
-
     // Reset the collection of overlays
     this.overlaysCollection.reset(vizjson.overlays);
 

--- a/test/spec/dataviews/category-dataview-model.spec.js
+++ b/test/spec/dataviews/category-dataview-model.spec.js
@@ -7,7 +7,7 @@ describe('dataviews/category-dataview-model', function () {
   beforeEach(function () {
     this.map = new Backbone.Model();
     this.map.getViewBounds = jasmine.createSpy();
-    this.map.reload = jasmine.createSpy();
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
     this.map.getViewBounds.and.returnValue([[1, 2], [3, 4]]);
 
     this.layer = new Backbone.Model();
@@ -17,6 +17,7 @@ describe('dataviews/category-dataview-model', function () {
       source: {id: 'a0'}
     }, {
       map: this.map,
+      vis: this.vis,
       layer: this.layer,
       filter: new WindshaftFiltersCategory(),
       analysisCollection: new Backbone.Collection()
@@ -24,17 +25,17 @@ describe('dataviews/category-dataview-model', function () {
   });
 
   it('should reload map and force fetch on changing attrs', function () {
-    this.map.reload.calls.reset();
+    this.vis.reload.calls.reset();
     this.model.set('column', 'random_col');
-    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: 'a0' });
+    expect(this.vis.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: 'a0' });
 
-    this.map.reload.calls.reset();
+    this.vis.reload.calls.reset();
     this.model.set('aggregation', 'count');
-    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: 'a0' });
+    expect(this.vis.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: 'a0' });
 
-    this.map.reload.calls.reset();
+    this.vis.reload.calls.reset();
     this.model.set('aggregation_column', 'other');
-    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: 'a0' });
+    expect(this.vis.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: 'a0' });
   });
 
   it('should define several internal models/collections', function () {
@@ -49,6 +50,7 @@ describe('dataviews/category-dataview-model', function () {
       apiKey: 'API_KEY'
     }, {
       map: this.map,
+      vis: this.vis,
       layer: jasmine.createSpyObj('layer', ['get', 'getDataProvider']),
       filter: new WindshaftFiltersCategory(),
       analysisCollection: new Backbone.Collection()

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -380,7 +380,7 @@ describe('dataviews/dataview-model-base', function () {
       this.removeSpy = jasmine.createSpy('remove');
       this.model.once('destroy', this.removeSpy);
       spyOn(this.model, 'stopListening');
-      spyOn(this.model, '_reloadMap');
+      spyOn(this.model, '_reloadVis');
       spyOn(this.model.layer, 'off').and.callThrough();
       spyOn(this.a0, 'off').and.callThrough();
 
@@ -399,7 +399,7 @@ describe('dataviews/dataview-model-base', function () {
     });
 
     it('should reload the map if there is a filter and it is not empty', function () {
-      expect(this.model._reloadMap).toHaveBeenCalled();
+      expect(this.model._reloadVis).toHaveBeenCalled();
     });
 
     it('should stop listening to events', function () {

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -57,7 +57,7 @@ describe('dataviews/dataview-model-base', function () {
     this.analysisFactory = new AnalysisFactory({
       analysisCollection: this.analysisCollection,
       camshaftReference: fakeCamshaftReference,
-      map: jasmine.createSpyObj('map', ['reload'])
+      vis: jasmine.createSpyObj('vis', ['reload'])
     });
 
     // Disable debounce

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -37,7 +37,7 @@ describe('dataviews/dataview-model-base', function () {
   beforeEach(function () {
     this.map = new Backbone.Model();
     this.map.getViewBounds = function () {};
-    this.map.reload = function () {};
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
     spyOn(this.map, 'getViewBounds').and.returnValue([[1, 2], [3, 4]]);
 
     this.analysisCollection = new Backbone.Collection();
@@ -48,8 +48,9 @@ describe('dataviews/dataview-model-base', function () {
     this.model = new DataviewModelBase({
       source: {id: 'a0'}
     }, {
-      map: this.map,
       layer: this.layer,
+      map: this.map,
+      vis: this.vis,
       analysisCollection: this.analysisCollection
     });
     this.model.toJSON = jasmine.createSpy('toJSON').and.returnValue({});
@@ -57,7 +58,7 @@ describe('dataviews/dataview-model-base', function () {
     this.analysisFactory = new AnalysisFactory({
       analysisCollection: this.analysisCollection,
       camshaftReference: fakeCamshaftReference,
-      vis: jasmine.createSpyObj('vis', ['reload'])
+      vis: this.vis
     });
 
     // Disable debounce
@@ -349,7 +350,6 @@ describe('dataviews/dataview-model-base', function () {
 
   describe('bindings to the filter', function () {
     beforeEach(function () {
-      spyOn(this.map, 'reload');
       this.layer = new Backbone.Model({
         id: 'layerId'
       });
@@ -361,8 +361,9 @@ describe('dataviews/dataview-model-base', function () {
       new DataviewModelBase({ // eslint-disable-line
         source: { id: 'a0' }
       }, {
-        map: this.map,
         layer: this.layer,
+        map: this.map,
+        vis: this.vis,
         filter: filter,
         analysisCollection: this.analysisCollection
       });
@@ -370,7 +371,7 @@ describe('dataviews/dataview-model-base', function () {
       // Filter changes
       filter.trigger('change', filter);
 
-      expect(this.map.reload).toHaveBeenCalledWith({ sourceId: 'a0' });
+      expect(this.vis.reload).toHaveBeenCalledWith({ sourceId: 'a0' });
     });
   });
 
@@ -451,6 +452,7 @@ describe('dataviews/dataview-model-base', function () {
       }, {
         layer: this.layer,
         map: this.map,
+        vis: this.vis,
         analysisCollection: this.analysisCollection
       });
 
@@ -468,6 +470,7 @@ describe('dataviews/dataview-model-base', function () {
       }, {
         layer: this.layer,
         map: this.map,
+        vis: this.vis,
         analysisCollection: this.analysisCollection
       });
 
@@ -484,6 +487,7 @@ describe('dataviews/dataview-model-base', function () {
       }, {
         layer: this.layer,
         map: this.map,
+        vis: this.vis,
         analysisCollection: this.analysisCollection
       });
 
@@ -500,8 +504,6 @@ describe('dataviews/dataview-model-base', function () {
     });
 
     it('should apply the filter to the data provider when the filter changes and data provider can apply filters to the dataview', function () {
-      spyOn(this.map, 'reload');
-
       var filter = new Backbone.Model();
       var dataview = new DataviewModelBase({ // eslint-disable-line
         column: 'columnName',
@@ -509,6 +511,7 @@ describe('dataviews/dataview-model-base', function () {
       }, {
         layer: this.layer,
         map: this.map,
+        vis: this.vis,
         filter: filter,
         analysisCollection: this.analysisCollection
       });
@@ -518,13 +521,11 @@ describe('dataviews/dataview-model-base', function () {
       // Filter changes
       filter.trigger('change', filter);
 
-      expect(this.map.reload).not.toHaveBeenCalled();
+      expect(this.vis.reload).not.toHaveBeenCalled();
       expect(this.geoJSONDataProvider.applyFilter).toHaveBeenCalledWith(dataview, filter);
     });
 
     it("should NOT apply the filter to the data provider when the filter changes and data provider CAN'T apply filters to the dataview", function () {
-      spyOn(this.map, 'reload');
-
       var filter = new Backbone.Model();
       var dataview = new DataviewModelBase({ // eslint-disable-line
         column: 'columnName',
@@ -532,6 +533,7 @@ describe('dataviews/dataview-model-base', function () {
       }, {
         layer: this.layer,
         map: this.map,
+        vis: this.vis,
         filter: filter,
         analysisCollection: this.analysisCollection
       });
@@ -541,7 +543,7 @@ describe('dataviews/dataview-model-base', function () {
       // Filter changes
       filter.trigger('change', filter);
 
-      expect(this.map.reload).toHaveBeenCalled();
+      expect(this.vis.reload).toHaveBeenCalled();
       expect(this.geoJSONDataProvider.applyFilter).not.toHaveBeenCalled();
     });
   });
@@ -561,6 +563,7 @@ describe('dataviews/dataview-model-base', function () {
       }, { // eslint-disable-line
         layer: layer,
         map: this.map,
+        vis: this.vis,
         analysisCollection: this.analysisCollection
       });
 
@@ -581,6 +584,7 @@ describe('dataviews/dataview-model-base', function () {
       }, { // eslint-disable-line
         layer: layer,
         map: this.map,
+        vis: this.vis,
         analysisCollection: this.analysisCollection
       });
 
@@ -603,6 +607,7 @@ describe('dataviews/dataview-model-base', function () {
       }, { // eslint-disable-line
         layer: layer,
         map: this.map,
+        vis: this.vis,
         analysisCollection: this.analysisCollection
       });
 
@@ -623,6 +628,7 @@ describe('dataviews/dataview-model-base', function () {
       }, { // eslint-disable-line
         layer: layer,
         map: this.map,
+        vis: this.vis,
         analysisCollection: this.analysisCollection
       });
 

--- a/test/spec/dataviews/histogram-dataview-model.spec.js
+++ b/test/spec/dataviews/histogram-dataview-model.spec.js
@@ -7,6 +7,8 @@ describe('dataviews/histogram-dataview-model', function () {
   beforeEach(function () {
     this.map = jasmine.createSpyObj('map', ['getViewBounds', 'bind', 'reload']);
     this.map.getViewBounds.and.returnValue([[1, 2], [3, 4]]);
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
+
     this.filter = new RangeFilter();
 
     this.layer = new Model();
@@ -20,6 +22,7 @@ describe('dataviews/histogram-dataview-model', function () {
       source: { id: 'a0' }
     }, {
       map: this.map,
+      vis: this.vis,
       layer: this.layer,
       filter: this.filter,
       analysisCollection: new Backbone.Collection()
@@ -43,6 +46,7 @@ describe('dataviews/histogram-dataview-model', function () {
       source: { id: 'a0' }
     }, {
       map: this.map,
+      vis: this.vis,
       layer: jasmine.createSpyObj('layer', ['get', 'getDataProvider']),
       filter: this.filter,
       analysisCollection: new Backbone.Collection()
@@ -144,21 +148,21 @@ describe('dataviews/histogram-dataview-model', function () {
 
   describe('when column changes', function () {
     it('should reload map and force fetch', function () {
-      this.map.reload.calls.reset();
+      this.vis.reload.calls.reset();
       this.model.set('column', 'random_col');
-      expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: 'a0' });
+      expect(this.vis.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: 'a0' });
     });
   });
 
   describe('when bins change', function () {
     beforeEach(function () {
-      this.map.reload.calls.reset();
+      this.vis.reload.calls.reset();
       spyOn(this.model.filter, 'unsetRange');
       this.model.set('bins', 123);
     });
 
     it('should refresh data on bins change', function () {
-      expect(this.map.reload).not.toHaveBeenCalled();
+      expect(this.vis.reload).not.toHaveBeenCalled();
       expect(this.model.fetch).toHaveBeenCalled();
     });
 
@@ -173,14 +177,14 @@ describe('dataviews/histogram-dataview-model', function () {
 
   describe('when start change', function () {
     beforeEach(function () {
-      this.map.reload.calls.reset();
+      this.vis.reload.calls.reset();
       spyOn(this.model.filter, 'unsetRange');
 
       this.model.set('start', 0);
     });
 
     it('should refresh data on bins change', function () {
-      expect(this.map.reload).not.toHaveBeenCalled();
+      expect(this.vis.reload).not.toHaveBeenCalled();
       expect(this.model.fetch).toHaveBeenCalled();
     });
 
@@ -195,13 +199,13 @@ describe('dataviews/histogram-dataview-model', function () {
 
   describe('when end change', function () {
     beforeEach(function () {
-      this.map.reload.calls.reset();
+      this.vis.reload.calls.reset();
       spyOn(this.model.filter, 'unsetRange');
       this.model.set('end', 0);
     });
 
     it('should refresh data on bins change', function () {
-      expect(this.map.reload).not.toHaveBeenCalled();
+      expect(this.vis.reload).not.toHaveBeenCalled();
       expect(this.model.fetch).toHaveBeenCalled();
     });
 

--- a/test/spec/geo/cartodb-layer-group-anonymous-map.spec.js
+++ b/test/spec/geo/cartodb-layer-group-anonymous-map.spec.js
@@ -6,6 +6,7 @@ var CartoDBLayerGroupAnonymousMap = require('../../../src/geo/cartodb-layer-grou
 describe('geo/layer-group-anonymous-map', function () {
   beforeEach(function () {
     this.layersCollection = new Layers();
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
   });
 
   // TODO: This test is a bit useless
@@ -18,8 +19,8 @@ describe('geo/layer-group-anonymous-map', function () {
 
   describe('fetchAttributes', function () {
     it('should calculate indexes correctly', function () {
-      var cartoDBLayer1 = new CartoDBLayer();
-      var cartoDBLayer2 = new CartoDBLayer();
+      var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
+      var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });
 
       spyOn($, 'ajax').and.callFake(function (options) {
         options.success('attributes!');
@@ -67,8 +68,8 @@ describe('geo/layer-group-anonymous-map', function () {
     });
 
     it('should generate the TileJSON when all layers are visible', function () {
-      var cartoDBLayer1 = new CartoDBLayer();
-      var cartoDBLayer2 = new CartoDBLayer();
+      var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
+      var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });
 
       var layerGroup = new CartoDBLayerGroupAnonymousMap({
         baseURL: 'http://wadus.com'
@@ -113,8 +114,8 @@ describe('geo/layer-group-anonymous-map', function () {
     });
 
     it('should NOT include grid URLs for hidden layers', function () {
-      var cartoDBLayer1 = new CartoDBLayer();
-      var cartoDBLayer2 = new CartoDBLayer();
+      var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
+      var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });
 
       var layerGroup = new CartoDBLayerGroupAnonymousMap({
         baseURL: 'http://wadus.com'

--- a/test/spec/geo/cartodb-layer-group-base.spec.js
+++ b/test/spec/geo/cartodb-layer-group-base.spec.js
@@ -11,6 +11,7 @@ var MyCartoDBLayerGroup = CartoDBLayerGroupBase.extend({
 describe('geo/cartodb-layer-group-base', function () {
   beforeEach(function () {
     this.layersCollection = new Layers();
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
   });
 
   describe('internal collection of CartoDB layers', function () {
@@ -75,7 +76,7 @@ describe('geo/cartodb-layer-group-base', function () {
   describe('fetchAttributes', function () {
     it('should trigger a request to the right URL', function () {
       var callback = jasmine.createSpy('callback');
-      var cartoDBLayer1 = new CartoDBLayer();
+      var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });;
 
       var layer = new MyCartoDBLayerGroup({
         baseURL: 'http://wadus.com'
@@ -97,7 +98,7 @@ describe('geo/cartodb-layer-group-base', function () {
 
     it('should not trigger a request when the layer index is invalid and callback should return null', function () {
       var callback = jasmine.createSpy('callback');
-      var cartoDBLayer1 = new CartoDBLayer();
+      var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });;
 
       var layer = new MyCartoDBLayerGroup({
         baseURL: 'http://wadus.com'
@@ -119,7 +120,7 @@ describe('geo/cartodb-layer-group-base', function () {
 
     it('should invoke the callback with null when the ajax request fails', function () {
       var callback = jasmine.createSpy('callback');
-      var cartoDBLayer1 = new CartoDBLayer();
+      var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });;
 
       var layer = new MyCartoDBLayerGroup({
         baseURL: 'http://wadus.com'
@@ -141,7 +142,7 @@ describe('geo/cartodb-layer-group-base', function () {
 
     it('should use an api_key if WindhsaftMap has one', function () {
       var callback = jasmine.createSpy('callback');
-      var cartoDBLayer1 = new CartoDBLayer();
+      var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });;
 
       var layer = new MyCartoDBLayerGroup({
         apiKey: 'THE_API_KEY',

--- a/test/spec/geo/cartodb-layer-group-base.spec.js
+++ b/test/spec/geo/cartodb-layer-group-base.spec.js
@@ -76,7 +76,7 @@ describe('geo/cartodb-layer-group-base', function () {
   describe('fetchAttributes', function () {
     it('should trigger a request to the right URL', function () {
       var callback = jasmine.createSpy('callback');
-      var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });;
+      var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
 
       var layer = new MyCartoDBLayerGroup({
         baseURL: 'http://wadus.com'
@@ -98,7 +98,7 @@ describe('geo/cartodb-layer-group-base', function () {
 
     it('should not trigger a request when the layer index is invalid and callback should return null', function () {
       var callback = jasmine.createSpy('callback');
-      var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });;
+      var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
 
       var layer = new MyCartoDBLayerGroup({
         baseURL: 'http://wadus.com'
@@ -120,7 +120,7 @@ describe('geo/cartodb-layer-group-base', function () {
 
     it('should invoke the callback with null when the ajax request fails', function () {
       var callback = jasmine.createSpy('callback');
-      var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });;
+      var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
 
       var layer = new MyCartoDBLayerGroup({
         baseURL: 'http://wadus.com'
@@ -142,7 +142,7 @@ describe('geo/cartodb-layer-group-base', function () {
 
     it('should use an api_key if WindhsaftMap has one', function () {
       var callback = jasmine.createSpy('callback');
-      var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });;
+      var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
 
       var layer = new MyCartoDBLayerGroup({
         apiKey: 'THE_API_KEY',

--- a/test/spec/geo/cartodb-layer-group-named-map.spec.js
+++ b/test/spec/geo/cartodb-layer-group-named-map.spec.js
@@ -6,6 +6,7 @@ var CartoDBLayerGroupNamed = require('../../../src/geo/cartodb-layer-group-named
 describe('geo/cartodb-layer-group-named-map', function () {
   beforeEach(function () {
     this.layersCollection = new Layers();
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
   });
 
   // TODO: This test is a bit useless
@@ -18,8 +19,8 @@ describe('geo/cartodb-layer-group-named-map', function () {
 
   describe('fetchAttributes', function () {
     it('should calculate indexes correctly', function () {
-      var cartoDBLayer1 = new CartoDBLayer();
-      var cartoDBLayer2 = new CartoDBLayer();
+      var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
+      var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });
 
       spyOn($, 'ajax').and.callFake(function (options) {
         options.success('attributes!');
@@ -68,8 +69,8 @@ describe('geo/cartodb-layer-group-named-map', function () {
     });
 
     it('should be return the TileJSON for the given layerIndex', function () {
-      var cartoDBLayer1 = new CartoDBLayer();
-      var cartoDBLayer2 = new CartoDBLayer();
+      var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
+      var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });
 
       var layerGroup = new CartoDBLayerGroupNamed({
         baseURL: 'http://wadus.com'

--- a/test/spec/geo/gmaps/gmaps-torque-layer-view.spec.js
+++ b/test/spec/geo/gmaps/gmaps-torque-layer-view.spec.js
@@ -18,12 +18,13 @@ describe('geo/gmaps/gmaps-torque-layer-view', function () {
       layerGroupModel: new Backbone.Model()
     });
 
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
     var model = new TorqueLayer({
       type: 'torque',
       sql: 'select * from table',
       cartocss: '#test {}',
       'torque-steps': 100
-    });
+    }, { vis: this.vis });
     spyOn(torque, 'GMapsTorqueLayer').and.callThrough();
     map.addLayer(model);
     this.view = mapView._layerViews[model.cid];

--- a/test/spec/geo/leaflet/leaflet-cartodb-vector-layer-group-view.spec.js
+++ b/test/spec/geo/leaflet/leaflet-cartodb-vector-layer-group-view.spec.js
@@ -14,8 +14,8 @@ describe('src/geo/leaflet/leaflet-cartodb-vector-layer-group-view.js', function 
   });
 
   it('should register a new GeoJSONDataProvider on each CartoDBLayer on the layergroup', function () {
-    var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });;
-    var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });;
+    var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
+    var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });
     this.layerGroupModel.layers = new Backbone.Collection([
       cartoDBLayer1, cartoDBLayer2
     ]);
@@ -32,8 +32,8 @@ describe('src/geo/leaflet/leaflet-cartodb-vector-layer-group-view.js', function 
   it('should register a new GeoJSONDataProvider on new CartoDBLayers added to the layergroup after the layer view has been initialized', function () {
     new LeafletCartoDBVectorLayerGroupView(this.layerGroupModel, this.leafletMap); // eslint-disable-line
 
-    var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });;
-    var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });;
+    var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
+    var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });
 
     expect(cartoDBLayer1.getDataProvider()).toBeUndefined();
     expect(cartoDBLayer2.getDataProvider()).toBeUndefined();
@@ -46,7 +46,7 @@ describe('src/geo/leaflet/leaflet-cartodb-vector-layer-group-view.js', function 
   });
 
   it('should translate internal L.CartoDBd3Layer events to Backbone events', function (done) {
-    var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });;
+    var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
     this.layerGroupModel.layers = new Backbone.Collection([
       cartoDBLayer1
     ]);
@@ -78,8 +78,8 @@ describe('src/geo/leaflet/leaflet-cartodb-vector-layer-group-view.js', function 
     });
   });
   it('should call setUrl when all named map styles have been added', function () {
-    var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });;
-    var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });;
+    var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
+    var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });
     L.CartoDBd3Layer.prototype.setUrl = jasmine.createSpy();
     LeafletCartoDBVectorLayerGroupView.prototype._onTileJSONChanged = function () {
       this.options.styles = [undefined, undefined];

--- a/test/spec/geo/leaflet/leaflet-cartodb-vector-layer-group-view.spec.js
+++ b/test/spec/geo/leaflet/leaflet-cartodb-vector-layer-group-view.spec.js
@@ -10,11 +10,12 @@ describe('src/geo/leaflet/leaflet-cartodb-vector-layer-group-view.js', function 
     this.leafletMap;
     this.layerGroupModel = new Backbone.Model({ type: 'wadus' });
     this.layerGroupModel.layers = new Backbone.Collection([]);
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
   });
 
   it('should register a new GeoJSONDataProvider on each CartoDBLayer on the layergroup', function () {
-    var cartoDBLayer1 = new CartoDBLayer();
-    var cartoDBLayer2 = new CartoDBLayer();
+    var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });;
+    var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });;
     this.layerGroupModel.layers = new Backbone.Collection([
       cartoDBLayer1, cartoDBLayer2
     ]);
@@ -31,8 +32,8 @@ describe('src/geo/leaflet/leaflet-cartodb-vector-layer-group-view.js', function 
   it('should register a new GeoJSONDataProvider on new CartoDBLayers added to the layergroup after the layer view has been initialized', function () {
     new LeafletCartoDBVectorLayerGroupView(this.layerGroupModel, this.leafletMap); // eslint-disable-line
 
-    var cartoDBLayer1 = new CartoDBLayer();
-    var cartoDBLayer2 = new CartoDBLayer();
+    var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });;
+    var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });;
 
     expect(cartoDBLayer1.getDataProvider()).toBeUndefined();
     expect(cartoDBLayer2.getDataProvider()).toBeUndefined();
@@ -45,7 +46,7 @@ describe('src/geo/leaflet/leaflet-cartodb-vector-layer-group-view.js', function 
   });
 
   it('should translate internal L.CartoDBd3Layer events to Backbone events', function (done) {
-    var cartoDBLayer1 = new CartoDBLayer();
+    var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });;
     this.layerGroupModel.layers = new Backbone.Collection([
       cartoDBLayer1
     ]);
@@ -77,8 +78,8 @@ describe('src/geo/leaflet/leaflet-cartodb-vector-layer-group-view.js', function 
     });
   });
   it('should call setUrl when all named map styles have been added', function () {
-    var cartoDBLayer1 = new CartoDBLayer();
-    var cartoDBLayer2 = new CartoDBLayer();
+    var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });;
+    var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });;
     L.CartoDBd3Layer.prototype.setUrl = jasmine.createSpy();
     LeafletCartoDBVectorLayerGroupView.prototype._onTileJSONChanged = function () {
       this.options.styles = [undefined, undefined];

--- a/test/spec/geo/leaflet/leaflet-map-view.spec.js
+++ b/test/spec/geo/leaflet/leaflet-map-view.spec.js
@@ -34,7 +34,6 @@ describe('geo/leaflet/leaflet-map-view', function () {
     map = new Map(null, {
       windshaftMap: fakeWindshaftMap
     });
-    map.instantiateMap();
 
     mapView = new LeafletMapView({
       el: container,

--- a/test/spec/geo/leaflet/leaflet-map-view.spec.js
+++ b/test/spec/geo/leaflet/leaflet-map-view.spec.js
@@ -28,12 +28,7 @@ describe('geo/leaflet/leaflet-map-view', function () {
       'width': '200px'
     });
 
-    // Map needs a WindshaftMap so we're setting up a fake one
-    var fakeWindshaftMap = jasmine.createSpyObj('windshaftMap', ['createInstance', 'bind']);
-
-    map = new Map(null, {
-      windshaftMap: fakeWindshaftMap
-    });
+    map = new Map(null);
 
     mapView = new LeafletMapView({
       el: container,
@@ -50,6 +45,8 @@ describe('geo/leaflet/leaflet-map-view', function () {
     map.bind('change:keyboard', spy.keyboardChanged);
     map.bind('change:center', spy.centerChanged);
     map.bind('change', spy.changed);
+
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
   });
 
   it('should change bounds when center is set', function () {
@@ -147,8 +144,8 @@ describe('geo/leaflet/leaflet-map-view', function () {
   });
 
   it('should remove all layers when map view is cleaned', function () {
-    var cartoDBLayer1 = new CartoDBLayer();
-    var cartoDBLayer2 = new CartoDBLayer();
+    var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
+    var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });
     var tileLayer = new TileLayer({ urlTemplate: 'test' });
 
     map.addLayer(cartoDBLayer1);
@@ -386,7 +383,7 @@ describe('geo/leaflet/leaflet-map-view', function () {
       // Add a CartoDB layer with some custom attribution
       layer = new CartoDBLayer({
         attribution: 'custom attribution'
-      });
+      }, { vis: this.vis });
       map.addLayer(layer);
 
       var attributions = mapView.$el.find('.leaflet-control-attribution').text();
@@ -416,7 +413,7 @@ describe('geo/leaflet/leaflet-map-view', function () {
       // Add a CartoDB layer with some custom attribution
       layer = new CartoDBLayer({
         attribution: 'custom attribution'
-      });
+      }, { vis: this.vis });
       map.addLayer(layer);
 
       var attributions = mapView.$el.find('.leaflet-control-attribution').text();

--- a/test/spec/geo/leaflet/leaflet-torque-layer.spec.js
+++ b/test/spec/geo/leaflet/leaflet-torque-layer.spec.js
@@ -13,6 +13,7 @@ describe('geo/leaflet/leaflet-torque-layer', function () {
       'height': '200px',
       'width': '200px'
     });
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
     this.map = new Map();
     this.mapView = new LeafletMapView({
       el: container,
@@ -28,7 +29,7 @@ describe('geo/leaflet/leaflet-torque-layer', function () {
       sql: 'select * from table',
       cartocss: '#test {}',
       dynamic_cdn: 'dynamic-cdn-value'
-    });
+    }, { vis: this.vis });
     this.map.addLayer(model);
     this.view = this.mapView._layerViews[model.cid];
   });
@@ -39,7 +40,9 @@ describe('geo/leaflet/leaflet-torque-layer', function () {
     expect(this.view instanceof L.TorqueLayer).toEqual(true);
 
     this.view.check = 'testing';
-    var newLayer = this.view.model.clone();
+    var newLayer = new TorqueLayer(this.view.model.attributes, {
+      vis: this.vis
+    });
     newLayer.set({ sql: 'select * from table', cartocss: '#test {}' });
     this.map.layers.reset([newLayer]);
 

--- a/test/spec/geo/map-view.spec.js
+++ b/test/spec/geo/map-view.spec.js
@@ -35,8 +35,8 @@ describe('core/geo/map-view', function () {
         return jasmine.createSpyObj('layerView', ['something']);
       });
       var tileLayer = new TileLayer();
-      var cartoDBLayer1 = new CartoDBLayer();
-      var cartoDBLayer2 = new CartoDBLayer();
+      var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
+      var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });
 
       this.map.layers.reset([tileLayer, cartoDBLayer1, cartoDBLayer2]);
 

--- a/test/spec/geo/map-view.spec.js
+++ b/test/spec/geo/map-view.spec.js
@@ -10,15 +10,10 @@ var CartoDBLayerGroupBase = require('../../../src/geo/cartodb-layer-group-base')
 var LayerGroupModel = CartoDBLayerGroupBase;
 
 describe('core/geo/map-view', function () {
-  beforeEach(function() {
+  beforeEach(function () {
     this.container = $('<div>').css('height', '200px');
-
-    // Map needs a WindshaftMap so we're setting up a fake one
-    var windshaftMap = jasmine.createSpyObj('windshaftMap', ['bind', 'createInstance']);
-
-    this.map = new Map(null, {
-      windshaftMap: windshaftMap
-    });
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
+    this.map = new Map();
 
     this.layerViewFactory = jasmine.createSpyObj('layerViewFactory', ['createLayerView']);
     this.mapView = new MapView({
@@ -26,7 +21,6 @@ describe('core/geo/map-view', function () {
       map: this.map,
       layerViewFactory: this.layerViewFactory,
       layerGroupModel: new LayerGroupModel(null, {
-        windshaftMap: windshaftMap,
         layersCollection: this.map.layers
       })
     });
@@ -57,8 +51,8 @@ describe('core/geo/map-view', function () {
           return jasmine.createSpyObj('layerView', ['something']);
         });
         var tileLayer = new TileLayer();
-        var cartoDBLayer1 = new CartoDBLayer();
-        var cartoDBLayer2 = new CartoDBLayer();
+        var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
+        var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });
 
         this.map.layers.reset([tileLayer, cartoDBLayer1, cartoDBLayer2]);
         expect(this.mapView._addLayerToMap.calls.count()).toEqual(2);
@@ -80,7 +74,7 @@ describe('core/geo/map-view', function () {
         this.layerViewFactory.createLayerView.and.callFake(function () {
           return jasmine.createSpyObj('layerView', ['something']);
         });
-        var layer1 = new CartoDBLayer();
+        var layer1 = new CartoDBLayer({}, { vis: this.vis });
 
         this.map.addLayer(layer1);
 
@@ -95,8 +89,8 @@ describe('core/geo/map-view', function () {
           return jasmine.createSpyObj('layerView', ['something']);
         });
         var tileLayer = new TileLayer();
-        var cartoDBLayer1 = new CartoDBLayer();
-        var cartoDBLayer2 = new CartoDBLayer();
+        var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
+        var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });
 
         this.map.addLayer(tileLayer);
         expect(this.mapView._addLayerToMap).toHaveBeenCalled();
@@ -146,8 +140,8 @@ describe('core/geo/map-view', function () {
         this.layerViewFactory.createLayerView.and.callFake(function () {
           return jasmine.createSpyObj('layerView', ['remove']);
         });
-        var cartoDBLayer1 = new CartoDBLayer();
-        var cartoDBLayer2 = new CartoDBLayer();
+        var cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
+        var cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });
 
         this.map.layers.reset([cartoDBLayer1, cartoDBLayer2]);
 
@@ -176,7 +170,7 @@ describe('core/geo/map-view', function () {
         this.layerViewFactory.createLayerView.and.callFake(function () {
           return jasmine.createSpyObj('layerView', ['remove']);
         });
-        var cartoDBLayer = new CartoDBLayer();
+        var cartoDBLayer = new CartoDBLayer({}, { vis: this.vis });
 
         this.map.layers.reset([cartoDBLayer]);
 

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -12,7 +12,8 @@ describe('core/geo/map', function () {
   var map;
 
   beforeEach(function () {
-    map = new Map();
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
+    map = new Map({});
   });
 
   describe('.initialize', function () {
@@ -114,10 +115,10 @@ describe('core/geo/map', function () {
       '© <a href="https://carto.com/attributions" target="_blank">CARTO</a>'
     ]);
 
-    var layer1 = new CartoDBLayer({ attribution: 'attribution1' });
-    var layer2 = new CartoDBLayer({ attribution: 'attribution1' });
-    var layer3 = new CartoDBLayer({ attribution: 'wadus' });
-    var layer4 = new CartoDBLayer({ attribution: '' });
+    var layer1 = new CartoDBLayer({ attribution: 'attribution1' }, { vis: this.vis });
+    var layer2 = new CartoDBLayer({ attribution: 'attribution1' }, { vis: this.vis });
+    var layer3 = new CartoDBLayer({ attribution: 'wadus' }, { vis: this.vis });
+    var layer4 = new CartoDBLayer({ attribution: '' }, { vis: this.vis });
 
     map.layers.reset([ layer1, layer2, layer3, layer4 ]);
 
@@ -128,7 +129,7 @@ describe('core/geo/map', function () {
       '© <a href="https://carto.com/attributions" target="_blank">CARTO</a>'
     ]);
 
-    var layer = new CartoDBLayer({ attribution: 'attribution2' });
+    var layer = new CartoDBLayer({ attribution: 'attribution2' }, { vis: this.vis });
 
     map.layers.add(layer);
 
@@ -159,7 +160,7 @@ describe('core/geo/map', function () {
     ]);
 
     // Addind a layer with the default attribution
-    layer = new CartoDBLayer();
+    layer = new CartoDBLayer({}, { vis: this.vis });
 
     map.layers.add(layer, { at: 0 });
 
@@ -173,10 +174,7 @@ describe('core/geo/map', function () {
 
   describe('API methods', function () {
     beforeEach(function () {
-      var windshaftMap = jasmine.createSpyObj('windshaftMap', ['createInstance']);
-      this.map = new Map({}, {
-        windshaftMap: windshaftMap
-      });
+      this.map = new Map();
     });
 
     var testCases = [
@@ -346,7 +344,7 @@ describe('core/geo/map', function () {
 
   describe('.getLayerById', function () {
     beforeEach(function () {
-      var layer1 = new CartoDBLayer({ id: 'xyz-123', attribution: 'attribution1' });
+      var layer1 = new CartoDBLayer({ id: 'xyz-123', attribution: 'attribution1' }, { vis: this.vis });
 
       map.layers.reset(layer1);
     });

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -13,7 +13,7 @@ describe('core/geo/map', function () {
 
   beforeEach(function () {
     this.vis = jasmine.createSpyObj('vis', ['reload']);
-    map = new Map({});
+    map = new Map();
   });
 
   describe('.initialize', function () {
@@ -174,7 +174,9 @@ describe('core/geo/map', function () {
 
   describe('API methods', function () {
     beforeEach(function () {
-      this.map = new Map();
+      this.map = new Map({}, {
+        vis: {}
+      });
     });
 
     var testCases = [

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -82,12 +82,6 @@ describe('core/geo/map', function () {
   });
 
   it('should adjust zoom to layer', function () {
-    spyOn(map, 'reload').and.callFake(function (options) {
-      options && options.success && options.success();
-    });
-
-    map.instantiateMap();
-
     expect(map.get('maxZoom')).toEqual(map.defaults.maxZoom);
     expect(map.get('minZoom')).toEqual(map.defaults.minZoom);
 
@@ -114,7 +108,6 @@ describe('core/geo/map', function () {
 
   it('should update the attributions of the map when layers are reset/added/removed', function () {
     map = new Map();
-    map.instantiateMap();
 
     // Map has the default CartoDB attribution
     expect(map.get('attribution')).toEqual([
@@ -176,103 +169,6 @@ describe('core/geo/map', function () {
       'wadus',
       '© <a href="https://carto.com/attributions" target="_blank">CARTO</a>'
     ]);
-  });
-
-  describe('bindings to collection of layers', function () {
-    beforeEach(function () {
-      spyOn(map, 'reload').and.callFake(function (options) {
-        options && options.success && options.success();
-      });
-
-      map.instantiateMap();
-
-      map.reload.calls.reset();
-    });
-
-    it('should reload the map when layers are resetted', function () {
-      map.layers.reset([{ id: 'layer1' }]);
-
-      expect(map.reload).toHaveBeenCalled();
-    });
-
-    it('should reload the map when a new layer is added', function () {
-      map.layers.add({ id: 'layer1' });
-
-      expect(map.reload).toHaveBeenCalledWith({
-        sourceId: 'layer1'
-      });
-    });
-
-    it('should reload the map when a layer is removed', function () {
-      var layer = map.layers.add({ id: 'layer1' }, { silent: true });
-      map.layers.remove(layer);
-
-      expect(map.reload).toHaveBeenCalledWith({
-        sourceId: 'layer1'
-      });
-    });
-  });
-
-  describe('reload', function () {
-    beforeEach(function () {
-      this.windshaftMap = jasmine.createSpyObj('windshaftMap', ['createInstance']);
-      this.map = new Map({}, {
-        windshaftMap: this.windshaftMap
-      });
-    });
-
-    describe("when map hasn't been instantiated yet", function () {
-      it('should NOT instantiate map', function (done) {
-        this.map.reload({});
-
-        setTimeout(function () {
-          expect(this.windshaftMap.createInstance).not.toHaveBeenCalled();
-
-          done();
-        }.bind(this), 25);
-      });
-    });
-
-    describe('when map has been instantiated once', function () {
-      beforeEach(function () {
-        this.map.instantiateMap();
-      });
-
-      it('should instantiate map and forward options', function (done) {
-        this.map.reload({
-          a: 1,
-          b: 2,
-          sourceId: 'sourceId',
-          forceFetch: 'forceFetch',
-          success: 'success'
-        });
-
-        setTimeout(function () {
-          expect(this.windshaftMap.createInstance).toHaveBeenCalledWith({
-            sourceId: 'sourceId',
-            forceFetch: 'forceFetch',
-            success: 'success'
-          });
-
-          done();
-        }.bind(this), 25);
-      });
-
-      it('should be debounced', function (done) {
-        // Reload the map 1000 times in a row
-        for (var i = 0; i < 1000; i++) {
-          this.map.reload();
-        }
-
-        setTimeout(function () {
-          expect(this.windshaftMap.createInstance).toHaveBeenCalled();
-
-          // windshaftMap.createInstance is debounced and has only been called once
-          expect(this.windshaftMap.createInstance.calls.count()).toEqual(1);
-          done();
-        }.bind(this), 25);
-      });
-    });
   });
 
   describe('API methods', function () {

--- a/test/spec/geo/map/cartodb-layer.spec.js
+++ b/test/spec/geo/map/cartodb-layer.spec.js
@@ -5,34 +5,36 @@ var sharedTestsForInteractiveLayers = require('./shared-for-interactive-layers')
 describe('geo/map/cartodb-layer', function () {
   sharedTestsForInteractiveLayers(CartoDBLayer);
 
+  beforeEach(function () {
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
+  });
+
   it('should be type CartoDB', function () {
-    var layer = new CartoDBLayer();
+    var layer = new CartoDBLayer({}, { vis: this.vis });
     expect(layer.get('type')).toEqual('CartoDB');
   });
 
   it('should expose infowindow and tooltip properties', function () {
-    var layer = new CartoDBLayer();
+    var layer = new CartoDBLayer({}, { vis: this.vis });
     expect(layer.infowindow).toBeDefined();
     expect(layer.tooltip).toBeDefined();
   });
 
-  describe('map reloading', function () {
+  describe('vis reloading', function () {
     var ATTRIBUTES = ['visible', 'sql', 'source', 'sql_wrap', 'cartocss'];
 
     _.each(ATTRIBUTES, function (attribute) {
-      it("should reload the map when '" + attribute + "' attribute changes", function () {
-        var map = jasmine.createSpyObj('map', ['reload']);
-        var layer = new CartoDBLayer({}, { map: map });
+      it("should reload the vis when '" + attribute + "' attribute changes", function () {
+        var layer = new CartoDBLayer({}, { vis: this.vis });
 
         layer.set(attribute, 'new_value');
 
-        expect(map.reload).toHaveBeenCalled();
+        expect(this.vis.reload).toHaveBeenCalled();
       });
     });
 
     it('should reload the map just once when multiple attributes change', function () {
-      var map = jasmine.createSpyObj('map', ['reload']);
-      var layer = new CartoDBLayer({}, { map: map });
+      var layer = new CartoDBLayer({}, { vis: this.vis });
 
       var newAttributes = {};
       _.each(ATTRIBUTES, function (attr, index) {
@@ -40,18 +42,17 @@ describe('geo/map/cartodb-layer', function () {
       });
       layer.set(newAttributes);
 
-      expect(map.reload).toHaveBeenCalled();
-      expect(map.reload.calls.count()).toEqual(1);
+      expect(this.vis.reload).toHaveBeenCalled();
+      expect(this.vis.reload.calls.count()).toEqual(1);
     });
 
     it('should NOT reload the map if cartocss has changed and layer has a dataProvider', function () {
-      var map = jasmine.createSpyObj('map', ['reload']);
-      var layer = new CartoDBLayer({}, { map: map });
+      var layer = new CartoDBLayer({}, { vis: this.vis });
       layer.setDataProvider('wadus');
 
       layer.set('cartocss', 'new_value');
 
-      expect(map.reload).not.toHaveBeenCalled();
+      expect(this.vis.reload).not.toHaveBeenCalled();
     });
   });
 
@@ -70,7 +71,7 @@ describe('geo/map/cartodb-layer', function () {
             { name: 'c' }
           ]
         }
-      });
+      }, { vis: this.vis });
 
       expect(this.layer.getInteractiveColumnNames()).toEqual([ 'cartodb_id', 'a', 'b', 'c' ]);
     });
@@ -83,7 +84,7 @@ describe('geo/map/cartodb-layer', function () {
         tooltip: {
           fields: []
         }
-      });
+      }, { vis: this.vis });
 
       expect(this.layer.getInteractiveColumnNames()).toEqual([]);
     });

--- a/test/spec/geo/map/layers.spec.js
+++ b/test/spec/geo/map/layers.spec.js
@@ -8,6 +8,7 @@ describe('geo/map/layers', function () {
   var layers;
 
   beforeEach(function () {
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
     layers = new Layers();
   });
 
@@ -39,9 +40,9 @@ describe('geo/map/layers', function () {
 
   it('should re-assign order when new layers are added to the collection', function () {
     var baseLayer = new TileLayer();
-    var layer1 = new CartoDBLayer();
-    var layer2 = new CartoDBLayer();
-    var layer3 = new CartoDBLayer();
+    var layer1 = new CartoDBLayer({}, { vis: this.vis });
+    var layer2 = new CartoDBLayer({}, { vis: this.vis });
+    var layer3 = new CartoDBLayer({}, { vis: this.vis });
 
     // Sets the order to 0
     layers.add(baseLayer);
@@ -66,7 +67,7 @@ describe('geo/map/layers', function () {
     expect(layer3.get('order')).toEqual(1);
     expect(layers.pluck('order')).toEqual([ 0, 1, 2, 3 ]);
 
-    var torqueLayer = new TorqueLayer({});
+    var torqueLayer = new TorqueLayer({}, { vis: this.vis });
 
     // Torque layer should be at the top
     layers.add(torqueLayer);
@@ -91,7 +92,7 @@ describe('geo/map/layers', function () {
     expect(tiledLayer.get('order')).toEqual(5);
     expect(layers.pluck('order')).toEqual([ 0, 1, 2, 3, 4, 5 ]);
 
-    var layer4 = new CartoDBLayer({});
+    var layer4 = new CartoDBLayer({}, { vis: this.vis });
     layers.add(layer4);
 
     expect(baseLayer.get('order')).toEqual(0);
@@ -106,9 +107,9 @@ describe('geo/map/layers', function () {
 
   it('should re-assign order when new layers are removed from the collection', function () {
     var baseLayer = new TileLayer();
-    var layer1 = new CartoDBLayer();
-    var layer2 = new CartoDBLayer();
-    var torqueLayer = new TorqueLayer({});
+    var layer1 = new CartoDBLayer({}, { vis: this.vis });
+    var layer2 = new CartoDBLayer({}, { vis: this.vis });
+    var torqueLayer = new TorqueLayer({}, { vis: this.vis });
     var labelsLayer = new TileLayer();
 
     // Sets the order to 0

--- a/test/spec/geo/map/shared-for-interactive-layers.js
+++ b/test/spec/geo/map/shared-for-interactive-layers.js
@@ -12,7 +12,7 @@ module.exports = function (LayerModel) {
 
   _.each(METHODS, function (method) {
     it('should respond to .' + method, function () {
-      var layer = new LayerModel();
+      var layer = new LayerModel({}, { vis: this.vis });
 
       expect(typeof layer[method] === 'function').toBeTruthy();
     });

--- a/test/spec/geo/map/torque-layer.spec.js
+++ b/test/spec/geo/map/torque-layer.spec.js
@@ -3,25 +3,27 @@ var TorqueLayer = require('../../../../src/geo/map/torque-layer');
 var sharedTestsForInteractiveLayers = require('./shared-for-interactive-layers');
 
 describe('geo/map/torque-layer', function () {
+  beforeEach(function () {
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
+  });
+
   sharedTestsForInteractiveLayers(TorqueLayer);
 
-  describe('map reloading', function () {
+  describe('vis reloading', function () {
     var ATTRIBUTES = ['visible', 'sql', 'source'];
 
     _.each(ATTRIBUTES, function (attribute) {
-      it("should reload the map when '" + attribute + "' attribute changes", function () {
-        var map = jasmine.createSpyObj('map', ['reload']);
-        var layer = new TorqueLayer({}, { map: map });
+      it("should reload the vis when '" + attribute + "' attribute changes", function () {
+        var layer = new TorqueLayer({}, { vis: this.vis });
 
         layer.set(attribute, 'new_value');
 
-        expect(map.reload).toHaveBeenCalled();
+        expect(this.vis.reload).toHaveBeenCalled();
       });
     });
 
     it('should reload the map just once when multiple attributes change', function () {
-      var map = jasmine.createSpyObj('map', ['reload']);
-      var layer = new TorqueLayer({}, { map: map });
+      var layer = new TorqueLayer({}, { vis: this.vis });
 
       var newAttributes = {};
       _.each(ATTRIBUTES, function (attr, index) {
@@ -29,28 +31,26 @@ describe('geo/map/torque-layer', function () {
       });
       layer.set(newAttributes);
 
-      expect(map.reload).toHaveBeenCalled();
-      expect(map.reload.calls.count()).toEqual(1);
+      expect(this.vis.reload).toHaveBeenCalled();
+      expect(this.vis.reload.calls.count()).toEqual(1);
     });
 
     it('should NOT reload the map when cartocss is set and it was previously empty', function () {
-      var map = jasmine.createSpyObj('map', ['reload']);
-      var layer = new TorqueLayer({}, { map: map });
+      var layer = new TorqueLayer({}, { vis: this.vis });
 
       layer.set('cartocss', 'new_value');
 
-      expect(map.reload).not.toHaveBeenCalled();
+      expect(this.vis.reload).not.toHaveBeenCalled();
     });
 
     it('should NOT reload the map if a cartocss property has changed and a reload is not needed', function () {
-      var map = jasmine.createSpyObj('map', ['reload']);
       var layer = new TorqueLayer({
         cartocss: 'Map { something: "a"; -torque-time-attribute: "column"; }'
-      }, { map: map });
+      }, { vis: this.vis });
 
       layer.set('cartocss', 'Map { something: "b"; -torque-time-attribute: "column"; }');
 
-      expect(map.reload).not.toHaveBeenCalled();
+      expect(this.vis.reload).not.toHaveBeenCalled();
     });
 
     _.each([
@@ -61,14 +61,13 @@ describe('geo/map/torque-layer', function () {
       '-torque-resolution'
     ], function (property) {
       it('should reload the map if cartocss attribute has changed and "' + property + '"" property has changed', function () {
-        var map = jasmine.createSpyObj('map', ['reload']);
         var layer = new TorqueLayer({
           cartocss: 'Map { something: "a"; ' + property + ': "valueA"; }'
-        }, { map: map });
+        }, { vis: this.vis });
 
         layer.set('cartocss', 'Map { something: "b"; ' + property + ': "valueB"; }');
 
-        expect(map.reload).toHaveBeenCalled();
+        expect(this.vis.reload).toHaveBeenCalled();
       });
     });
   });

--- a/test/spec/geo/ui/layer-selector-torque.spec.js
+++ b/test/spec/geo/ui/layer-selector-torque.spec.js
@@ -12,15 +12,15 @@ describe('geo/ui/layer-selector (torque)', function() {
   var layerSelector;
 
   beforeEach(function() {
-    // TODO: Remove this
-    var map = new Map();
-    map.vis = { reload: function () {} };
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
 
-    var l1 = new TorqueLayer({ layer_name: 'Layer 1' }, { map: map });
-    var l2 = new TorqueLayer({ layer_name: 'Layer 2' }, { map: map });
-    var l3 = new TorqueLayer({ layer_name: 'Layer 3' }, { map: map });
+    var l1 = new TorqueLayer({ layer_name: 'Layer 1' }, { vis: this.vis });
+    var l2 = new TorqueLayer({ layer_name: 'Layer 2' }, { vis: this.vis });
+    var l3 = new TorqueLayer({ layer_name: 'Layer 3' }, { vis: this.vis });
 
-    map.layers = new Layers([l1, l2, l3]);
+    var map = new Map({}, {
+      layersCollection: new Layers([l1, l2, l3])
+    });
 
     var mapView = new LeafletMapView({
       el: $("<div>"),

--- a/test/spec/geo/ui/layer-selector-torque.spec.js
+++ b/test/spec/geo/ui/layer-selector-torque.spec.js
@@ -12,12 +12,9 @@ describe('geo/ui/layer-selector (torque)', function() {
   var layerSelector;
 
   beforeEach(function() {
-    // Map needs a WindshaftMap so we're setting up a fake one
-    var windshaftMap = jasmine.createSpyObj('windshaftMap', ['bind', 'createInstance', 'reload']);
-
-    var map = new Map(null, {
-      windshaftMap: windshaftMap
-    });
+    // TODO: Remove this
+    var map = new Map();
+    map.vis = { reload: function () {} };
 
     var l1 = new TorqueLayer({ layer_name: 'Layer 1' }, { map: map });
     var l2 = new TorqueLayer({ layer_name: 'Layer 2' }, { map: map });

--- a/test/spec/geo/ui/layer-selector.spec.js
+++ b/test/spec/geo/ui/layer-selector.spec.js
@@ -11,21 +11,18 @@ describe('geo/ui/layer-selector', function () {
   var layerSelector, layer1, layer2;
 
   beforeEach(function() {
-    // Map needs a WindshaftMap so we're setting up a fake one
-    var windshaftMap = jasmine.createSpyObj('windshaftMap', ['bind', 'createInstance', 'reload']);
+    // TODO: Remove this
+    var map = new Map();
+    map.vis = { reload: function () {} };
 
-    var map2 = new Map(null, {
-      windshaftMap: windshaftMap
-    });
+    layer1 = new CartoDBLayer({ options: { layer_name: 'Layer 1' } }, { map: map });
+    layer2 = new CartoDBLayer({ options: { layer_name: 'Layer 2' } }, { map: map });
 
-    layer1 = new CartoDBLayer({ options: { layer_name: 'Layer 1' } }, { map: map2 });
-    layer2 = new CartoDBLayer({ options: { layer_name: 'Layer 2' } }, { map: map2 });
-
-    map2.layers.reset([layer1, layer2]);
+    map.layers.reset([layer1, layer2]);
 
     var mapView2 = new LeafletMapView({
       el: $("<div>"),
-      map: map2,
+      map: map,
       layerViewFactory: new LeafletLayerViewFactory(),
       layerGroupModel: new Backbone.Model({ type: 'layergroup' })
     });

--- a/test/spec/geo/ui/layer-selector.spec.js
+++ b/test/spec/geo/ui/layer-selector.spec.js
@@ -1,6 +1,7 @@
 var $ = require('jquery');
 var Backbone = require('backbone');
 var Map = require('../../../../src/geo/map');
+var Layers = require('../../../../src/geo/map/layers');
 var CartoDBLayer = require('../../../../src/geo/map/cartodb-layer');
 var Template = require('../../../../src/core/template');
 var LayerSelector = require('../../../../src/geo/ui/layer-selector');
@@ -11,14 +12,13 @@ describe('geo/ui/layer-selector', function () {
   var layerSelector, layer1, layer2;
 
   beforeEach(function() {
-    // TODO: Remove this
-    var map = new Map();
-    map.vis = { reload: function () {} };
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
+    layer1 = new CartoDBLayer({ options: { layer_name: 'Layer 1' } }, { vis: this.vis });
+    layer2 = new CartoDBLayer({ options: { layer_name: 'Layer 2' } }, { vis: this.vis });
 
-    layer1 = new CartoDBLayer({ options: { layer_name: 'Layer 1' } }, { map: map });
-    layer2 = new CartoDBLayer({ options: { layer_name: 'Layer 2' } }, { map: map });
-
-    map.layers.reset([layer1, layer2]);
+    var map = new Map({}, {
+      layersCollection: new Layers([layer1, layer2])
+    });
 
     var mapView2 = new LeafletMapView({
       el: $("<div>"),

--- a/test/spec/vis/infowindow-manager-spec.js
+++ b/test/spec/vis/infowindow-manager-spec.js
@@ -8,6 +8,7 @@ var InfowindowManager = require('../../../src/vis/infowindow-manager');
 describe('src/vis/infowindow-manager.js', function () {
   beforeEach(function () {
     var windshaftMap = new Backbone.Model({});
+    // TODO: Remove this?
     this.map = new Map({}, {
       windshaftMap: windshaftMap
     });
@@ -26,7 +27,8 @@ describe('src/vis/infowindow-manager.js', function () {
     this.mapView.getSize = function () { return { x: 1000, y: 1000 }; };
 
     this.vis = {
-      mapView: this.mapView
+      mapView: this.mapView,
+      reload: jasmine.createSpy('reload')
     };
   });
 
@@ -539,8 +541,6 @@ describe('src/vis/infowindow-manager.js', function () {
   });
 
   it('should reload the map when the infowindow template gets new fields', function () {
-    spyOn(this.map, 'reload');
-
     var layer = new CartoDBLayer({
       infowindow: {
         template: 'template',
@@ -580,7 +580,7 @@ describe('src/vis/infowindow-manager.js', function () {
       ]
     });
 
-    expect(this.map.reload).toHaveBeenCalledWith({});
+    expect(this.vis.reload).toHaveBeenCalledWith({});
   });
 
   it('should reload the map and fetch attributes when the infowindow template is active (visible) and it gets fields', function () {
@@ -621,7 +621,7 @@ describe('src/vis/infowindow-manager.js', function () {
     infowindowManager._infowindowModel.setInfowindowTemplate(layer.infowindow);
     infowindowManager._infowindowModel.set('visibility', true);
 
-    spyOn(this.map, 'reload');
+    spyOn(this.vis, 'reload');
 
     layer.infowindow.update({
       fields: [
@@ -702,7 +702,7 @@ describe('src/vis/infowindow-manager.js', function () {
 
     // Nothing happened
     expect(infowindowView.model.get('visibility')).toBe(true);
-    expect(this.map.reload).not.toHaveBeenCalledWith({});
+    expect(this.vis.reload).not.toHaveBeenCalledWith({});
 
     // Clear fields on layer #0 (the one that was opened)
     layer1.infowindow.update({
@@ -711,6 +711,6 @@ describe('src/vis/infowindow-manager.js', function () {
 
     // Infowindow has been closed and map has NOT been reloaded
     expect(infowindowView.model.get('visibility')).toBe(false);
-    expect(this.map.reload).not.toHaveBeenCalledWith({});
+    expect(this.vis.reload).not.toHaveBeenCalledWith({});
   });
 });

--- a/test/spec/vis/infowindow-manager-spec.js
+++ b/test/spec/vis/infowindow-manager-spec.js
@@ -7,11 +7,7 @@ var InfowindowManager = require('../../../src/vis/infowindow-manager');
 
 describe('src/vis/infowindow-manager.js', function () {
   beforeEach(function () {
-    var windshaftMap = new Backbone.Model({});
-    // TODO: Remove this?
-    this.map = new Map({}, {
-      windshaftMap: windshaftMap
-    });
+    this.map = new Map({}, {});
     this.layerView = new Backbone.Model();
     var layerViewFactory = jasmine.createSpyObj('layerViewFactory', ['createLayerView']);
     layerViewFactory.createLayerView.and.returnValue(this.layerView);
@@ -43,7 +39,7 @@ describe('src/vis/infowindow-manager.js', function () {
           'position': 1
         }]
       }
-    });
+    }, { vis: this.vis });
 
     this.map.layers.reset([ layer ]);
 
@@ -64,7 +60,7 @@ describe('src/vis/infowindow-manager.js', function () {
           'position': 1
         }]
       }
-    });
+    }, { vis: this.vis });
 
     var infowindowManager = new InfowindowManager(this.vis);
     infowindowManager.manage(this.mapView, this.map);
@@ -84,7 +80,7 @@ describe('src/vis/infowindow-manager.js', function () {
           'position': 1
         }]
       }
-    });
+    }, { vis: this.vis });
 
     var infowindowManager = new InfowindowManager(this.vis);
     infowindowManager.manage(this.mapView, this.map);
@@ -104,7 +100,7 @@ describe('src/vis/infowindow-manager.js', function () {
           'position': 1
         }]
       }
-    });
+    }, { vis: this.vis });
 
     var layer2 = new CartoDBLayer({
       infowindow: {
@@ -114,7 +110,7 @@ describe('src/vis/infowindow-manager.js', function () {
           'position': 1
         }]
       }
-    });
+    }, { vis: this.vis });
 
     var infowindowManager = new InfowindowManager(this.vis);
     infowindowManager.manage(this.mapView, this.map);
@@ -138,7 +134,7 @@ describe('src/vis/infowindow-manager.js', function () {
         }],
         alternative_names: 'alternative_names1'
       }
-    });
+    }, { vis: this.vis });
 
     var layer2 = new CartoDBLayer({
       infowindow: {
@@ -151,7 +147,7 @@ describe('src/vis/infowindow-manager.js', function () {
         }],
         alternative_names: 'alternative_names2'
       }
-    });
+    }, { vis: this.vis });
 
     var infowindowManager = new InfowindowManager(this.vis);
     infowindowManager.manage(this.mapView, this.map);
@@ -274,7 +270,7 @@ describe('src/vis/infowindow-manager.js', function () {
         }],
         alternative_names: 'alternative_names1'
       }
-    });
+    }, { vis: this.vis });
 
     var layer2 = new CartoDBLayer({
       infowindow: {
@@ -287,7 +283,7 @@ describe('src/vis/infowindow-manager.js', function () {
         }],
         alternative_names: 'alternative_names2'
       }
-    });
+    }, { vis: this.vis });
 
     var infowindowManager = new InfowindowManager(this.vis);
     infowindowManager.manage(this.mapView, this.map);
@@ -316,7 +312,7 @@ describe('src/vis/infowindow-manager.js', function () {
         }],
         alternative_names: 'alternative_names1'
       }
-    });
+    }, { vis: this.vis });
 
     var infowindowManager = new InfowindowManager(this.vis);
     infowindowManager.manage(this.mapView, this.map);
@@ -383,7 +379,7 @@ describe('src/vis/infowindow-manager.js', function () {
         }],
         alternative_names: 'alternative_names1'
       }
-    });
+    }, { vis: this.vis });
 
     var infowindowManager = new InfowindowManager(this.vis);
     infowindowManager.manage(this.mapView, this.map);
@@ -461,7 +457,7 @@ describe('src/vis/infowindow-manager.js', function () {
         }],
         alternative_names: 'alternative_names'
       }
-    });
+    }, { vis: this.vis });
 
     var infowindowManager = new InfowindowManager(this.vis);
     infowindowManager.manage(this.mapView, this.map);
@@ -510,7 +506,7 @@ describe('src/vis/infowindow-manager.js', function () {
         }],
         alternative_names: 'alternative_names'
       }
-    });
+    }, { vis: this.vis });
 
     var infowindowManager = new InfowindowManager(this.vis);
     infowindowManager.manage(this.mapView, this.map);
@@ -552,7 +548,7 @@ describe('src/vis/infowindow-manager.js', function () {
         }],
         alternative_names: 'alternative_names'
       }
-    });
+    }, { vis: this.vis });
 
     var infowindowManager = new InfowindowManager(this.vis);
     infowindowManager.manage(this.mapView, this.map);
@@ -597,7 +593,7 @@ describe('src/vis/infowindow-manager.js', function () {
         }],
         alternative_names: 'alternative_names'
       }
-    });
+    }, { vis: this.vis });
 
     var infowindowManager = new InfowindowManager(this.vis);
     infowindowManager.manage(this.mapView, this.map);
@@ -621,7 +617,7 @@ describe('src/vis/infowindow-manager.js', function () {
     infowindowManager._infowindowModel.setInfowindowTemplate(layer.infowindow);
     infowindowManager._infowindowModel.set('visibility', true);
 
-    spyOn(this.vis, 'reload');
+    this.vis.reload.calls.reset();
 
     layer.infowindow.update({
       fields: [
@@ -633,7 +629,7 @@ describe('src/vis/infowindow-manager.js', function () {
       ]
     });
 
-    expect(this.map.reload.calls.argsFor(0)[0].success).toEqual(jasmine.any(Function));
+    expect(this.vis.reload.calls.argsFor(0)[0].success).toEqual(jasmine.any(Function));
   });
 
   it('should hide the infowindow when fields are cleared in the infowindow template', function () {
@@ -642,7 +638,6 @@ describe('src/vis/infowindow-manager.js', function () {
     tooltipView.setFilter.and.returnValue(tooltipView);
     this.layerView.tooltipView = tooltipView;
 
-    spyOn(this.map, 'reload');
     spyOn(this.mapView, 'addInfowindow');
 
     var layer1 = new CartoDBLayer({
@@ -656,7 +651,7 @@ describe('src/vis/infowindow-manager.js', function () {
         }],
         alternative_names: 'alternative_names'
       }
-    });
+    }, { vis: this.vis });
 
     var layer2 = new CartoDBLayer({
       infowindow: {
@@ -669,7 +664,7 @@ describe('src/vis/infowindow-manager.js', function () {
         }],
         alternative_names: 'alternative_names'
       }
-    });
+    }, { vis: this.vis });
 
     var infowindowManager = new InfowindowManager(this.vis);
     infowindowManager.manage(this.mapView, this.map);

--- a/test/spec/vis/layers.spec.js
+++ b/test/spec/vis/layers.spec.js
@@ -9,6 +9,10 @@ var Layers = require('../../../src/vis/vis/layers');
 require('../../../src/vis/layers'); // Layers.register calls
 
 describe('vis/layers', function () {
+  beforeEach(function () {
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
+  });
+
   describe('https/http', function () {
     it('torque layer should not rewrite to http if https is not present', function () {
       var layer = Layers.create('torque', {
@@ -16,7 +20,7 @@ describe('vis/layers', function () {
         sql_api_port: 123,
         sql_api_domain: 'carto.com',
         sql_api_protocol: 'https'
-      }, {});
+      }, { vis: this.vis });
       expect(layer.get('sql_api_protocol')).toEqual('https');
       expect(layer.get('sql_api_port')).toEqual(123);
     });
@@ -28,7 +32,8 @@ describe('vis/layers', function () {
         sql_api_domain: 'carto.com',
         sql_api_protocol: 'http'
       }, {
-        https: true
+        https: true,
+        vis: this.vis
       });
       expect(layer.get('sql_api_protocol')).toEqual('https');
       expect(layer.get('sql_api_port')).toEqual(443);
@@ -39,7 +44,8 @@ describe('vis/layers', function () {
         type: 'Tiled',
         urlTemplate: 'http://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png'
       }, {
-        https: true
+        https: true,
+        vis: this.vis
       });
       expect(layer.get('urlTemplate').indexOf('https')).not.toBe(-1);
     });

--- a/test/spec/vis/tooltip-manager-spec.js
+++ b/test/spec/vis/tooltip-manager-spec.js
@@ -7,10 +7,7 @@ var TooltipManager = require('../../../src/vis/tooltip-manager');
 
 describe('src/vis/tooltip-manager.js', function () {
   beforeEach(function () {
-    var windshaftMap = new Backbone.Model({});
-    this.map = new Map({}, {
-      windshaftMap: windshaftMap
-    });
+    this.map = new Map();
     this.layerView = new Backbone.Model();
     var layerViewFactory = jasmine.createSpyObj('layerViewFactory', ['createLayerView']);
     layerViewFactory.createLayerView.and.returnValue(this.layerView);
@@ -42,7 +39,7 @@ describe('src/vis/tooltip-manager.js', function () {
           'position': 1
         }]
       }
-    });
+    }, { vis: this.vis });
 
     this.map.layers.reset([ layer ]);
 
@@ -63,7 +60,7 @@ describe('src/vis/tooltip-manager.js', function () {
           'position': 1
         }]
       }
-    });
+    }, { vis: this.vis });
 
     var tooltipManager = new TooltipManager(this.vis);
     tooltipManager.manage(this.mapView, this.map);
@@ -83,7 +80,7 @@ describe('src/vis/tooltip-manager.js', function () {
           'position': 1
         }]
       }
-    });
+    }, { vis: this.vis });
 
     var tooltipManager = new TooltipManager(this.vis);
     tooltipManager.manage(this.mapView, this.map);
@@ -103,7 +100,7 @@ describe('src/vis/tooltip-manager.js', function () {
           'position': 1
         }]
       }
-    });
+    }, { vis: this.vis });
 
     var layer2 = new CartoDBLayer({
       tooltip: {
@@ -113,7 +110,7 @@ describe('src/vis/tooltip-manager.js', function () {
           'position': 1
         }]
       }
-    });
+    }, { vis: this.vis });
 
     var tooltipManager = new TooltipManager(this.vis);
     tooltipManager.manage(this.mapView, this.map);
@@ -138,7 +135,7 @@ describe('src/vis/tooltip-manager.js', function () {
         }],
         alternative_names: 'alternative_names1'
       }
-    });
+    }, { vis: this.vis });
     var layer2 = new CartoDBLayer({
       tooltip: {
         template: 'template2',
@@ -150,7 +147,7 @@ describe('src/vis/tooltip-manager.js', function () {
         }],
         alternative_names: 'alternative_names2'
       }
-    });
+    }, { vis: this.vis });
 
     var tooltipManager = new TooltipManager(this.vis);
     tooltipManager.manage(this.mapView, this.map);
@@ -210,7 +207,7 @@ describe('src/vis/tooltip-manager.js', function () {
         }],
         alternative_names: 'alternative_names1'
       }
-    });
+    }, { vis: this.vis });
     var layer2 = new CartoDBLayer({
       tooltip: {
         template: 'template2',
@@ -222,7 +219,7 @@ describe('src/vis/tooltip-manager.js', function () {
         }],
         alternative_names: 'alternative_names2'
       }
-    });
+    }, { vis: this.vis });
 
     var tooltipManager = new TooltipManager(this.vis);
     tooltipManager.manage(this.mapView, this.map);
@@ -240,7 +237,7 @@ describe('src/vis/tooltip-manager.js', function () {
   it('should disable the tooltipView if the layerModel doesn\'t have tooltip data', function () {
     spyOn(this.mapView, 'addOverlay');
 
-    var layer1 = new CartoDBLayer({});
+    var layer1 = new CartoDBLayer({}, { vis: this.vis });
     var layer2 = new CartoDBLayer({
       tooltip: {
         template: 'template2',
@@ -252,7 +249,7 @@ describe('src/vis/tooltip-manager.js', function () {
         }],
         alternative_names: 'alternative_names2'
       }
-    });
+    }, { vis: this.vis });
 
     var tooltipManager = new TooltipManager(this.vis);
     tooltipManager.manage(this.mapView, this.map);

--- a/test/spec/vis/tooltip-manager-spec.js
+++ b/test/spec/vis/tooltip-manager-spec.js
@@ -26,7 +26,8 @@ describe('src/vis/tooltip-manager.js', function () {
     this.mapView.getSize = function () { return { x: 1000, y: 1000 }; };
 
     this.vis = {
-      mapView: this.mapView
+      mapView: this.mapView,
+      reload: jasmine.createSpy('reload')
     };
   });
 

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -234,6 +234,81 @@ describe('vis/vis', function () {
     expect(this.vis.get('loading')).toEqual(false);
   });
 
+  describe('bindings to collection of layers', function () {
+    beforeEach(function () {
+      spyOn(this.vis, 'reload').and.callFake(function (options) {
+        options && options.success && options.success();
+      });
+
+      this.vis.load(new VizJSON(fakeVizJSON()), {});
+      this.vis.instantiateMap();
+
+      this.vis.reload.calls.reset();
+    });
+
+    it('should reload the map when layers are resetted', function () {
+      this.vis.map.layers.reset([{ id: 'layer1' }]);
+
+      expect(this.vis.reload).toHaveBeenCalled();
+    });
+
+    it('should reload the map when a new layer is added', function () {
+      this.vis.map.layers.add({ id: 'layer1' });
+
+      expect(this.vis.reload).toHaveBeenCalledWith({
+        sourceId: 'layer1'
+      });
+    });
+
+    it('should reload the map when a layer is removed', function () {
+      var layer = this.vis.map.layers.add({ id: 'layer1' }, { silent: true });
+      this.vis.map.layers.remove(layer);
+
+      expect(this.vis.reload).toHaveBeenCalledWith({
+        sourceId: 'layer1'
+      });
+    });
+  });
+
+  describe('.reload', function () {
+    beforeEach(function () {
+      this.vis.load(new VizJSON(fakeVizJSON()), {});
+
+      spyOn(this.vis._windshaftMap, 'createInstance');
+    });
+
+    describe("when vis hasn't been instantiated yet", function () {
+      it('should NOT instantiate map', function () {
+        this.vis.reload({});
+
+        expect(this.vis._windshaftMap.createInstance).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when vis has been instantiated once', function () {
+      beforeEach(function () {
+        this.vis.instantiateMap();
+        this.vis._windshaftMap.createInstance.calls.reset();
+      });
+
+      it('should instantiate map and forward options', function () {
+        this.vis.reload({
+          a: 1,
+          b: 2,
+          sourceId: 'sourceId',
+          forceFetch: 'forceFetch',
+          success: 'success'
+        });
+
+        expect(this.vis._windshaftMap.createInstance).toHaveBeenCalledWith({
+          sourceId: 'sourceId',
+          forceFetch: 'forceFetch',
+          success: 'success'
+        });
+      });
+    });
+  });
+
   describe('.load', function () {
     beforeEach(function () {
       this.vis.load(new VizJSON(fakeVizJSON()), {});

--- a/test/spec/windshaft/anonymous-map.spec.js
+++ b/test/spec/windshaft/anonymous-map.spec.js
@@ -25,7 +25,7 @@ var createFakeDataview = function (attrs, windshaftMap, layer, analysisCollectio
 
   return new HistogramDataviewModel(attrs, {
     map: jasmine.createSpyObj('map', ['getViewBounds', 'bind']),
-    vis: jasmine.createSpyObj('map', ['reload']),
+    vis: this.vis,
     windshaftMap: windshaftMap,
     layer: layer,
     analysisCollection: new Backbone.Collection()
@@ -35,12 +35,14 @@ var createFakeDataview = function (attrs, windshaftMap, layer, analysisCollectio
 describe('windshaft/anonymous-map', function () {
   beforeEach(function () {
     this.analysisCollection = new Backbone.Collection();
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
     this.cartoDBLayer1 = new CartoDBLayer({
       id: 'layer1',
       sql: 'sql1',
       cartocss: 'cartoCSS1',
       cartocss_version: '2.0'
     }, {
+      vis: this.vis,
       analysisCollection: this.analysisCollection
     });
     this.cartoDBLayer2 = new CartoDBLayer({
@@ -49,6 +51,7 @@ describe('windshaft/anonymous-map', function () {
       cartocss: 'cartoCSS2',
       cartocss_version: '2.0'
     }, {
+      vis: this.vis,
       analysisCollection: this.analysisCollection
     });
     this.cartoDBLayer3 = new CartoDBLayer({
@@ -57,6 +60,7 @@ describe('windshaft/anonymous-map', function () {
       cartocss: 'cartoCSS3',
       cartocss_version: '2.0'
     }, {
+      vis: this.vis,
       analysisCollection: this.analysisCollection
     });
 
@@ -211,6 +215,8 @@ describe('windshaft/anonymous-map', function () {
         id: 'torqueId',
         sql: 'sql',
         cartocss: 'cartocss'
+      }, {
+        vis: this.vis
       }));
 
       expect(this.map.toJSON()).toEqual({
@@ -245,7 +251,8 @@ describe('windshaft/anonymous-map', function () {
           id: 'a0'
         }
       }, {
-        map: jasmine.createSpyObj('map', ['getViewBounds', 'bind', 'reload']),
+        map: jasmine.createSpyObj('map', ['getViewBounds', 'bind']),
+        vis: this.vis,
         windshaftMap: this.map,
         layer: this.cartoDBLayer1,
         analysisCollection: new Backbone.Collection()
@@ -259,7 +266,8 @@ describe('windshaft/anonymous-map', function () {
           id: 'a1'
         }
       }, {
-        map: jasmine.createSpyObj('map', ['getViewBounds', 'bind', 'reload']),
+        map: jasmine.createSpyObj('map', ['getViewBounds', 'bind']),
+        vis: this.vis,
         windshaftMap: this.map,
         layer: this.cartoDBLayer2,
         analysisCollection: new Backbone.Collection()
@@ -328,7 +336,7 @@ describe('windshaft/anonymous-map', function () {
         this.analysisFactory = new AnalysisFactory({
           analysisCollection: this.analysisCollection,
           camshaftReference: fakeCamshaftReference,
-          vis: jasmine.createSpyObj('vis', ['reload'])
+          vis: this.vis
         });
       });
 

--- a/test/spec/windshaft/anonymous-map.spec.js
+++ b/test/spec/windshaft/anonymous-map.spec.js
@@ -327,7 +327,7 @@ describe('windshaft/anonymous-map', function () {
         this.analysisFactory = new AnalysisFactory({
           analysisCollection: this.analysisCollection,
           camshaftReference: fakeCamshaftReference,
-          map: jasmine.createSpyObj('map', ['reload'])
+          vis: jasmine.createSpyObj('vis', ['reload'])
         });
       });
 

--- a/test/spec/windshaft/anonymous-map.spec.js
+++ b/test/spec/windshaft/anonymous-map.spec.js
@@ -24,7 +24,8 @@ var createFakeDataview = function (attrs, windshaftMap, layer, analysisCollectio
   });
 
   return new HistogramDataviewModel(attrs, {
-    map: jasmine.createSpyObj('map', ['getViewBounds', 'bind', 'reload']),
+    map: jasmine.createSpyObj('map', ['getViewBounds', 'bind']),
+    vis: jasmine.createSpyObj('map', ['reload']),
     windshaftMap: windshaftMap,
     layer: layer,
     analysisCollection: new Backbone.Collection()

--- a/test/spec/windshaft/map-base.spec.js
+++ b/test/spec/windshaft/map-base.spec.js
@@ -80,8 +80,7 @@ describe('windshaft/map-base', function () {
         view_bounds_sw: [],
         view_bounds_ne: []
       });
-      // TODO: Remove this
-      this.map.vis = { reload: function () {} };
+      this.vis = { reload: function () {} };
 
       this.filter = new CategoryFilter({
         dataviewId: 'dataviewId'
@@ -93,6 +92,7 @@ describe('windshaft/map-base', function () {
         source: { id: 'a0' }
       }, {
         map: this.map,
+        vis: this.vis,
         windshaftMap: this.windshaftMap,
         layer: this.cartoDBLayer1,
         filter: this.filter,

--- a/test/spec/windshaft/map-base.spec.js
+++ b/test/spec/windshaft/map-base.spec.js
@@ -54,10 +54,11 @@ describe('windshaft/map-base', function () {
       userName: 'rambo'
     });
 
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
     this.cartoDBLayerGroup = new Model();
-    this.cartoDBLayer1 = new CartoDBLayer({ id: '12345-67890' });
-    this.cartoDBLayer2 = new CartoDBLayer({ id: '09876-54321' });
-    this.torqueLayer = new TorqueLayer();
+    this.cartoDBLayer1 = new CartoDBLayer({ id: '12345-67890' }, { vis: this.vis });
+    this.cartoDBLayer2 = new CartoDBLayer({ id: '09876-54321' }, { vis: this.vis });
+    this.torqueLayer = new TorqueLayer({}, { vis: this.vis });
 
     this.windshaftMap = new WindshaftMap({
       statTag: 'stat_tag'
@@ -80,7 +81,6 @@ describe('windshaft/map-base', function () {
         view_bounds_sw: [],
         view_bounds_ne: []
       });
-      this.vis = { reload: function () {} };
 
       this.filter = new CategoryFilter({
         dataviewId: 'dataviewId'

--- a/test/spec/windshaft/map-base.spec.js
+++ b/test/spec/windshaft/map-base.spec.js
@@ -79,9 +79,9 @@ describe('windshaft/map-base', function () {
       this.map = new Map({
         view_bounds_sw: [],
         view_bounds_ne: []
-      }, {
-        windshaftMap: this.windshaftMap
       });
+      // TODO: Remove this
+      this.map.vis = { reload: function () {} };
 
       this.filter = new CategoryFilter({
         dataviewId: 'dataviewId'

--- a/test/spec/windshaft/named-map.spec.js
+++ b/test/spec/windshaft/named-map.spec.js
@@ -6,12 +6,14 @@ var NamedMap = require('../../../src/windshaft/named-map');
 describe('windshaft/named-map', function () {
   beforeEach(function () {
     this.analysisCollection = new Backbone.Collection();
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
     this.cartoDBLayer1 = new CartoDBLayer({
       id: 'layer1',
       sql: 'sql1',
       cartocss: 'cartoCSS1',
       cartocss_version: '2.0'
     }, {
+      vis: this.vis,
       analysisCollection: this.analysisCollection
     });
     this.cartoDBLayer2 = new CartoDBLayer({
@@ -20,6 +22,7 @@ describe('windshaft/named-map', function () {
       cartocss: 'cartoCSS2',
       cartocss_version: '2.0'
     }, {
+      vis: this.vis,
       analysisCollection: this.analysisCollection
     });
     this.cartoDBLayer3 = new CartoDBLayer({
@@ -28,6 +31,7 @@ describe('windshaft/named-map', function () {
       cartocss: 'cartoCSS3',
       cartocss_version: '2.0'
     }, {
+      vis: this.vis,
       analysisCollection: this.analysisCollection
     });
 

--- a/test/unit/analysis/analysis-factory.spec.js
+++ b/test/unit/analysis/analysis-factory.spec.js
@@ -19,11 +19,12 @@ describe('src/analysis/analysis-factory.js', function () {
         return map[analysisType];
       }
     };
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
     this.analysisCollection = new Backbone.Collection();
     this.analysisFactory = new AnalysisFactory({
       camshaftReference: this.fakeCamshaftReference,
       analysisCollection: this.analysisCollection,
-      map: jasmine.createSpyObj('map', ['reload'])
+      vis: this.vis
     });
   });
 
@@ -48,7 +49,7 @@ describe('src/analysis/analysis-factory.js', function () {
         authToken: 'THE_AUTH_TOKEN',
         camshaftReference: this.fakeCamshaftReference,
         analysisCollection: this.analysisCollection,
-        map: jasmine.createSpyObj('map', ['reload'])
+        vis: this.vis
       });
 
       var analysisModel = this.analysisFactory.analyse({

--- a/test/unit/analysis/analysis-model.spec.js
+++ b/test/unit/analysis/analysis-model.spec.js
@@ -4,7 +4,7 @@ var AnalysisFactory = require('../../../src/analysis/analysis-factory.js');
 
 describe('src/analysis/analysis-model.js', function () {
   beforeEach(function () {
-    this.map = jasmine.createSpyObj('map', ['reload']);
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
     var fakeCamshaftReference = {
       getSourceNamesForAnalysisType: function (analysisType) {
         var map = {
@@ -26,7 +26,7 @@ describe('src/analysis/analysis-model.js', function () {
       attribute1: 'value1',
       attribute2: 'value2'
     }, {
-      map: this.map,
+      vis: this.vis,
       camshaftReference: fakeCamshaftReference
     });
   });
@@ -59,21 +59,21 @@ describe('src/analysis/analysis-model.js', function () {
           attribute1: 'newValue1'
         });
 
-        expect(this.map.reload).toHaveBeenCalled();
-        this.map.reload.calls.reset();
+        expect(this.vis.reload).toHaveBeenCalled();
+        this.vis.reload.calls.reset();
 
         this.analysisModel.set({
           attribute2: 'newValue2'
         });
 
-        expect(this.map.reload).toHaveBeenCalled();
-        this.map.reload.calls.reset();
+        expect(this.vis.reload).toHaveBeenCalled();
+        this.vis.reload.calls.reset();
 
         this.analysisModel.set({
           attribute900: 'something'
         });
 
-        expect(this.map.reload).not.toHaveBeenCalled();
+        expect(this.vis.reload).not.toHaveBeenCalled();
       });
 
       it('should be marked as failed if request to reload the map fails', function () {
@@ -83,7 +83,7 @@ describe('src/analysis/analysis-model.js', function () {
         });
 
         // Request to the Maps API fails and error callback is invoked...
-        this.map.reload.calls.argsFor(0)[0].error('something bad just happened');
+        this.vis.reload.calls.argsFor(0)[0].error('something bad just happened');
 
         expect(this.analysisModel.get('status')).toEqual(AnalysisModel.STATUS.FAILED);
       });
@@ -100,22 +100,21 @@ describe('src/analysis/analysis-model.js', function () {
 
       it('should reload the map', function () {
         this.analysisModel.set('type', 'something');
-        expect(this.map.reload).toHaveBeenCalled();
+        expect(this.vis.reload).toHaveBeenCalled();
       });
 
       it('should keep listening type change again', function () {
         this.analysisModel.set('type', 'something');
-        expect(this.map.reload).toHaveBeenCalled();
-        this.map.reload.calls.reset();
+        expect(this.vis.reload).toHaveBeenCalled();
+        this.vis.reload.calls.reset();
         this.analysisModel.set('type', 'something else');
-        expect(this.map.reload).toHaveBeenCalled();
+        expect(this.vis.reload).toHaveBeenCalled();
       });
     });
   });
 
   describe('.findAnalysisById', function () {
     it('should find a node in the graph', function () {
-      var map = jasmine.createSpyObj('map', ['reload']);
       var fakeCamshaftReference = {
         getSourceNamesForAnalysisType: function (analysisType) {
           var map = {
@@ -139,7 +138,7 @@ describe('src/analysis/analysis-model.js', function () {
       };
 
       var analysisFactory = new AnalysisFactory({
-        map: map,
+        vis: this.vis,
         analysisCollection: new Backbone.Collection(),
         camshaftReference: fakeCamshaftReference
       });
@@ -180,7 +179,6 @@ describe('src/analysis/analysis-model.js', function () {
 
   describe('.toJSON', function () {
     it('should serialize the graph', function () {
-      var map = jasmine.createSpyObj('map', ['reload']);
       var fakeCamshaftReference = {
         getSourceNamesForAnalysisType: function (analysisType) {
           var map = {
@@ -204,7 +202,7 @@ describe('src/analysis/analysis-model.js', function () {
       };
 
       var analysisFactory = new AnalysisFactory({
-        map: map,
+        vis: this.vis,
         analysisCollection: new Backbone.Collection(),
         camshaftReference: fakeCamshaftReference
       });

--- a/test/unit/analysis/analysis-poller.spec.js
+++ b/test/unit/analysis/analysis-poller.spec.js
@@ -6,9 +6,9 @@ describe('src/analysis/analysis-poller', function () {
   beforeEach(function () {
     jasmine.clock().install();
 
-    this.map = jasmine.createSpyObj('map', ['something']);
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
     this.reference = jasmine.createSpyObj('reference', ['getParamNamesForAnalysisType']);
-    this.analysisModel1 = new AnalysisModel({ id: 'a1' }, { map: this.map, camshaftReference: this.reference });
+    this.analysisModel1 = new AnalysisModel({ id: 'a1' }, { vis: this.vis, camshaftReference: this.reference });
     this.analysisPoller = new AnalysisPoller();
   });
 

--- a/test/unit/dataviews/dataviews-collection.spec.js
+++ b/test/unit/dataviews/dataviews-collection.spec.js
@@ -9,11 +9,13 @@ describe('dataviews/dataview-collection', function () {
   it('should remove item when removed', function () {
     var map = jasmine.createSpyObj('map', ['getViewBounds', 'off']);
     map.getViewBounds.and.returnValue([[0, 0], [0, 0]]);
+    var vis = jasmine.createSpyObj('vis', ['reload']);
     var layer = new Backbone.Model();
     layer.getDataProvider = function () {};
     var dataviewModel = new DataviewModel({source: {id: 'a0'}}, {
-      analysisCollection: new Backbone.Collection(),
       map: map,
+      vis: vis,
+      analysisCollection: new Backbone.Collection(),
       layer: layer
     });
     this.collection.add(dataviewModel);

--- a/test/unit/dataviews/dataviews-factory.spec.js
+++ b/test/unit/dataviews/dataviews-factory.spec.js
@@ -14,9 +14,10 @@ describe('dataviews/dataviews-factory', function () {
     this.analysisCollection = new Backbone.Collection();
     this.dataviewsCollection = new Backbone.Collection();
     this.factory = new DataviewsFactory(null, {
+      map: {},
+      vis: {},
       analysisCollection: this.analysisCollection,
-      dataviewsCollection: this.dataviewsCollection,
-      map: {}
+      dataviewsCollection: this.dataviewsCollection
     });
     this.layer = new Backbone.Model();
     this.layer.getDataProvider = jasmine.createSpy('getDataProvider');
@@ -51,9 +52,10 @@ describe('dataviews/dataviews-factory', function () {
       this.factory = new DataviewsFactory({
         apiKey: 'THE_API_KEY'
       }, {
+        map: {},
+        vis: {},
         analysisCollection: this.analysisCollection,
-        dataviewsCollection: this.dataviewsCollection,
-        map: {}
+        dataviewsCollection: this.dataviewsCollection
       });
 
       var attributes = generateFakeAttributes(requiredAttributes);
@@ -66,9 +68,10 @@ describe('dataviews/dataviews-factory', function () {
       this.factory = new DataviewsFactory({
         apiKey: 'THE_API_KEY'
       }, {
+        map: {},
+        vis: {},
         analysisCollection: this.analysisCollection,
-        dataviewsCollection: this.dataviewsCollection,
-        map: {}
+        dataviewsCollection: this.dataviewsCollection
       });
 
       var attributes = generateFakeAttributes(requiredAttributes);

--- a/test/unit/dataviews/formula-dataview-model.spec.js
+++ b/test/unit/dataviews/formula-dataview-model.spec.js
@@ -5,6 +5,7 @@ describe('dataviews/formula-dataview-model', function () {
   beforeEach(function () {
     this.map = jasmine.createSpyObj('map', ['getViewBounds', 'bind', 'reload']);
     this.map.getViewBounds.and.returnValue([[1, 2], [3, 4]]);
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
 
     this.layer = new Backbone.Model();
     this.layer.getDataProvider = jasmine.createSpy('getDataProvider');
@@ -13,21 +14,22 @@ describe('dataviews/formula-dataview-model', function () {
       source: {id: 'a0'},
       operation: 'min'
     }, {
-      analysisCollection: new Backbone.Collection(),
       map: this.map,
+      vis: this.vis,
+      analysisCollection: new Backbone.Collection(),
       layer: this.layer
     });
   });
 
   it('should reload map and force fetch on operation change', function () {
-    this.map.reload.calls.reset();
+    this.vis.reload.calls.reset();
     this.model.set('operation', 'avg');
-    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: 'a0' });
+    expect(this.vis.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: 'a0' });
   });
 
   it('should reload map and force fetch on column change', function () {
-    this.map.reload.calls.reset();
+    this.vis.reload.calls.reset();
     this.model.set('column', 'other_col');
-    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: 'a0' });
+    expect(this.vis.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: 'a0' });
   });
 });

--- a/test/unit/dataviews/list-dataview-model.spec.js
+++ b/test/unit/dataviews/list-dataview-model.spec.js
@@ -5,6 +5,7 @@ describe('dataviews/list-dataview-model', function () {
   beforeEach(function () {
     this.map = jasmine.createSpyObj('map', ['getViewBounds', 'bind', 'reload']);
     this.map.getViewBounds.and.returnValue([[1, 2], [3, 4]]);
+    this.vis = jasmine.createSpyObj('vis', ['reload']);
 
     this.layer = new Backbone.Model();
     this.layer.getDataProvider = jasmine.createSpy('getDataProvider');
@@ -12,15 +13,16 @@ describe('dataviews/list-dataview-model', function () {
     this.model = new ListDataviewModel({
       source: {id: 'a0'}
     }, {
-      analysisCollection: new Backbone.Collection(),
       map: this.map,
+      vis: this.vis,
+      analysisCollection: new Backbone.Collection(),
       layer: this.layer
     });
   });
 
   it('should reload map and force fetch on columns change', function () {
-    this.map.reload.calls.reset();
+    this.vis.reload.calls.reset();
     this.model.set('columns', ['asd']);
-    expect(this.map.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: 'a0' });
+    expect(this.vis.reload).toHaveBeenCalledWith({ forceFetch: true, sourceId: 'a0' });
   });
 });


### PR DESCRIPTION
To remove some indirection and (hopefully) troubleshoot failed map instantiations easier.

We had this relationships before:

```
  Layers (CartoDBLayer and TorqueLayer) -> Map#reload
  Analysis -> Map#reload
  Dataviews -> Map#reload
  Map#reload -> Vis#reload
```

This PR removes Map#reload and makes objects reload the vis directly:

```
  Layers (CartoDBLayer and TorqueLayer) -> Vis#reload
  Analysis -> Vis#reload
  Dataviews -> Vis#reload
  Map -> Vis#reload
```

As a follow up, I think it'd make sense to centralice all calls to `vis.reload` in a single class, so that it's easier to control when the map gets instantiated... 

@viddo what do you think? Thx!



@viddo what do you think?
