### PR TITLE
Add/append api_key and auth_token in torque layers

### DIFF
--- a/src/geo/map-view.js
+++ b/src/geo/map-view.js
@@ -157,6 +157,10 @@ var MapView = View.extend({
   },
 
   _addIndividualLayer: function (layerModel) {
+    layerModel.attributes.extra_params = layerModel.attributes.extra_params || {};
+    layerModel.attributes.extra_params.map_key = this._cartoDBLayerGroup.get('apiKey');
+    layerModel.attributes.extra_params.auth_token = this._cartoDBLayerGroup.get('authToken');
+
     var layerView = this._createLayerView(layerModel);
     if (layerView) {
       this._layerViews[layerModel.cid] = layerView;

--- a/src/geo/torque-layer-view-base.js
+++ b/src/geo/torque-layer-view-base.js
@@ -30,7 +30,7 @@ module.exports = {
       attribution: layerModel.get('attribution'),
       cartocss: layerModel.get('cartocss') || layerModel.get('tile_style'),
       named_map: layerModel.get('named_map'),
-      auth_token: layerModel.get('auth_token'),
+      auth_token: layerModel.get('auth_token') || extra.auth_token,
       no_cdn: layerModel.get('no_cdn'),
       loop: !(layerModel.get('loop') === false)
     };


### PR DESCRIPTION
This is a temporary workaround, it reuses api_key and auth_token
from existing _cartoDBLayerGroup model.

cc @alonsogarciapablo 