### PR TITLE
popups: alternative names in custom templates

### DIFF
--- a/src/geo/ui/default-infowindow-template.tpl
+++ b/src/geo/ui/default-infowindow-template.tpl
@@ -12,7 +12,6 @@
               <li class="CDB-infowindow-listItem">
                 <% if (field.title) { %><h5 class="CDB-infowindow-subtitle"><%- field.title %></h5><% } %>
                 <% if (field.value) { %><h4 class="CDB-infowindow-title"><%- field.value %></h4><% } %>
-                <% if (!field.title) { %><h4 class="CDB-infowindow-title">null</h4><% } %>
               </li>
               <% }) %>
           <% } %>

--- a/src/geo/ui/infowindow-model.js
+++ b/src/geo/ui/infowindow-model.js
@@ -96,6 +96,7 @@ var InfowindowModel = Backbone.Model.extend({
       var value = attributes[field.name];
       if (options.showEmptyFields || (value !== undefined && value !== null)) {
         render_fields.push({
+          name: field.name,
           title: field.title ? field.name : null,
           value: (value !== undefined && value !== null) ? value : 'null',
           index: j

--- a/src/geo/ui/infowindow-view.js
+++ b/src/geo/ui/infowindow-view.js
@@ -115,7 +115,7 @@ var Infowindow = View.extend({
       var values = {};
 
       _.each(fields, function (pair) {
-        values[pair.title] = pair.value;
+        values[pair.name] = pair.value;
       });
 
       var obj = _.extend({
@@ -260,16 +260,9 @@ var Infowindow = View.extend({
       attr.value = '';
     }
 
-    // Get the alternative title
-    var alternative_name = this.model.getAlternativeName(attr.title);
-
-    if (attr.title && alternative_name) {
-      // Alternative title
-      attr.title = alternative_name;
-    } else if (attr.title) {
-      // Remove '_' character from titles
-      attr.title = attr.title.replace(/_/g, ' ');
-    }
+    // Get the alternative name
+    var alternative_name = this.model.getAlternativeName(attr.name);
+    attr.title = (attr.title && alternative_name) ? alternative_name : attr.title;
 
     // Save new sanitized value
     attr.value = JSON.parse(JSON.stringify(attr.value), this._sanitizeValue);

--- a/test/spec/geo/ui/infowindow-model.spec.js
+++ b/test/spec/geo/ui/infowindow-model.spec.js
@@ -27,14 +27,14 @@ describe('geo/ui/infowindow-model', function () {
       var infowindowModel = new InfowindowModel({ fields: [{ name: 'NAME', title: true }, { name: 'SOMETHING', title: true }] });
       infowindowModel.updateContent({ NAME: 'CartoDB' }, { showEmptyFields: false });
 
-      expect(infowindowModel.get('content').fields).toEqual([{ title: 'NAME', value: 'CartoDB', index: 0 }]);
+      expect(infowindowModel.get('content').fields).toEqual([{ name: 'NAME', title: 'NAME', value: 'CartoDB', index: 0 }]);
     });
 
     it('should include empty fields', function () {
       var infowindowModel = new InfowindowModel({ fields: [{ name: 'NAME', title: true }, { name: 'SOMETHING', title: true }] });
       infowindowModel.updateContent({ NAME: 'CartoDB' }, { showEmptyFields: true });
 
-      expect(infowindowModel.get('content').fields).toEqual([{ title: 'NAME', value: 'CartoDB', index: 0 }, { title: 'SOMETHING', value: 'null', index: 1 }]);
+      expect(infowindowModel.get('content').fields).toEqual([{ name: 'NAME', title: 'NAME', value: 'CartoDB', index: 0 }, { name: 'SOMETHING', title: 'SOMETHING', value: 'null', index: 1 }]);
     });
   });
 
@@ -76,11 +76,13 @@ describe('geo/ui/infowindow-model', function () {
 
       expect(content.fields.length).toEqual(2);
       expect(content.fields[0]).toEqual({
+        name: 'field1',
         title: null,
         value: 'value1',
         index: 0
       });
       expect(content.fields[1]).toEqual({
+        name: 'field2',
         title: null,
         value: 'null',
         index: 1
@@ -95,6 +97,7 @@ describe('geo/ui/infowindow-model', function () {
 
       expect(content.fields.length).toEqual(1);
       expect(content.fields[0]).toEqual({
+        name: 'field1',
         title: null,
         value: 'value1',
         index: 0
@@ -108,6 +111,7 @@ describe('geo/ui/infowindow-model', function () {
 
       expect(content.fields.length).toEqual(1);
       expect(content.fields[0]).toEqual({
+        name: 'field1',
         title: null,
         value: 'wadus',
         index: 0

--- a/test/spec/geo/ui/infowindow.spec.js
+++ b/test/spec/geo/ui/infowindow.spec.js
@@ -314,23 +314,43 @@ describe('geo/ui/infowindow-view', function() {
     });
 
     it("should render properly when there is only a field without title", function() {
-      model.set({
-        fields: [
-          { name: 'test1', position: 0, title: false },
-        ],
+      view.model.set({
+        template: ['{{#content.fields}}',
+          '<li class="CDB-infowindow-listItem">',
+            '{{#title}}<h5 class="CDB-infowindow-subtitle">{{title}}</h5>{{/title}}',
+            '{{#value}}<h4 class="CDB-infowindow-title">{{{ value }}}</h4>{{/value}}',
+            '{{^value}}<h4 class="CDB-infowindow-title">null</h4>{{/value}}',
+          '</li>',
+          '{{/content.fields}}'].join(' '),
         content: {
           fields: [
-            { name: 'test1', title: 'test1', position: 0, value: 'jamon' },
+            { name: 'test1', title: null, position: 0, value: 'jamon' },
           ]
         }
       });
 
-      var new_view = new Infowindow({
-        model: model,
-        mapView: mapView
+      view.render();
+      expect(view.$el.html()).toContain('<li class="CDB-infowindow-listItem">  <h4 class="CDB-infowindow-title">jamon</h4>  </li>');
+    });
+
+    it("should render with alternative_name set", function() {
+      view.model.set({
+        template: ['{{#content.fields}}',
+          '<li class="CDB-infowindow-listItem">',
+            '{{#title}}<h5 class="CDB-infowindow-subtitle">{{title}}</h5>{{/title}}',
+            '{{#value}}<h4 class="CDB-infowindow-title">{{{ value }}}</h4>{{/value}}',
+            '{{^value}}<h4 class="CDB-infowindow-title">null</h4>{{/value}}',
+          '</li>',
+          '{{/content.fields}}'].join(' '),
+        content: {
+          fields: [
+            { name: 'test1', title: 'test1_', value: 'test1' }
+          ]
+        }
       });
 
-      expect(new_view.render().$el.html()).toBe('<div>jamon</div>');
+      view.render();
+      expect(view.$el.html()).toContain('<h5 class="CDB-infowindow-subtitle">test1_</h5> <h4 class="CDB-infowindow-title">test1</h4>');
     });
 
     it("shouldn't sanitize the fields", function() {

--- a/test/spec/geo/ui/infowindow.spec.js
+++ b/test/spec/geo/ui/infowindow.spec.js
@@ -93,6 +93,38 @@ describe('geo/ui/infowindow-view', function() {
     expect(view.render().$el.html().length).not.toBe(0);
   });
 
+  it("should render with alternative_name set", function() {
+    model.set({
+      content: {
+        fields: [
+          { name: 'jamon1', title: 'jamon1_', value: 'jamon1' }
+        ]
+      }
+    }, { silent: true });
+
+    view.render();
+
+    var item1 = view.$el.find('.CDB-infowindow-listItem:nth-child(1)');
+    expect(item1.find('.CDB-infowindow-title').text()).toEqual('jamon1');
+    expect(item1.find('.CDB-infowindow-subtitle').text()).toEqual('jamon1_');
+  });
+
+  it("should render without title", function() {
+    model.set({
+      content: {
+        fields: [
+          { name: 'jamon1', title: null, value: 'jamon1' }
+        ]
+      }
+    }, { silent: true });
+
+    view.render();
+
+    var item1 = view.$el.find('.CDB-infowindow-listItem:nth-child(1)');
+    expect(item1.find('.CDB-infowindow-title').text()).toEqual('jamon1');
+    expect(item1.find('.CDB-infowindow-subtitle').length).toBe(0);
+  });
+
   it("should convert value to string when it is a number", function() {
     model.set({
       content: {
@@ -208,8 +240,8 @@ describe('geo/ui/infowindow-view', function() {
     model.set({
       content: {
         fields: [
-          { title: 'jamon1', value: [{ jamon2: 'jamon2', istrue: true, isempty: '', isnum: 9 }] },
-          { title: 'jamon3', value: ['jamon4', 'jamon5'] }
+          { name: 'jamon1', title: 'jamon1', value: [{ jamon2: 'jamon2', istrue: true, isempty: '', isnum: 9 }] },
+          { name: 'jamon3', title: 'jamon3', value: ['jamon4', 'jamon5'] }
         ]
       },
       template: template,
@@ -288,7 +320,7 @@ describe('geo/ui/infowindow-view', function() {
         ],
         content: {
           fields: [
-            { title: 'test1', position: 0, value: 'jamon' },
+            { name: 'test1', title: 'test1', position: 0, value: 'jamon' },
           ]
         }
       });

--- a/test/spec/vis/infowindow-manager-spec.js
+++ b/test/spec/vis/infowindow-manager-spec.js
@@ -151,6 +151,7 @@ describe('src/vis/infowindow-manager.js', function () {
       'content': {
         'fields': [
           {
+            'name': 'name',
             'title': 'name',
             'value': 'juan',
             'index': 0


### PR DESCRIPTION
fixed an issue where values in custom templates weren't appearing, related to alternative names overriding titles

also, removed functionality where titles had underscores and they were _sanitized_, but again used in custom templates, thus not appearing

- added test to check alternative_name, and no title in both default and custom template
- changes in default template, surfaced when adding the tests

find the discussion below:

---

managed to reproduce it, this was already happening in the current editor, where we sanitize the title in the infowindow and replace "_" with spaces (see attached)

https://github.com/CartoDB/cartodb.js/blob/develop/src/geo/ui/infowindow.js#L455

![infowindows](https://cloud.githubusercontent.com/assets/36676/19149212/f8f9e32c-8bc0-11e6-90e4-30417d287853.gif)

I'm removing this sanitization as it doesn't contribute a lot, and the user could always make this change manually with the alternative name

another issue which is still happening in new builder (but doesn't in eld editor) is when alternative names are set, we lose the field in the infowindow no matter if sanitization is done or not, because the field title is overriden with the alternative name, thus the index doesn't exist

this is happening because we didn't do that previously for custom templates, but new infowindows don't take that into account

so, I'll be working in these two fixes (and update the tests to cover the cases), and then I'll move to CartoDB/cartodb#9993 which I also reproduced and seem serious
