### PR TITLE
popups: image header, add order class to hide first field in content

### DIFF
--- a/themes/scss/infowindow/cartodb-infowindow-default.scss
+++ b/themes/scss/infowindow/cartodb-infowindow-default.scss
@@ -77,6 +77,9 @@
 .CDB-infowindow-listItem:first-child {
   margin-top: 0;
 }
+.CDB-infowindow-listItem--order1 {
+  display: none;
+}
 
 .CDB-infowindow-list .ps-scrollbar-y-rail {
   width: 1px !important; // Resets standard scroll track color


### PR DESCRIPTION
CR @xavijam 

![screen shot 2016-09-28 at 15 53 11](https://cloud.githubusercontent.com/assets/36676/18916184/d9c488e6-8593-11e6-9c66-f0f616b3235d.png)

this is needed along with some changes in https://github.com/CartoDB/cartodb/issues/9701