### PR TITLE
Hide legends if no legend is visible.

### DIFF
--- a/src/api/create-vis.js
+++ b/src/api/create-vis.js
@@ -92,7 +92,7 @@ var loadVizJSON = function (el, visModel, vizjsonData, options) {
 };
 
 var applyOptionsToVizJSON = function (vizjson, options) {
-  vizjson.options.scrollwheel = options.scrollwheel || vizjson.options.scrollwheel;
+  vizjson.options.scrollwheel = options && options.scrollwheel || vizjson.options.scrollwheel;
 
   if (!options.tiles_loader || !options.loaderControl) {
     vizjson.removeLoaderOverlay();

--- a/src/api/create-vis.js
+++ b/src/api/create-vis.js
@@ -92,7 +92,7 @@ var loadVizJSON = function (el, visModel, vizjsonData, options) {
 };
 
 var applyOptionsToVizJSON = function (vizjson, options) {
-  vizjson.options.scrollwheel = options && options.scrollwheel || vizjson.options.scrollwheel;
+  vizjson.options.scrollwheel = options.scrollwheel || vizjson.options && vizjson.options.scrollwheel;
 
   if (!options.tiles_loader || !options.loaderControl) {
     vizjson.removeLoaderOverlay();

--- a/src/geo/map/legends/legends.js
+++ b/src/geo/map/legends/legends.js
@@ -84,4 +84,12 @@ Legends.prototype._findDataForLegend = function (legendType) {
   return _.find(this._legendsData, { type: legendType });
 };
 
+Legends.prototype.hasAnyLegend = function () {
+  var legendTypes = _.keys(LEGENDS_METADATA);
+  return _.some(legendTypes, function (legendType) {
+    var legend = this[legendType];
+    return legend && legend.isVisible();
+  }, this);
+};
+
 module.exports = Legends;

--- a/src/geo/ui/legends/legends-view.js
+++ b/src/geo/ui/legends/legends-view.js
@@ -93,7 +93,8 @@ var LegendsView = Backbone.View.extend({
   _renderLayerLegends: function (layerModel) {
     var layerLegendsView = new LayerLegendsView({
       model: layerModel,
-      settingsModel: this.settingsModel
+      settingsModel: this.settingsModel,
+      tryContainerVisibility: this._tryVisibility.bind(this)
     });
 
     this.$(this._container()).append(layerLegendsView.render().$el);
@@ -105,6 +106,14 @@ var LegendsView = Backbone.View.extend({
       this._clear();
       this.render();
     }
+  },
+
+  _tryVisibility: function () {
+    var shouldHide = !_.every(this.$('.js-layer-legends'), function (el) {
+      return $(el).is(':empty');
+    });
+
+    this.$el.toggle(shouldHide);
   },
 
   _hasLegends: function (layerModel) {

--- a/test/spec/geo/ui/legends/layer-legends-view.spec.js
+++ b/test/spec/geo/ui/legends/layer-legends-view.spec.js
@@ -21,9 +21,12 @@ describe('geo/ui/legends/layer-legends-view', function () {
       ]
     }, { vis: vis });
 
+    this.tryContainerVisibility = jasmine.createSpy('tryContainerVisibility');
+
     this.layerLegendsView = new LayerLegendsView({
       model: this.cartoDBLayer,
-      settingsModel: this.settingsModel
+      settingsModel: this.settingsModel,
+      tryContainerVisibility: this.tryContainerVisibility
     });
 
     this.layerLegendsView.render();
@@ -89,5 +92,12 @@ describe('geo/ui/legends/layer-legends-view', function () {
 
     expect(this.layerLegendsView.$el.hasClass('is-disabled')).toBeFalsy();
     expect(this.layerLegendsView.$('.is-disabled').length).toEqual(0);
+  });
+
+  it('should be hidden if no legends are rendered', function () {
+    spyOn(this.cartoDBLayer.legends, 'hasAnyLegend').and.returnValue(false);
+    this.settingsModel.set('showLayerSelector', false);
+    this.layerLegendsView.render();
+    expect(this.layerLegendsView.$el.is(':empty')).toBe(true);
   });
 });

--- a/test/spec/geo/ui/legends/legends-view.spec.js
+++ b/test/spec/geo/ui/legends/legends-view.spec.js
@@ -74,4 +74,11 @@ describe('geo/ui/legends/legends-view', function () {
     this.settingsModel.set('showLayerSelector', false);
     expect(this.legendsView.$('input').length).toBe(0);
   });
+
+  it('should hide element if showLayerSelector is false and no legends are visible', function () {
+    spyOn(this.cartoDBLayer1.legends, 'hasAnyLegend').and.returnValue(false);
+    spyOn(this.cartoDBLayer2.legends, 'hasAnyLegend').and.returnValue(false);
+    this.settingsModel.set('showLayerSelector', false);
+    expect(this.legendsView.el.style.display).toEqual('none');
+  });
 });


### PR DESCRIPTION
This PR hides the legends container if layer selector is not activated and no legend is visible.

![map-legends-options](https://cloud.githubusercontent.com/assets/1366843/19159746/d158c55e-8bed-11e6-86e6-44c4b38088ba.gif)

@alonsogarciapablo 🙏 

