### PR TITLE
Catch errors thrown by legend adapters

### DIFF
--- a/src/windshaft-integration/model-updater.js
+++ b/src/windshaft-integration/model-updater.js
@@ -150,19 +150,15 @@ ModelUpdater.prototype._updateLegendModel = function (legendModel, layerMetadata
     };
     if (cartoCSSRules) {
       var adapter = RuleToLegendModelAdapters.getAdapterForLegend(legendModel);
-      var cartoCSSRule = _.find(cartoCSSRules, function (rule) {
-        if (adapter.canAdapt(rule)) {
-          return rule;
-        }
-      });
-      if (cartoCSSRule) {
-        newLegendAttrs = _.extend(newLegendAttrs, adapter.adapt(cartoCSSRule));
+      var ruleForLegend = _.find(cartoCSSRules, adapter.canAdapt);
+      if (ruleForLegend) {
+        newLegendAttrs = _.extend(newLegendAttrs, adapter.adapt(ruleForLegend));
       }
     }
     legendModel.set(newLegendAttrs);
   } catch (error) {
     legendModel.set({ state: 'error' });
-    log.error("legend of type '" + legendModel.get('type') + "'couldn't be updated: " + error.message);
+    log.error("legend of type '" + legendModel.get('type') + "' couldn't be updated: " + error.message);
   }
 };
 

--- a/test/unit/windshaft-integration/model-updater.spec.js
+++ b/test/unit/windshaft-integration/model-updater.spec.js
@@ -444,6 +444,37 @@ describe('src/vis/model-updater', function () {
         expect(layer.legends.bubble.get('avg')).toEqual(3500);
         expect(layer.legends.bubble.isSuccess()).toBeTruthy();
       });
+
+      it('should set legend state to "error" if adapter fails to generate attrs from rule', function () {
+        this.windshaftMap.set('metadata', {
+          layers: [
+            {
+              'type': 'mapnik',
+              'id': '923b7812-2d56-41c6-ac15-b090f3ce430d',
+              'meta': {
+                'stats': [],
+                'cartocss': 'cartocss',
+                'cartocss_meta': {
+                  'rules': [
+                    {
+                      'prop': 'marker-width',
+                      'mapping': '>'
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        });
+
+        var layer = new CartoDBLayer({}, { vis: this.visModel });
+
+        this.layersCollection.reset([ layer ]);
+
+        this.modelUpdater.updateModels(this.windshaftMap, 'sourceId', 'forceFetch');
+
+        expect(layer.legends.bubble.isError()).toBeTruthy();
+      });
     });
 
     describe('dataview models', function () {
@@ -488,7 +519,7 @@ describe('src/vis/model-updater', function () {
     });
 
     describe('analysis models', function () {
-      it('should update analysis models and "mark" them as ok', function () {
+      it('should update analysis models and set analysis state to "ok"', function () {
         var getParamNames = function () { return []; };
         var analysis1 = new Backbone.Model({ id: 'a1' });
         analysis1.setOk = jasmine.createSpy('setOk');
@@ -530,7 +561,7 @@ describe('src/vis/model-updater', function () {
         expect(analysis2.setOk).toHaveBeenCalled();
       });
 
-      it('should update analysis models and "mark" them as failed', function () {
+      it('should update analysis models and set status to "failed"', function () {
         var getParamNames = function () { return []; };
         var analysis1 = new Backbone.Model({ id: 'a1' });
         this.analysisCollection.reset([ analysis1 ]);
@@ -599,7 +630,7 @@ describe('src/vis/model-updater', function () {
       expect(error.context).toBeUndefined();
     });
 
-    it('should "mark" analysis as erroneous', function () {
+    it('should set analysis status to "error"', function () {
       var analysis = new Backbone.Model({
         id: 'ANALYSIS_NODE_ID'
       });


### PR DESCRIPTION
And reflect that in the UI by changing legend's state to "error" when this happens. It was stopping the map re-instantiation before.

Also, ensure that only one rule is used to update each legend model.

@rochoa 👍 ?