### PR TITLE
Use /jsonp endpoint to instantiate named maps via GET

### DIFF
--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -89,17 +89,23 @@ var VisModel = Backbone.Model.extend({
 
   load: function (vizjson) {
     // Create the WindhaftClient
-    var endpoint;
+    var endpoints;
     var WindshaftMapClass;
 
     var datasource = vizjson.datasource;
     var isNamedMap = !!datasource.template_name;
 
     if (isNamedMap) {
-      endpoint = [ WindshaftConfig.MAPS_API_BASE_URL, 'named', datasource.template_name ].join('/');
+      endpoints = {
+        get: [ WindshaftConfig.MAPS_API_BASE_URL, 'named', datasource.template_name, 'jsonp' ].join('/'),
+        post: [ WindshaftConfig.MAPS_API_BASE_URL, 'named', datasource.template_name ].join('/')
+      };
       WindshaftMapClass = WindshaftNamedMap;
     } else {
-      endpoint = WindshaftConfig.MAPS_API_BASE_URL;
+      endpoints = {
+        get: WindshaftConfig.MAPS_API_BASE_URL,
+        post: WindshaftConfig.MAPS_API_BASE_URL
+      };
       WindshaftMapClass = WindshaftAnonymousMap;
     }
 
@@ -111,7 +117,7 @@ var VisModel = Backbone.Model.extend({
     });
 
     var windshaftClient = new WindshaftClient({
-      endpoint: endpoint,
+      endpoints: endpoints,
       urlTemplate: datasource.maps_api_template,
       userName: datasource.user_name
     });

--- a/src/windshaft/client.js
+++ b/src/windshaft/client.js
@@ -20,11 +20,11 @@ var COMPRESSION_LEVEL = 3;
  * @param {object} options Options to set up the client
  */
 var WindshaftClient = function (options) {
-  validatePresenceOfOptions(options, ['urlTemplate', 'userName', 'endpoint']);
+  validatePresenceOfOptions(options, ['urlTemplate', 'userName', 'endpoints']);
 
   this.urlTemplate = options.urlTemplate;
   this.userName = options.userName;
-  this.endpoint = options.endpoint;
+  this.endpoints = options.endpoints;
   this.statTag = options.statTag;
 
   this.url = this.urlTemplate.replace('{user}', this.userName);
@@ -68,7 +68,7 @@ WindshaftClient.prototype.instantiateMap = function (options) {
       if (this._isURLValid(compressedURL)) {
         this._get(compressedURL, ajaxOptions);
       } else {
-        var url = this._getURL(params);
+        var url = this._getURL(params, 'post');
         this._post(url, mapDefinition, ajaxOptions);
       }
     }.bind(this));
@@ -134,7 +134,14 @@ WindshaftClient.prototype._abortPreviousRequest = function () {
   }
 };
 
-WindshaftClient.prototype._getURL = function (params) {
+WindshaftClient.prototype._getURL = function (params, method) {
+  method = method || 'get';
+  var queryString = this._convertParamsToQueryString(params);
+  var endpoint = this.endpoints[method];
+  return [this.url, endpoint].join('/') + queryString;
+};
+
+WindshaftClient.prototype._convertParamsToQueryString = function (params) {
   var queryString = [];
   _.each(params, function (value, name) {
     if (value instanceof Array) {
@@ -147,8 +154,7 @@ WindshaftClient.prototype._getURL = function (params) {
       queryString.push(name + '=' + encodeURIComponent(value));
     }
   });
-
-  return [this.url, this.endpoint].join('/') + (queryString ? '?' + queryString.join('&') : '');
+  return queryString.length > 0 ? '?' + queryString.join('&') : '';
 };
 
 WindshaftClient.prototype._jsonpCallbackName = function (payload) {

--- a/test/spec/api/create-vis.spec.js
+++ b/test/spec/api/create-vis.spec.js
@@ -281,7 +281,7 @@ describe('src/api/create-vis', function () {
 
   var mapInstantiationRequestDone = function () {
     return _.any($.ajax.calls.allArgs(), function (args) {
-      var expectedURLRegexp = /(http|https):\/\/cdb.localhost.lan:8181\/api\/v1\/map\/named\/tpl_6a31d394_7c8e_11e5_8e42_080027880ca6\?/;
+      var expectedURLRegexp = /(http|https):\/\/cdb.localhost.lan:8181\/api\/v1\/map\/named\/tpl_6a31d394_7c8e_11e5_8e42_080027880ca6\/jsonp\?/;
       return args[0].url.match(expectedURLRegexp);
     });
   };
@@ -291,7 +291,7 @@ describe('src/api/create-vis', function () {
       spyOn($, 'ajax');
     });
 
-    it('should instantiate map', function (done) {
+    it('should instantiate map using a GET request', function (done) {
       this.vis = createVis(this.containerId, fakeVizJSON, {});
 
       setTimeout(function () {

--- a/test/spec/windshaft/anonymous-map.spec.js
+++ b/test/spec/windshaft/anonymous-map.spec.js
@@ -65,8 +65,11 @@ describe('windshaft/anonymous-map', function () {
     });
 
     this.client = new WindshaftClient({
-      endpoint: 'v1',
-      urlTemplate: 'http://{user}.wadus.com',
+      endpoints: {
+        get: 'v1',
+        post: 'v1'
+      },
+      urlTemplate: 'http://{user}.example.com',
       userName: 'rambo'
     });
 

--- a/test/spec/windshaft/client.spec.js
+++ b/test/spec/windshaft/client.spec.js
@@ -7,8 +7,8 @@ var LZMA = require('lzma');
 describe('windshaft/client', function () {
   it('should throw an error if required options are not passed to the constructor', function () {
     expect(function () {
-      new WindshaftClient({}, ['urlTemplate', 'userName', 'endpoint']); // eslint-disable-line
-    }).toThrowError('WindshaftClient could not be initialized. The following options are missing: urlTemplate, userName, endpoint');
+      new WindshaftClient({}); // eslint-disable-line
+    }).toThrowError('WindshaftClient could not be initialized. The following options are missing: urlTemplate, userName, endpoints');
   });
 
   describe('#instantiateMap', function () {
@@ -24,7 +24,10 @@ describe('windshaft/client', function () {
       this.client = new WindshaftClient({
         urlTemplate: 'https://{user}.example.com:443',
         userName: 'rambo',
-        endpoint: 'api/v1'
+        endpoints: {
+          get: 'api/v1',
+          post: 'api/v1'
+        }
       });
     });
 
@@ -136,13 +139,16 @@ describe('windshaft/client', function () {
         this.client = new WindshaftClient({
           urlTemplate: 'https://{user}.carto.com:443',
           userName: 'rambo',
-          endpoint: 'api/v1'
+          endpoints: {
+            get: 'api/v1/get-endpoint',
+            post: 'api/v1/post-endpoint'
+          }
         });
       });
 
       it('should use GET to URL with encoded config', function (done) {
         this.client.instantiateMap({
-          mapDefinition: { something: new Array(1946).join('x') },
+          mapDefinition: { something: new Array(1933).join('x') },
           params: {
             a: 'a sentence'
           }
@@ -153,7 +159,7 @@ describe('windshaft/client', function () {
           var params = this.ajaxParams.url.split('?')[1].split('&');
 
           expect(this.ajaxParams.url.length).toBeLessThan(2033);
-          expect(url).toEqual('https://rambo.carto.com:443/api/v1');
+          expect(url).toEqual('https://rambo.carto.com:443/api/v1/get-endpoint');
           expect(this.ajaxParams.method).toEqual('GET');
           expect(params[0]).toMatch('^config=');
           expect(params[0]).not.toMatch('^lzma=');
@@ -165,7 +171,7 @@ describe('windshaft/client', function () {
 
       it('should use GET to URL with compressed config', function (done) {
         this.client.instantiateMap({
-          mapDefinition: { something: new Array(1947).join('x') },
+          mapDefinition: { something: new Array(1934).join('x') },
           params: {
             a: 'a sentence'
           }
@@ -176,7 +182,7 @@ describe('windshaft/client', function () {
           var params = this.ajaxParams.url.split('?')[1].split('&');
 
           expect(this.ajaxParams.url.length).toBeLessThan(2033);
-          expect(url).toEqual('https://rambo.carto.com:443/api/v1');
+          expect(url).toEqual('https://rambo.carto.com:443/api/v1/get-endpoint');
           expect(this.ajaxParams.method).toEqual('GET');
           expect(params[0]).toMatch('^lzma=');
           expect(params[0]).not.toMatch('^config=');
@@ -203,7 +209,7 @@ describe('windshaft/client', function () {
           var url = this.ajaxParams.url.split('?')[0];
           var params = this.ajaxParams.url.split('?')[1].split('&');
 
-          expect(url).toEqual('https://rambo.carto.com:443/api/v1');
+          expect(url).toEqual('https://rambo.carto.com:443/api/v1/post-endpoint');
           expect(this.ajaxParams.crossOrigin).toEqual(true);
           expect(this.ajaxParams.method).toEqual('POST');
           expect(this.ajaxParams.dataType).toEqual('json');

--- a/test/spec/windshaft/map-base.spec.js
+++ b/test/spec/windshaft/map-base.spec.js
@@ -49,8 +49,11 @@ describe('windshaft/map-base', function () {
     this.analysisCollection = new Backbone.Collection();
     this.modelUpdater = jasmine.createSpyObj('modelUpdater', ['updateModels', 'setErrors']);
     this.client = new WindshaftClient({
-      endpoint: 'v1',
-      urlTemplate: 'http://{user}.wadus.com',
+      endpoints: {
+        get: 'v1',
+        post: 'v1'
+      },
+      urlTemplate: 'http://{user}.example.com',
       userName: 'rambo'
     });
 
@@ -520,21 +523,16 @@ describe('windshaft/map-base', function () {
 
   describe('#getBaseURL', function () {
     it("should return Windshaft's url if no CDN info is present", function () {
-      var windshaftClient = new WindshaftClient({
-        urlTemplate: 'https://{user}.example.com:443',
-        userName: 'rambo',
-        endpoint: 'v2'
-      });
       var windshaftMap = new WindshaftMap({
         layergroupid: '0123456789'
       }, {
-        client: windshaftClient,
+        client: this.client,
         modelUpdater: this.modelUpdater,
         dataviewsCollection: this.dataviewsCollection,
         layersCollection: this.layersCollection,
         analysisCollection: this.analysisCollection
       });
-      expect(windshaftMap.getBaseURL()).toEqual('https://rambo.example.com:443/api/v1/map/0123456789');
+      expect(windshaftMap.getBaseURL()).toEqual('http://rambo.example.com/api/v1/map/0123456789');
     });
 
     it('should return the CDN URL for http when CDN info is present', function () {
@@ -545,11 +543,7 @@ describe('windshaft/map-base', function () {
           https: 'cdn.https.example.com'
         }
       }, {
-        client: new WindshaftClient({
-          urlTemplate: 'http://{user}.example.com:443',
-          userName: 'rambo',
-          endpoint: 'v2'
-        }),
+        client: this.client,
         modelUpdater: this.modelUpdater,
         dataviewsCollection: this.dataviewsCollection,
         layersCollection: this.layersCollection,
@@ -560,6 +554,15 @@ describe('windshaft/map-base', function () {
     });
 
     it('should return the CDN URL for https when CDN info is present', function () {
+      this.client = new WindshaftClient({
+        endpoints: {
+          get: 'v1',
+          post: 'v1'
+        },
+        urlTemplate: 'https://{user}.example.com',
+        userName: 'rambo'
+      });
+
       var windshaftMap = new WindshaftMap({
         layergroupid: '0123456789',
         cdn_url: {
@@ -567,11 +570,7 @@ describe('windshaft/map-base', function () {
           https: 'cdn.https.example.com'
         }
       }, {
-        client: new WindshaftClient({
-          urlTemplate: 'https://{user}.example.com:443',
-          userName: 'rambo',
-          endpoint: 'v2'
-        }),
+        client: this.client,
         modelUpdater: this.modelUpdater,
         dataviewsCollection: this.dataviewsCollection,
         layersCollection: this.layersCollection,
@@ -599,11 +598,7 @@ describe('windshaft/map-base', function () {
           ]
         }
       }, {
-        client: new WindshaftClient({
-          urlTemplate: 'http://{user}.example.com:443',
-          userName: 'rambo',
-          endpoint: 'v2'
-        }),
+        client: this.client,
         modelUpdater: this.modelUpdater,
         dataviewsCollection: this.dataviewsCollection,
         layersCollection: this.layersCollection,
@@ -636,11 +631,7 @@ describe('windshaft/map-base', function () {
           ]
         }
       }, {
-        client: new WindshaftClient({
-          urlTemplate: 'https://{user}.example.com:443',
-          userName: 'rambo',
-          endpoint: 'v2'
-        }),
+        client: this.client,
         modelUpdater: this.modelUpdater,
         dataviewsCollection: this.dataviewsCollection,
         layersCollection: this.layersCollection,
@@ -681,11 +672,7 @@ describe('windshaft/map-base', function () {
           }
         }
       }, {
-        client: new WindshaftClient({
-          urlTemplate: 'https://{user}.example.com:443',
-          userName: 'rambo',
-          endpoint: 'v2'
-        }),
+        client: this.client,
         modelUpdater: this.modelUpdater,
         dataviewsCollection: this.dataviewsCollection,
         layersCollection: this.layersCollection,
@@ -773,11 +760,7 @@ describe('windshaft/map-base', function () {
         },
         'last_updated': '2016-04-15T20:14:14.653Z'
       }, {
-        client: new WindshaftClient({
-          urlTemplate: 'https://{user}.example.com:443',
-          userName: 'rambo',
-          endpoint: 'v2'
-        }),
+        client: this.client,
         modelUpdater: this.modelUpdater,
         dataviewsCollection: this.dataviewsCollection,
         layersCollection: this.layersCollection,

--- a/test/spec/windshaft/named-map.spec.js
+++ b/test/spec/windshaft/named-map.spec.js
@@ -36,7 +36,10 @@ describe('windshaft/named-map', function () {
     });
 
     this.client = new WindshaftClient({
-      endpoint: 'v1',
+      endpoints: {
+        get: 'v1',
+        post: 'v1'
+      },
       urlTemplate: 'http://{user}.wadus.com',
       userName: 'rambo'
     });


### PR DESCRIPTION
In #1398 we removed the code that was enforcing usage of POST requests when creating/instantiating maps. That change revealed something that was wrong: we're hitting the wrong endpoint when instantiating named maps via GET/JSONP.

We're using the following URLs (wrong):

```
.../api/v1/map/named/tpl_13cc78fc_7435_11e6_857e_04013fc66a01?config=...
```
When we should be using the /jsonp endpoint:

```
.../api/v1/map/named/tpl_f9e77bf4_7438_11e6_ac8d_080027a55d4d/jsonp?config...
```

This PR fixes that.

@rochoa would you please take a look? Thanks!

fixes #1402.