### PR TITLE
Check if changed CartoCSS is using turbo carto in order to instantiate map

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -51,7 +51,6 @@
 **/src/geo/leaflet/leaflet-wms-layer-view.js
 **/src/geo/map/gmaps-base-layer.js
 **/src/geo/map/tile-layer.js
-**/src/geo/map/torque-layer.js
 **/src/geo/map/wms-layer.js
 **/src/geo/map.js
 **/src/geo/ui/annotation.js

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "leaflet": "0.7.3",
     "mustache": "1.1.0",
     "perfect-scrollbar": "0.6.7",
-    "torque.js": "^2.15",
+    "torque.js": "CartoDB/torque#master",
     "underscore": "1.8.3",
-    "carto": "https://github.com/CartoDB/carto/archive/master.tar.gz"
+    "carto": "cartodb/carto#master"
   },
   "devDependencies": {
     "browserify": "13.0.0",

--- a/src/geo/map/torque-layer.js
+++ b/src/geo/map/torque-layer.js
@@ -2,6 +2,7 @@ var _ = require('underscore');
 var LayerModelBase = require('./layer-model-base');
 var carto = require('carto');
 var ATTRIBUTES_THAT_TRIGGER_VIS_RELOAD = ['sql', 'sql_wrap', 'source', 'cartocss'];
+var PROPERTIES_THAT_CAN_USE_TURBO_CARTO = ['marker-fill', 'marker-line-color'];
 var TORQUE_LAYER_CARTOCSS_PROPS = [
   '-torque-frame-count',
   '-torque-time-attribute',
@@ -42,9 +43,7 @@ var TorqueLayer = LayerModelBase.extend({
     var reloadVis = _.any(ATTRIBUTES_THAT_TRIGGER_VIS_RELOAD, function (attr) {
       if (this.hasChanged(attr)) {
         if (attr === 'cartocss') {
-          var hasTorquePropsChanged = this._torqueCartoCSSPropsChanged();
-          var usesTurboCarto = this._hasTurboCarto();
-          return this.previous('cartocss') && (hasTorquePropsChanged || usesTurboCarto);
+          return this.previous('cartocss') && (this._torqueCartoCSSPropsChanged() || this._hasTurboCarto());
         }
         return true;
       }
@@ -58,18 +57,26 @@ var TorqueLayer = LayerModelBase.extend({
   _hasTurboCarto: function () {
     var currentCartoCSS = this.get('cartocss');
     var shader = new carto.RendererJS().render(currentCartoCSS);
-    var layer = shader.findLayer({ name: '#layer' });
+    var layers = shader.getLayers();
 
-    if (layer) {
-      var layerShader = layer.getStyle({ property: 1 }, { zoom: 10 });
+    var isAnyLayerUsingTurboCarto = _.any(layers, function (layer) {
+      if (layer) {
+        var layerShader = layer.getStyle({ property: 1 }, { zoom: 10 });
 
-      var markerFill = layerShader['marker-fill'];
-      if (markerFill && markerFill.name === 'ramp') {
-        return true;
+        var isAnyPropertyUsingCarto = _.any(PROPERTIES_THAT_CAN_USE_TURBO_CARTO, function (property) {
+          var value = layerShader[property];
+          if (value && value.name === 'ramp') {
+            return true;
+          }
+        });
+
+        return isAnyPropertyUsingCarto;
       }
-    }
 
-    return false;
+      return false;
+    });
+
+    return isAnyLayerUsingTurboCarto;
   },
 
   _torqueCartoCSSPropsChanged: function () {

--- a/src/geo/map/torque-layer.js
+++ b/src/geo/map/torque-layer.js
@@ -44,7 +44,7 @@ var TorqueLayer = LayerModelBase.extend({
         if (attr === 'cartocss') {
           var hasTorquePropsChanged = this._torqueCartoCSSPropsChanged();
           var usesTurboCarto = this._hasTurboCarto();
-          return this.previous('cartocss') && (hasTorquePropsChanged || usesTurboCarto);
+          return this.previous('cartocss') && (hasTorquePropsChanged || usesTurboCarto);
         }
         return true;
       }
@@ -59,11 +59,14 @@ var TorqueLayer = LayerModelBase.extend({
     var currentCartoCSS = this.get('cartocss');
     var shader = new carto.RendererJS().render(currentCartoCSS);
     var layer = shader.findLayer({ name: '#layer' });
-    var layerShader = layer.getStyle({ property: 1 }, { zoom: 10 });
 
-    var markerFill = layerShader['marker-fill'];
-    if (markerFill && markerFill.name === 'ramp') {
-      return true;
+    if (layer) {
+      var layerShader = layer.getStyle({ property: 1 }, { zoom: 10 });
+
+      var markerFill = layerShader['marker-fill'];
+      if (markerFill && markerFill.name === 'ramp') {
+        return true;
+      }
     }
 
     return false;
@@ -123,15 +126,15 @@ var TorqueLayer = LayerModelBase.extend({
     this.set('renderRange', {});
   },
 
-  isEqual: function(other) {
+  isEqual: function (other) {
     var properties = ['query', 'query_wrapper', 'cartocss'];
     var self = this;
-    return this.get('type') === other.get('type') && _.every(properties, function(p) {
-      return other.get(p) === self.get(p);
-    });
+    return this.get('type') === other.get('type') && _.every(properties, function (p) {
+        return other.get(p) === self.get(p);
+      });
   },
 
-  isVisible: function() {
+  isVisible: function () {
     return true;
   },
 
@@ -139,20 +142,19 @@ var TorqueLayer = LayerModelBase.extend({
     return this.get('layer_name') || this.get('table_name');
   },
 
-  getInteractiveColumnNames: function() {
+  getInteractiveColumnNames: function () {
     return [];
   },
 
-  getInfowindowFieldNames: function() {
+  getInfowindowFieldNames: function () {
     return [];
   },
 
-  hasInteraction: function() {
+  hasInteraction: function () {
     return this.getInteractiveColumnNames() > 0;
   },
 
-  fetchAttributes: function(layer, featureID, callback) {
-  },
+  fetchAttributes: function (layer, featureID, callback) {},
 
   setDataProvider: function (dataProvider) {
     this._dataProvider = dataProvider;
@@ -163,11 +165,11 @@ var TorqueLayer = LayerModelBase.extend({
   },
 
   // given a timestamp returns a step (float)
-  timeToStep: function(timestamp) {
+  timeToStep: function (timestamp) {
     var steps = this.get('steps');
     var start = this.get('start');
     var end = this.get('end');
-    var step = (steps * (1000*timestamp - start)) / (end - start);
+    var step = (steps * (1000 * timestamp - start)) / (end - start);
     return step;
   },
 

--- a/src/geo/map/torque-layer.js
+++ b/src/geo/map/torque-layer.js
@@ -137,8 +137,8 @@ var TorqueLayer = LayerModelBase.extend({
     var properties = ['query', 'query_wrapper', 'cartocss'];
     var self = this;
     return this.get('type') === other.get('type') && _.every(properties, function (p) {
-        return other.get(p) === self.get(p);
-      });
+      return other.get(p) === self.get(p);
+    });
   },
 
   isVisible: function () {

--- a/test/spec/geo/leaflet/leaflet-torque-layer-view.spec.js
+++ b/test/spec/geo/leaflet/leaflet-torque-layer-view.spec.js
@@ -27,7 +27,7 @@ describe('geo/leaflet/leaflet-torque-layer-view', function () {
     this.model = new TorqueLayer({
       type: 'torque',
       sql: 'select * from table',
-      cartocss: '#test {}',
+      cartocss: 'Map {}',
       dynamic_cdn: 'dynamic-cdn-value'
     }, { vis: this.vis });
     this.map.addLayer(this.model);
@@ -43,7 +43,7 @@ describe('geo/leaflet/leaflet-torque-layer-view', function () {
     var newLayer = new TorqueLayer(this.view.model.attributes, {
       vis: this.vis
     });
-    newLayer.set({ sql: 'select * from table', cartocss: '#test {}' });
+    newLayer.set({ sql: 'select * from table', cartocss: 'Map {}' });
     this.map.layers.reset([newLayer]);
 
     expect(this.mapView._layerViews[newLayer.cid] instanceof L.TorqueLayer).toEqual(true);

--- a/test/spec/geo/map/torque-layer.spec.js
+++ b/test/spec/geo/map/torque-layer.spec.js
@@ -53,12 +53,22 @@ describe('geo/map/torque-layer', function () {
       expect(this.vis.reload).not.toHaveBeenCalled();
     });
 
-    it('should reload the map if cartocss property has changed and it has a ramp', function () {
+    it('should reload the map if cartocss property has changed and fill has a ramp', function () {
       var layer = new TorqueLayer({
-        cartocss: 'Map { -torque-time-attribute: "cartodb_id"; } #layer { marker-fill: ramp([value], (#5B3F95, #1D6996, #129C63, #73AF48, #EDAD08, #E17C05, #C94034, #BA0040), (1, 2, 3, 4, 5, 6, 7, 8), "="); }'
+        cartocss: 'Map { -torque-time-attribute: "cartodb_id"; } #pepito { marker-fill: ramp([value], (#5B3F95, #1D6996, #129C63, #73AF48, #EDAD08, #E17C05, #C94034, #BA0040), (1, 2, 3, 4, 5, 6, 7, 8), "="); }'
       }, { vis: this.vis });
 
-      layer.set('cartocss', 'Map { -torque-time-attribute: "cartodb_id"; } #layer { marker-fill: ramp([value], (#5B3F95, #1D6996, #129C63, #73AF48, #EDAD08, #E17C05, #C94034, #BA0040), (1, 2, 3, 4, 5, 6, 7, 8), "="); comp-op: lighter; }');
+      layer.set('cartocss', 'Map { -torque-time-attribute: "cartodb_id"; } #pepito { marker-fill: ramp([value], (#5B3F95, #1D6996, #129C63, #73AF48, #EDAD08, #E17C05, #C94034, #BA0040), (1, 2, 3, 4, 5, 6, 7, 8), "="); comp-op: lighter; }');
+
+      expect(this.vis.reload).toHaveBeenCalled();
+    });
+
+    it('should reload the map if cartocss property has changed and line-color has a ramp', function () {
+      var layer = new TorqueLayer({
+        cartocss: 'Map { -torque-time-attribute: "cartodb_id"; } #layer { }'
+      }, { vis: this.vis });
+
+      layer.set('cartocss', 'Map { -torque-time-attribute: "cartodb_id"; } #layer { marker-line-color: ramp([value], (#5B3F95, #1D6996, #129C63, #73AF48, #EDAD08, #E17C05, #C94034, #BA0040), (1, 2, 3, 4, 5, 6, 7, 8), "="); }');
 
       expect(this.vis.reload).toHaveBeenCalled();
     });

--- a/test/spec/geo/map/torque-layer.spec.js
+++ b/test/spec/geo/map/torque-layer.spec.js
@@ -10,7 +10,7 @@ describe('geo/map/torque-layer', function () {
   sharedTestsForInteractiveLayers(TorqueLayer);
 
   describe('vis reloading', function () {
-    var ATTRIBUTES = ['sql', 'source'];
+    var ATTRIBUTES = ['sql', 'sql_wrap', 'source'];
 
     _.each(ATTRIBUTES, function (attribute) {
       it("should reload the vis when '" + attribute + "' attribute changes", function () {
@@ -43,7 +43,7 @@ describe('geo/map/torque-layer', function () {
       expect(this.vis.reload).not.toHaveBeenCalled();
     });
 
-    it('should NOT reload the map if a cartocss property has changed and a reload is not needed', function () {
+    it('should NOT reload the map if cartocss property has changed and a reload is not needed', function () {
       var layer = new TorqueLayer({
         cartocss: 'Map { something: "a"; -torque-time-attribute: "column"; }'
       }, { vis: this.vis });
@@ -51,6 +51,16 @@ describe('geo/map/torque-layer', function () {
       layer.set('cartocss', 'Map { something: "b"; -torque-time-attribute: "column"; }');
 
       expect(this.vis.reload).not.toHaveBeenCalled();
+    });
+
+    it('should reload the map if cartocss property has changed and it has a ramp', function () {
+      var layer = new TorqueLayer({
+        cartocss: 'Map { -torque-time-attribute: "cartodb_id"; } #layer { marker-fill: ramp([value], (#5B3F95, #1D6996, #129C63, #73AF48, #EDAD08, #E17C05, #C94034, #BA0040), (1, 2, 3, 4, 5, 6, 7, 8), "="); }'
+      }, { vis: this.vis });
+
+      layer.set('cartocss', 'Map { -torque-time-attribute: "cartodb_id"; } #layer { marker-fill: ramp([value], (#5B3F95, #1D6996, #129C63, #73AF48, #EDAD08, #E17C05, #C94034, #BA0040), (1, 2, 3, 4, 5, 6, 7, 8), "="); comp-op: lighter; }');
+
+      expect(this.vis.reload).toHaveBeenCalled();
     });
 
     _.each([


### PR DESCRIPTION
Basically if the `CartoCSS` is using TurboCarto, we have to instantiate in order to receive the "readable" `CartoCSS` from the instantiation, no matter what property has changed.

Things needed for this purpose:

- Added `sql_wrap` to those attributes that trigger vis reload.
- "Updated" *torque* dependency within package.json, now requesting it from repository instead of npm.
- "Updated" *carto* dependency as we do in Builder dependencies, requested from the repository.

CR: @alonsogarciapablo 
cc @rochoa and @javisantana 

This is part from https://github.com/CartoDB/cartodb/issues/9389.