### PR TITLE
Removed unnecessary instantiation when there is turbocarto on cartocss

### DIFF
--- a/src/geo/map/torque-layer.js
+++ b/src/geo/map/torque-layer.js
@@ -2,7 +2,6 @@ var _ = require('underscore');
 var LayerModelBase = require('./layer-model-base');
 var carto = require('carto');
 var ATTRIBUTES_THAT_TRIGGER_VIS_RELOAD = ['sql', 'sql_wrap', 'source', 'cartocss'];
-var PROPERTIES_THAT_CAN_USE_TURBO_CARTO = ['marker-fill', 'marker-line-color'];
 var TORQUE_LAYER_CARTOCSS_PROPS = [
   '-torque-frame-count',
   '-torque-time-attribute',

--- a/src/geo/map/torque-layer.js
+++ b/src/geo/map/torque-layer.js
@@ -43,7 +43,7 @@ var TorqueLayer = LayerModelBase.extend({
     var reloadVis = _.any(ATTRIBUTES_THAT_TRIGGER_VIS_RELOAD, function (attr) {
       if (this.hasChanged(attr)) {
         if (attr === 'cartocss') {
-          return this.previous('cartocss') && (this._torqueCartoCSSPropsChanged() || this._hasTurboCarto());
+          return this.previous('cartocss') && this._torqueCartoCSSPropsChanged();
         }
         return true;
       }
@@ -52,31 +52,6 @@ var TorqueLayer = LayerModelBase.extend({
     if (reloadVis) {
       this._reloadVis();
     }
-  },
-
-  _hasTurboCarto: function () {
-    var currentCartoCSS = this.get('cartocss');
-    var shader = new carto.RendererJS().render(currentCartoCSS);
-    var layers = shader.getLayers();
-
-    var isAnyLayerUsingTurboCarto = _.any(layers, function (layer) {
-      if (layer) {
-        var layerShader = layer.getStyle({ property: 1 }, { zoom: 10 });
-
-        var isAnyPropertyUsingCarto = _.any(PROPERTIES_THAT_CAN_USE_TURBO_CARTO, function (property) {
-          var value = layerShader[property];
-          if (value && value.name === 'ramp') {
-            return true;
-          }
-        });
-
-        return isAnyPropertyUsingCarto;
-      }
-
-      return false;
-    });
-
-    return isAnyLayerUsingTurboCarto;
   },
 
   _torqueCartoCSSPropsChanged: function () {

--- a/test/spec/geo/map/torque-layer.spec.js
+++ b/test/spec/geo/map/torque-layer.spec.js
@@ -53,26 +53,6 @@ describe('geo/map/torque-layer', function () {
       expect(this.vis.reload).not.toHaveBeenCalled();
     });
 
-    it('should reload the map if cartocss property has changed and fill has a ramp', function () {
-      var layer = new TorqueLayer({
-        cartocss: 'Map { -torque-time-attribute: "cartodb_id"; } #pepito { marker-fill: ramp([value], (#5B3F95, #1D6996, #129C63, #73AF48, #EDAD08, #E17C05, #C94034, #BA0040), (1, 2, 3, 4, 5, 6, 7, 8), "="); }'
-      }, { vis: this.vis });
-
-      layer.set('cartocss', 'Map { -torque-time-attribute: "cartodb_id"; } #pepito { marker-fill: ramp([value], (#5B3F95, #1D6996, #129C63, #73AF48, #EDAD08, #E17C05, #C94034, #BA0040), (1, 2, 3, 4, 5, 6, 7, 8), "="); comp-op: lighter; }');
-
-      expect(this.vis.reload).toHaveBeenCalled();
-    });
-
-    it('should reload the map if cartocss property has changed and line-color has a ramp', function () {
-      var layer = new TorqueLayer({
-        cartocss: 'Map { -torque-time-attribute: "cartodb_id"; } #layer { }'
-      }, { vis: this.vis });
-
-      layer.set('cartocss', 'Map { -torque-time-attribute: "cartodb_id"; } #layer { marker-line-color: ramp([value], (#5B3F95, #1D6996, #129C63, #73AF48, #EDAD08, #E17C05, #C94034, #BA0040), (1, 2, 3, 4, 5, 6, 7, 8), "="); }');
-
-      expect(this.vis.reload).toHaveBeenCalled();
-    });
-
     _.each([
       '-torque-frame-count',
       '-torque-time-attribute',


### PR DESCRIPTION
After checking new changes in the lastest torque, the instantiation is not needed in order to draw correctly the tiles, so better for us.

Goodbye useless work :(.

cc @alonsogarciapablo @rochoa @javisantana 