### PR TITLE
Look for options only if not null.

### DIFF
--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -326,7 +326,14 @@ var Vis = cdb.core.View.extend({
     this._applyOptions(data, options);
 
     // to know if the logo is enabled search in the overlays and see if logo overlay is included and is shown
-    var has_logo_overlay = !!_.find(data.overlays, function(o) { return o.type === 'logo' && o.options.display; });
+    var has_logo_overlay = !!_.find(data.overlays, function(o) {
+      // display option is not implemented for builder, if type logo is present just it
+      if (o.options == null) {
+        return (o.type === 'logo');
+      }
+
+      return o.type === 'logo' && o.options.display;
+    });
 
     this.cartodb_logo = (options.cartodb_logo !== undefined) ? options.cartodb_logo: has_logo_overlay;
 


### PR DESCRIPTION
This PR adds logo option backward compatibility: https://github.com/CartoDB/cartodb/issues/8674

cc @xavijam 