### PR TITLE
Update search overlay position when zoom is visible or hidden.

### DIFF
--- a/src/geo/ui/search/search.js
+++ b/src/geo/ui/search/search.js
@@ -224,6 +224,10 @@ var Search = View.extend({
     this._unbindEvents();
     this._destroySearchPin();
     View.prototype.clean.call(this);
+  },
+
+  updatePosition: function (hasZoom) {
+    this.$el.toggleClass('has-zoom', hasZoom);
   }
 
 });

--- a/src/vis/vis-view.js
+++ b/src/vis/vis-view.js
@@ -254,6 +254,10 @@ var Vis = View.extend({
         overlay.show();
       }
 
+      if (type === 'search') {
+        overlay.updatePosition(this._hasZoomOverlay());
+      }
+
       if (type === 'header') {
         var m = overlay.model;
 
@@ -273,6 +277,11 @@ var Vis = View.extend({
         overlay.render();
       }
     }, this);
+  },
+
+  _hasZoomOverlay: function () {
+    var overlays = this.model.overlaysCollection.pluck('type');
+    return overlays.indexOf('zoom') > -1;
   },
 
   _setupSublayers: function (layers, options) {

--- a/themes/scss/map/overlays.scss
+++ b/themes/scss/map/overlays.scss
@@ -100,7 +100,11 @@ $buttonColor: #636D72;
 .CDB-Search {
   position: absolute;
   bottom: 16px;
-  left: 84px;
+  left: 16px;
+
+  &.has-zoom {
+    left: 84px;
+  }
 }
 .CDB-Search-inner {
   @include transition(width, 100ms ease-in);


### PR DESCRIPTION
This PR updates the logic for search overlay positioning when the zoom overlay is present/hidden.
It's related to https://github.com/CartoDB/cartodb/issues/9410

cc @xavijam 