### PR TITLE
Try to create/instantiate maps using JSONP before using POST

### DIFF
--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -113,8 +113,7 @@ var VisModel = Backbone.Model.extend({
     var windshaftClient = new WindshaftClient({
       endpoint: endpoint,
       urlTemplate: datasource.maps_api_template,
-      userName: datasource.user_name,
-      forceCors: datasource.force_cors || true
+      userName: datasource.user_name
     });
 
     var modelUpdater = new ModelUpdater({

--- a/src/windshaft/client.js
+++ b/src/windshaft/client.js
@@ -12,6 +12,9 @@ var validatePresenceOfOptions = function (options, requiredOptions) {
   }
 };
 
+var MAX_URL_LENGTH = 2033;
+var COMPRESSION_LEVEL = 3;
+
 /**
  * Windshaft client. It provides a method to create instances of maps in Windshaft.
  * @param {object} options Options to set up the client
@@ -26,9 +29,6 @@ var WindshaftClient = function (options) {
 
   this.url = this.urlTemplate.replace('{user}', this.userName);
 };
-
-WindshaftClient.prototype.MAX_URL_LENGTH = 2033;
-WindshaftClient.prototype.COMPRESSION_LEVEL = 3;
 
 WindshaftClient.prototype.instantiateMap = function (options) {
   if (!options.mapDefinition) {
@@ -61,11 +61,11 @@ WindshaftClient.prototype.instantiateMap = function (options) {
   };
 
   var encodedURL = this._generateEncodedURL(mapDefinition, params);
-  if (!this._isURLTooLong(encodedURL)) {
+  if (this._isURLValid(encodedURL)) {
     this._get(encodedURL, ajaxOptions);
   } else {
     this._generateCompressedURL(mapDefinition, params, function (compressedURL) {
-      if (!this._isURLTooLong(compressedURL)) {
+      if (this._isURLValid(compressedURL)) {
         this._get(compressedURL, ajaxOptions);
       } else {
         var url = this._getURL(params);
@@ -88,7 +88,7 @@ WindshaftClient.prototype._generateCompressedURL = function (payload, params, ca
     config: JSON.stringify(payload)
   });
 
-  LZMA.compress(data, this.COMPRESSION_LEVEL, function (compressedPayload) {
+  LZMA.compress(data, COMPRESSION_LEVEL, function (compressedPayload) {
     params = _.extend({
       lzma: util.array2hex(compressedPayload)
     }, params);
@@ -97,8 +97,8 @@ WindshaftClient.prototype._generateCompressedURL = function (payload, params, ca
   }.bind(this));
 };
 
-WindshaftClient.prototype._isURLTooLong = function (url) {
-  return url.length >= this.MAX_URL_LENGTH;
+WindshaftClient.prototype._isURLValid = function (url) {
+  return url.length < MAX_URL_LENGTH;
 };
 
 WindshaftClient.prototype._post = function (url, payload, options) {

--- a/src/windshaft/client.js
+++ b/src/windshaft/client.js
@@ -77,14 +77,18 @@ WindshaftClient.prototype.instantiateMap = function (options) {
 
 WindshaftClient.prototype._generateEncodedURL = function (payload, params) {
   params = _.extend({
-    config: payload
+    config: JSON.stringify(payload)
   }, params);
 
   return this._getURL(params);
 };
 
 WindshaftClient.prototype._generateCompressedURL = function (payload, params, callback) {
-  LZMA.compress(payload, this.COMPRESSION_LEVEL, function (compressedPayload) {
+  var data = JSON.stringify({
+    config: JSON.stringify(payload)
+  });
+
+  LZMA.compress(data, this.COMPRESSION_LEVEL, function (compressedPayload) {
     params = _.extend({
       lzma: util.array2hex(compressedPayload)
     }, params);

--- a/test/spec/api/create-vis.spec.js
+++ b/test/spec/api/create-vis.spec.js
@@ -281,7 +281,7 @@ describe('src/api/create-vis', function () {
 
   var mapInstantiationRequestDone = function () {
     return _.any($.ajax.calls.allArgs(), function (args) {
-      var expectedURLRegexp = /(http|https):\/\/cdb.localhost.lan:8181\/api\/v1\/map\/named\/tpl_6a31d394_7c8e_11e5_8e42_080027880ca6\?stat_tag=6a31d394-7c8e-11e5-8e42-080027880ca6/;
+      var expectedURLRegexp = /(http|https):\/\/cdb.localhost.lan:8181\/api\/v1\/map\/named\/tpl_6a31d394_7c8e_11e5_8e42_080027880ca6\?/;
       return args[0].url.match(expectedURLRegexp);
     });
   };

--- a/test/spec/vis/vis-view.spec.js
+++ b/test/spec/vis/vis-view.spec.js
@@ -34,8 +34,7 @@ describe('vis/vis-view', function () {
       datasource: {
         user_name: 'wadus',
         maps_api_template: 'https://{user}.example.com:443',
-        stat_tag: 'ece6faac-7271-11e5-a85f-04013fc66a01',
-        force_cors: true // This is sometimes set in the editor
+        stat_tag: 'ece6faac-7271-11e5-a85f-04013fc66a01'
       }
     };
 

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -918,7 +918,7 @@ describe('vis/vis', function () {
           },
           'last_updated': '1970-01-01T00:00:00.000Z'
         });
-        expect($.ajax.calls.argsFor(0)[0].url).toEqual('http://cdb.localhost.lan:8181/api/v1/map?stat_tag=70af2a72-0709-11e6-a834-080027880ca6');
+        expect($.ajax.calls.argsFor(0)[0].url).toMatch(/api\/v1\/map\?config/);
         expect($.ajax.calls.argsFor(1)[0].url).toEqual('http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/e65b1ae05854aea96266808ec0686b91f3ee0a81');
         expect($.ajax.calls.argsFor(2)[0].url).toEqual('http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/b75b1ae05854aea96266808ec0686b91f3ee0a81');
 
@@ -935,7 +935,7 @@ describe('vis/vis', function () {
 
         // Map has been reloaded because a2 is the source of a layer
         expect($.ajax.calls.count()).toEqual(4);
-        expect($.ajax.calls.argsFor(3)[0].url).toEqual('http://cdb.localhost.lan:8181/api/v1/map?stat_tag=70af2a72-0709-11e6-a834-080027880ca6');
+        expect($.ajax.calls.argsFor(3)[0].url).toMatch(/api\/v1\/map\?config/);
       });
     });
   });

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -354,8 +354,7 @@ describe('vis/vis', function () {
           datasource: {
             user_name: 'wadus',
             maps_api_template: 'https://{user}.example.com:443',
-            stat_tag: 'ece6faac-7271-11e5-a85f-04013fc66a01',
-            force_cors: true // This is sometimes set in the editor
+            stat_tag: 'ece6faac-7271-11e5-a85f-04013fc66a01'
           }
         };
       });
@@ -481,8 +480,7 @@ describe('vis/vis', function () {
         datasource: {
           user_name: 'wadus',
           maps_api_template: 'https://{user}.example.com:443',
-          stat_tag: 'ece6faac-7271-11e5-a85f-04013fc66a01',
-          force_cors: true // This is sometimes set in the editor
+          stat_tag: 'ece6faac-7271-11e5-a85f-04013fc66a01'
         },
         analyses: [
           {


### PR DESCRIPTION
Fixes #1396 and fixes CartoDB/cartodb#9523.

We're always (and mistakenly) enforcing creation/instantiation of maps using POST. This PR implements the following algorithm to determine when to use GET (JSONP) vs POST requests:

- Length of URL with encoded params + `config` param < 2033 -> `GET /api/v1/map?config=…&stat_tag=...`
- Length of URL with encoded params + `lzma` param < 2033 -> `GET /api/v1/map?lzma=…&stat_tag=...`
- Length of URL with encoded params + `lzma` param >= 2033 -> `POST /api/v1/map?stat_tag=…`

@rochoa would you mind taking a look?

