### PR TITLE
Check for error_message when update analysis node.

### DIFF
--- a/src/vis/model-updater.js
+++ b/src/vis/model-updater.js
@@ -74,15 +74,27 @@ ModelUpdater.prototype._updateDataviewModels = function (windshaftMap, sourceId,
 ModelUpdater.prototype._updateAnalysisModels = function (windshaftMap) {
   this._analysisCollection.each(function (analysisNode) {
     var analysisMetadata = windshaftMap.getAnalysisNodeMetadata(analysisNode.get('id'));
+    var attrs;
     if (analysisMetadata) {
-      var attrs = {
+      attrs = {
         status: analysisMetadata.status,
         url: analysisMetadata.url[this._getProtocol()],
         query: analysisMetadata.query
       };
+
       attrs = _.omit(attrs, analysisNode.getParamNames());
-      analysisNode.set(attrs);
-      analysisNode.setOk();
+
+      if (analysisMetadata.error_message) {
+        attrs = _.extend(attrs, {
+          error: {
+            message: analysisMetadata.error_message
+          }
+        });
+        analysisNode.set(attrs);
+      } else {
+        analysisNode.set(attrs);
+        analysisNode.setOk();
+      }
     }
   }, this);
 };

--- a/test/unit/vis/model-updater.spec.js
+++ b/test/unit/vis/model-updater.spec.js
@@ -158,6 +158,31 @@ describe('src/vis/model-updater', function () {
       expect(analysis2.setOk).toHaveBeenCalled();
     });
 
+    it('should update analysis models and "mark" them as failed', function () {
+      var getParamNames = function () { return []; };
+      var analysis1 = new Backbone.Model({ id: 'a1' });
+      this.analysisCollection.reset([ analysis1 ]);
+      analysis1.getParamNames = getParamNames;
+
+      this.windshaftMap.getAnalysisNodeMetadata = function (analysisId) {
+        if (analysisId === 'a1') {
+          return {
+            error_message: 'wadus',
+            status: 'failed',
+            query: 'query_a1',
+            url: {
+              http: 'url_a1'
+            }
+          };
+        }
+      };
+
+      this.modelUpdater.updateModels(this.windshaftMap);
+
+      expect(analysis1.get('status')).toEqual('failed');
+      expect(analysis1.get('error')).toEqual({message: 'wadus'});
+    });
+
     it('should not update attributes that are original params (eg: query)', function () {
       var analysis1 = new Backbone.Model({ id: 'a1', query: 'original_query' });
       analysis1.getParamNames = function () { return ['query']; };


### PR DESCRIPTION
This PR fixes https://github.com/CartoDB/cartodb/issues/9415

When an analysis fails, the error message come wrapped inside the maps api request as `error_message` parameter:

![screen shot 2016-08-12 at 10 38 41](https://cloud.githubusercontent.com/assets/1366843/17617230/41c2d406-6079-11e6-88dc-58656299a9f3.png)

When the model is updated, we look for this parameter to set error properly. Otherwise the error message will be empty. 

I know there were some intents of solving notifications from the maps api in the past, and I guess some of the solutions implemented aren't valid now. Not sure if this change of behaviour obey to a change in Whidshaft but this is the easy way to fix this today.

![analysis-notification-error](https://cloud.githubusercontent.com/assets/1366843/17617343/e4c892bc-6079-11e6-89cb-f63960b5b362.gif)

cc @xavijam @alonsogarciapablo 

