### PR TITLE
Clickable features and "disableable" popups

### DIFF
--- a/src/geo/cartodb-layer-group-view-base.js
+++ b/src/geo/cartodb-layer-group-view-base.js
@@ -1,7 +1,4 @@
 function CartoDBLayerGroupViewBase (layerGroupModel) {
-  this.visible = true;
-  this.interactionEnabled = [];
-
   layerGroupModel.on('change:urls', this._reload, this);
   layerGroupModel.onLayerVisibilityChanged(this._reload.bind(this));
 }
@@ -14,22 +11,15 @@ CartoDBLayerGroupViewBase.prototype = {
   _reloadInteraction: function () {
     this._clearInteraction();
 
-    // Enable interaction for the layers that have interaction
-    // (are visible AND have tooltips OR infowindows)
     this.model.each(function (layer, layerIndex) {
-      if (layer.hasInteraction()) {
-        this._enableInteraction(layerIndex);
-      }
+      this._enableInteraction(layerIndex);
     }, this);
   },
 
   _clearInteraction: function () {
-    for (var layerIndex in this.interactionEnabled) {
-      if (this.interactionEnabled.hasOwnProperty(layerIndex) &&
-        this.interactionEnabled[layerIndex]) {
-        this._disableInteraction(layerIndex);
-      }
-    }
+    this.model.each(function (layer, layerIndex) {
+      this._disableInteraction(layerIndex);
+    }, this);
   },
 
   _enableInteraction: function (layerIndexInLayerGroup) {

--- a/src/geo/map-view.js
+++ b/src/geo/map-view.js
@@ -37,6 +37,51 @@ var MapView = View.extend({
     this.add_related_model(this.map.layers);
 
     this.bind('clean', this._removeLayers, this);
+
+    this.on('newLayerView', this._onNewLayerViewAdded, this);
+  },
+
+  _onNewLayerViewAdded: function (layerView, layerModel) {
+    layerView.on('featureOver', function () {
+      if (this.map.isInteractive()) {
+        this.setCursor('pointer');
+        this._triggerMouseEvent('featureOver', arguments);
+      }
+    }, this);
+
+    layerView.on('featureOut', function () {
+      if (this.map.isInteractive()) {
+        this.setCursor('auto');
+        this.map.trigger('featureOut');
+      }
+    }, this);
+
+    layerView.on('featureClick', function (e, latlng, pos, data, layerIndex) {
+      if (this.map.isInteractive()) {
+        this._triggerMouseEvent('featureClick', arguments);
+      }
+    }, this);
+  },
+
+  setCursor: function () {
+    throw new Error('subclasses of MapView must implement setCursor');
+  },
+
+  _triggerMouseEvent: function (eventName, originalEventArguments) {
+    var latlng = originalEventArguments[1];
+    var position = originalEventArguments[2];
+    var featureData = originalEventArguments[3];
+    var layerIndex = originalEventArguments[4];
+
+    this.map.trigger(eventName, {
+      layer: this.map.layers.getCartoDBLayers()[layerIndex],
+      latlng: latlng,
+      position: {
+        x: position.x,
+        y: position.y
+      },
+      feature: featureData
+    });
   },
 
   render: function () {

--- a/src/geo/map-view.js
+++ b/src/geo/map-view.js
@@ -45,19 +45,23 @@ var MapView = View.extend({
     layerView.on('featureOver', function () {
       if (this.map.isInteractive()) {
         this.setCursor('pointer');
-        this._triggerMouseEvent('featureOver', arguments);
+        if (this.map.isFeatureInteractivityEnabled()) {
+          this._triggerMouseEvent('featureOver', arguments);
+        }
       }
     }, this);
 
     layerView.on('featureOut', function () {
       if (this.map.isInteractive()) {
         this.setCursor('auto');
-        this.map.trigger('featureOut');
+        if (this.map.isFeatureInteractivityEnabled()) {
+          this.map.trigger('featureOut');
+        }
       }
     }, this);
 
     layerView.on('featureClick', function (e, latlng, pos, data, layerIndex) {
-      if (this.map.isInteractive()) {
+      if (this.map.isFeatureInteractivityEnabled()) {
         this._triggerMouseEvent('featureClick', arguments);
       }
     }, this);

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -19,7 +19,9 @@ var Map = Model.extend({
     keyboard: true,
     provider: 'leaflet',
     // enforce client-side rendering using GeoJSON vector tiles
-    vector: false
+    vector: false,
+    popupsEnabled: true,
+    isFeatureInteractivityEnabled: false
   },
 
   initialize: function (attrs, options) {
@@ -147,16 +149,11 @@ var Map = Model.extend({
 
   isInteractive: function () {
     return this.isFeatureInteractivityEnabled() ||
-      this.arePopupsEnabled() && this._wadus();
+      this.arePopupsEnabled() && this._isAnyCartoDBLayerInteractive();
   },
 
-  _wadus: function () {
-    var layers = _.union(
-      this.layers.getCartoDBLayers(),
-      this.layers.getTorqueLayers()
-    );
-
-    return _.all(layers, function (layerModel) {
+  _isAnyCartoDBLayerInteractive: function () {
+    return _.any(this.layers.getCartoDBLayers(), function (layerModel) {
       return layerModel.hasInteraction();
     });
   },

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -182,6 +182,10 @@ var Map = Model.extend({
     return !!this.get('popupsEnabled');
   },
 
+  arePopupsDisabled: function () {
+    return !this.arePopupsEnabled();
+  },
+
   // INTERNAL CartoDB.js METHODS
 
   setView: function (latlng, zoom) {

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -145,6 +145,46 @@ var Map = Model.extend({
     return this.layers.remove(layerModel);
   },
 
+  isInteractive: function () {
+    return this.isFeatureInteractivityEnabled() ||
+      this.arePopupsEnabled() && this._wadus();
+  },
+
+  _wadus: function () {
+    var layers = _.union(
+      this.layers.getCartoDBLayers(),
+      this.layers.getTorqueLayers()
+    );
+
+    return _.all(layers, function (layerModel) {
+      return layerModel.hasInteraction();
+    });
+  },
+
+  enableFeatureInteractivity: function () {
+    this.set('isFeatureInteractivityEnabled', true);
+  },
+
+  disableFeatureInteractivity: function () {
+    this.set('isFeatureInteractivityEnabled', false);
+  },
+
+  isFeatureInteractivityEnabled: function () {
+    return !!this.get('isFeatureInteractivityEnabled');
+  },
+
+  enablePopups: function () {
+    this.set('popupsEnabled', true);
+  },
+
+  disablePopups: function () {
+    this.set('popupsEnabled', false);
+  },
+
+  arePopupsEnabled: function () {
+    return !!this.get('popupsEnabled');
+  },
+
   // INTERNAL CartoDB.js METHODS
 
   setView: function (latlng, zoom) {

--- a/src/geo/map/cartodb-layer.js
+++ b/src/geo/map/cartodb-layer.js
@@ -91,14 +91,11 @@ var CartoDBLayer = LayerModelBase.extend({
   },
 
   getInteractiveColumnNames: function () {
-    var fieldNames = _.union(
-      this.infowindow.getFieldNames(),
-      this.tooltip.getFieldNames()
-    );
-    if (fieldNames.length) {
-      fieldNames.unshift('cartodb_id');
-    }
-    return _.uniq(fieldNames);
+    return _.chain(['cartodb_id'])
+      .union(this.infowindow.getFieldNames())
+      .union(this.tooltip.getFieldNames())
+      .uniq()
+      .value();
   },
 
   getName: function () {

--- a/src/vis/infowindow-manager.js
+++ b/src/vis/infowindow-manager.js
@@ -35,14 +35,6 @@ InfowindowManager.prototype._addInfowindowForLayer = function (layerModel) {
       this._bindFeatureClickEvent(layerView);
     }
     this._bindInfowindowModel(layerView, layerModel);
-
-    layerView.bind('mouseover', function () {
-      this._mapView.setCursor('pointer');
-    }, this);
-
-    layerView.bind('mouseout', function (m, layer) {
-      this._mapView.setCursor('auto');
-    }, this);
   }
 };
 

--- a/src/vis/infowindow-manager.js
+++ b/src/vis/infowindow-manager.js
@@ -24,6 +24,7 @@ InfowindowManager.prototype.manage = function (mapView, map) {
   }, this);
   this._map.layers.each(this._addInfowindowForLayer, this);
   this._map.layers.bind('add', this._addInfowindowForLayer, this);
+  this._map.on('change:popupsEnabled', this._onPopupsEnabledChanged, this);
 };
 
 InfowindowManager.prototype._addInfowindowForLayer = function (layerModel) {
@@ -53,38 +54,40 @@ InfowindowManager.prototype._addInfowindowOverlay = function (layerView, layerMo
 
 InfowindowManager.prototype._bindFeatureClickEvent = function (layerView) {
   layerView.bind('featureClick', function (e, latlng, pos, data, layerIndex) {
-    var layerModel = layerView.model.getLayerAt(layerIndex);
-    if (!layerModel) {
-      throw new Error('featureClick event for layer ' + layerIndex + ' was captured but layerModel coudn\'t be retrieved');
-    }
-
-    if (!layerModel.infowindow.hasFields()) {
-      return;
-    }
-
-    this._updateInfowindowModel(layerModel.infowindow);
-
-    this._infowindowModel.set({
-      latlng: latlng,
-      visibility: true
-    });
-
-    this._fetchAttributes(layerView, layerModel, data.cartodb_id, latlng);
-
-    if (layerView.tooltipView) {
-      layerView.tooltipView.setFilter(function (feature) {
-        return feature.cartodb_id !== data.cartodb_id;
-      }).hide();
-    }
-
-    var clearFilter = function (infowindowModel) {
-      if (!infowindowModel.get('visibility')) {
-        layerView.tooltipView && layerView.tooltipView.setFilter(null);
+    if (this._map.arePopupsEnabled()) {
+      var layerModel = layerView.model.getLayerAt(layerIndex);
+      if (!layerModel) {
+        throw new Error('featureClick event for layer ' + layerIndex + ' was captured but layerModel coudn\'t be retrieved');
       }
-    };
 
-    this._infowindowModel.unbind('change:visibility', clearFilter);
-    this._infowindowModel.once('change:visibility', clearFilter);
+      if (!layerModel.infowindow.hasFields()) {
+        return;
+      }
+
+      this._updateInfowindowModel(layerModel.infowindow);
+
+      this._infowindowModel.set({
+        latlng: latlng,
+        visibility: true
+      });
+
+      this._fetchAttributes(layerView, layerModel, data.cartodb_id, latlng);
+
+      if (layerView.tooltipView) {
+        layerView.tooltipView.setFilter(function (feature) {
+          return feature.cartodb_id !== data.cartodb_id;
+        }).hide();
+      }
+
+      var clearFilter = function (infowindowModel) {
+        if (!infowindowModel.get('visibility')) {
+          layerView.tooltipView && layerView.tooltipView.setFilter(null);
+        }
+      };
+
+      this._infowindowModel.unbind('change:visibility', clearFilter);
+      this._infowindowModel.once('change:visibility', clearFilter);
+    }
   }, this);
 };
 
@@ -124,14 +127,14 @@ InfowindowManager.prototype._bindInfowindowModel = function (layerView, layerMod
       this._reloadVis();
     } else {
       if (this._isLayerInfowindowActiveAndVisible(layerModel)) {
-        this._infowindowModel.set('visibility', false);
+        this._hideInfowindow();
       }
     }
   }, this);
 
   layerModel.bind('change:visible', function () {
     if (this._isLayerInfowindowActiveAndVisible(layerModel)) {
-      this._infowindowModel.set('visibility', false);
+      this._hideInfowindow();
     }
   }, this);
 };
@@ -152,6 +155,16 @@ InfowindowManager.prototype._reloadVisAndFetchAttributes = function (layerView, 
       this._fetchAttributes(layerView, layerModel);
     }.bind(this)
   });
+};
+
+InfowindowManager.prototype._onPopupsEnabledChanged = function () {
+  if (this._map.arePopupsDisabled()) {
+    this._hideInfowindow();
+  }
+};
+
+InfowindowManager.prototype._hideInfowindow = function () {
+  this._infowindowModel && this._infowindowModel.set('visibility', false);
 };
 
 module.exports = InfowindowManager;

--- a/src/vis/tooltip-manager.js
+++ b/src/vis/tooltip-manager.js
@@ -69,7 +69,7 @@ TooltipManager.prototype._bindFeatureOverEvent = function (layerView) {
       throw new Error('featureOver event for layer ' + layerIndex + ' was captured but layerModel coudn\'t be retrieved');
     }
 
-    if (layerModel.tooltip.hasFields()) {
+    if (this._map.arePopupsEnabled() && layerModel.tooltip.hasFields()) {
       layerView.tooltipView.setTemplate(layerModel.tooltip.get('template'));
       layerView.tooltipView.setFields(layerModel.tooltip.fields.toJSON());
       layerView.tooltipView.setAlternativeNames(layerModel.tooltip.get('alternative_names'));

--- a/test/spec/geo/map-view.spec.js
+++ b/test/spec/geo/map-view.spec.js
@@ -1,4 +1,5 @@
 var $ = require('jquery');
+var _ = require('underscore');
 var Backbone = require('backbone');
 var VisModel = require('../../../src/vis/vis');
 var Map = require('../../../src/geo/map');
@@ -29,6 +30,7 @@ describe('core/geo/map-view', function () {
         layersCollection: this.map.layers
       })
     });
+    spyOn(this.mapView, 'setCursor');
 
     spyOn(this.mapView, 'getNativeMap');
     spyOn(this.mapView, '_addLayerToMap');
@@ -230,6 +232,90 @@ describe('core/geo/map-view', function () {
         this.map.layers.add(cartoDBLayer);
         expect(this.mapView.getLayerViewByLayerCid(cartoDBLayer.cid)).toBeDefined();
         expect(this.layerViewFactory.createLayerView.calls.count()).toBe(2);
+      });
+    });
+  });
+
+  describe('triggering of featureOver, featureOut and featureClick events', function () {
+    beforeEach(function () {
+      spyOn(this.map, 'isInteractive').and.returnValue(true);
+      this.layerViewFactory.createLayerView.and.callFake(function () {
+        var newLayerView = new Backbone.View();
+        newLayerView.setCursor = jasmine.createSpy('setCursor');
+        this.mapView.trigger('newLayerView', newLayerView);
+        return newLayerView;
+      }.bind(this));
+
+      this.cartoDBLayer = new CartoDBLayer({}, { vis: this.vis });
+      this.map.layers.reset([ this.cartoDBLayer ]);
+      this.layerView = this.mapView.getLayerViewByLayerCid(this.cartoDBLayer.cid);
+    });
+
+    _.each(['featureOver', 'featureClick'], function (eventName) {
+      describe(eventName, function () {
+        it('map model should trigger a ' + eventName + ' event', function () {
+          var callback = jasmine.createSpy('callback');
+          this.map.on(eventName, callback);
+
+          this.layerView.trigger(eventName, {}, [10, 20], { x: 15, y: 30 }, { cartodb_id: 30 }, 0);
+
+          expect(callback).toHaveBeenCalledWith({
+            layer: this.cartoDBLayer,
+            latlng: [10, 20],
+            position: {
+              x: 15,
+              y: 30
+            },
+            feature: { cartodb_id: 30 }
+          });
+        });
+
+        if (eventName === 'featureOver') {
+          it('should change the mouse pointer', function () {
+            this.layerView.trigger(eventName, {}, [10, 20], { x: 15, y: 30 }, { cartodb_id: 30 }, 0);
+
+            expect(this.mapView.setCursor).toHaveBeenCalledWith('pointer');
+          });
+        }
+
+        it("map model should NOT trigger an event and mouse point shouldn't change if map is not interactive", function () {
+          this.map.isInteractive.and.returnValue(false);
+          var callback = jasmine.createSpy('callback');
+          this.map.on(eventName, callback);
+
+          this.layerView.trigger(eventName, {}, [10, 20], { x: 15, y: 30 }, { cartodb_id: 30 }, 0);
+
+          expect(this.mapView.setCursor).not.toHaveBeenCalled();
+          expect(callback).not.toHaveBeenCalled();
+        });
+      });
+    }, this);
+
+    describe('featureOut', function () {
+      it('map model should trigger a featureOut event', function () {
+        var callback = jasmine.createSpy('callback');
+        this.map.on('featureOut', callback);
+
+        this.layerView.trigger('featureOut', {});
+
+        expect(callback).toHaveBeenCalledWith();
+      });
+
+      it('should change the mouse pointer', function () {
+        this.layerView.trigger('featureOut', {});
+
+        expect(this.mapView.setCursor).toHaveBeenCalledWith('auto');
+      });
+
+      it("map model should NOT trigger an event and mouse point shouldn't change if map is not interactive", function () {
+        this.map.isInteractive.and.returnValue(false);
+        var callback = jasmine.createSpy('callback');
+        this.map.on('featureOver', callback);
+
+        this.layerView.trigger('featureOver', {}, [10, 20], { x: 15, y: 30 }, { cartodb_id: 30 }, 0);
+
+        expect(this.mapView.setCursor).not.toHaveBeenCalled();
+        expect(callback).not.toHaveBeenCalled();
       });
     });
   });

--- a/test/spec/geo/map-view.spec.js
+++ b/test/spec/geo/map-view.spec.js
@@ -239,6 +239,8 @@ describe('core/geo/map-view', function () {
   describe('triggering of featureOver, featureOut and featureClick events', function () {
     beforeEach(function () {
       spyOn(this.map, 'isInteractive').and.returnValue(true);
+      this.map.enableFeatureInteractivity();
+
       this.layerViewFactory.createLayerView.and.callFake(function () {
         var newLayerView = new Backbone.View();
         newLayerView.setCursor = jasmine.createSpy('setCursor');
@@ -270,24 +272,31 @@ describe('core/geo/map-view', function () {
           });
         });
 
+        it('map model should NOT trigger an event if feature interactivity is disabled', function () {
+          this.map.disableFeatureInteractivity();
+          var callback = jasmine.createSpy('callback');
+          this.map.on(eventName, callback);
+
+          this.layerView.trigger(eventName, {}, [10, 20], { x: 15, y: 30 }, { cartodb_id: 30 }, 0);
+
+          expect(callback).not.toHaveBeenCalled();
+        });
+
         if (eventName === 'featureOver') {
           it('should change the mouse pointer', function () {
             this.layerView.trigger(eventName, {}, [10, 20], { x: 15, y: 30 }, { cartodb_id: 30 }, 0);
 
             expect(this.mapView.setCursor).toHaveBeenCalledWith('pointer');
           });
+
+          it('should NOT change the mouse pointer if map is not interactive', function () {
+            this.map.isInteractive.and.returnValue(false);
+
+            this.layerView.trigger(eventName, {}, [10, 20], { x: 15, y: 30 }, { cartodb_id: 30 }, 0);
+
+            expect(this.mapView.setCursor).not.toHaveBeenCalled();
+          });
         }
-
-        it("map model should NOT trigger an event and mouse point shouldn't change if map is not interactive", function () {
-          this.map.isInteractive.and.returnValue(false);
-          var callback = jasmine.createSpy('callback');
-          this.map.on(eventName, callback);
-
-          this.layerView.trigger(eventName, {}, [10, 20], { x: 15, y: 30 }, { cartodb_id: 30 }, 0);
-
-          expect(this.mapView.setCursor).not.toHaveBeenCalled();
-          expect(callback).not.toHaveBeenCalled();
-        });
       });
     }, this);
 
@@ -301,20 +310,30 @@ describe('core/geo/map-view', function () {
         expect(callback).toHaveBeenCalledWith();
       });
 
+      it('map model should NOT trigger an event if feature interactivity is disabled', function () {
+        this.map.disableFeatureInteractivity();
+        var callback = jasmine.createSpy('callback');
+        this.map.on('featureOver', callback);
+
+        this.layerView.trigger('featureOver', {}, [10, 20], { x: 15, y: 30 }, { cartodb_id: 30 }, 0);
+
+        expect(callback).not.toHaveBeenCalled();
+      });
+
       it('should change the mouse pointer', function () {
         this.layerView.trigger('featureOut', {});
 
         expect(this.mapView.setCursor).toHaveBeenCalledWith('auto');
       });
 
-      it("map model should NOT trigger an event and mouse point shouldn't change if map is not interactive", function () {
-        this.map.isInteractive.and.returnValue(false);
+      it('should NOT change the mouse pointer if feature interactivity is disabled', function () {
+        this.map.disableFeatureInteractivity();
+
         var callback = jasmine.createSpy('callback');
         this.map.on('featureOver', callback);
 
         this.layerView.trigger('featureOver', {}, [10, 20], { x: 15, y: 30 }, { cartodb_id: 30 }, 0);
 
-        expect(this.mapView.setCursor).not.toHaveBeenCalled();
         expect(callback).not.toHaveBeenCalled();
       });
     });

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -375,9 +375,11 @@ describe('core/geo/map', function () {
 
   describe('.isInteractive', function () {
     beforeEach(function () {
-      this.layer = new CartoDBLayer(null, { vis: new Backbone.Model() });
-      spyOn(this.layer, 'hasInteraction').and.returnValue(true);
-      this.layersCollection = new LayersCollection([ this.layer ]);
+      this.layer1 = new CartoDBLayer(null, { vis: new Backbone.Model() });
+      this.layer2 = new CartoDBLayer(null, { vis: new Backbone.Model() });
+      spyOn(this.layer1, 'hasInteraction').and.returnValue(false);
+      spyOn(this.layer2, 'hasInteraction').and.returnValue(false);
+      this.layersCollection = new LayersCollection([ this.layer1, this.layer2 ]);
       this.map = new Map(null, {
         layersCollection: this.layersCollection,
         layersFactory: fakeLayersFactory
@@ -397,10 +399,12 @@ describe('core/geo/map', function () {
     describe('if feature interactivity is disabled', function () {
       beforeEach(function () {
         this.map.disableFeatureInteractivity();
+        this.layer1.hasInteraction.and.returnValue(true);
+        this.layer2.hasInteraction.and.returnValue(true);
         this.map.enablePopups();
       });
 
-      it('should be true', function () {
+      it('should be true if popups are enabled', function () {
         expect(this.map.isInteractive()).toBeTruthy();
       });
 
@@ -409,8 +413,9 @@ describe('core/geo/map', function () {
         expect(this.map.isInteractive()).toBeFalsy();
       });
 
-      it("should be false if layer doesn't have interaction", function () {
-        this.layer.hasInteraction.and.returnValue(false);
+      it('should be false if none of the CartoDB layers have interaction', function () {
+        this.layer1.hasInteraction.and.returnValue(false);
+        this.layer2.hasInteraction.and.returnValue(false);
         expect(this.map.isInteractive()).toBeFalsy();
       });
     });

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -7,6 +7,7 @@ var TorqueLayer = require('../../../src/geo/map/torque-layer');
 var TileLayer = require('../../../src/geo/map/tile-layer');
 var WMSLayer = require('../../../src/geo/map/wms-layer');
 var GMapsBaseLayer = require('../../../src/geo/map/gmaps-base-layer');
+var LayersCollection = require('../../../src/geo/map/layers');
 var LayersFactory = require('../../../src/vis/layers-factory');
 
 var fakeLayersFactory = new LayersFactory({
@@ -369,6 +370,49 @@ describe('core/geo/map', function () {
     it('should return the corresponding model for given id', function () {
       expect(map.getLayerById('xyz-123')).toBeDefined();
       expect(map.getLayerById('meh')).toBeUndefined();
+    });
+  });
+
+  describe('.isInteractive', function () {
+    beforeEach(function () {
+      this.layer = new CartoDBLayer(null, { vis: new Backbone.Model() });
+      spyOn(this.layer, 'hasInteraction').and.returnValue(true);
+      this.layersCollection = new LayersCollection([ this.layer ]);
+      this.map = new Map(null, {
+        layersCollection: this.layersCollection,
+        layersFactory: fakeLayersFactory
+      });
+    });
+
+    it('should be false', function () {
+      expect(this.map.isInteractive()).toBeFalsy();
+    });
+
+    it('should be true if feature interactivity is enabled', function () {
+      this.map.enableFeatureInteractivity();
+
+      expect(this.map.isInteractive()).toBeTruthy();
+    });
+
+    describe('if feature interactivity is disabled', function () {
+      beforeEach(function () {
+        this.map.disableFeatureInteractivity();
+        this.map.enablePopups();
+      });
+
+      it('should be true', function () {
+        expect(this.map.isInteractive()).toBeTruthy();
+      });
+
+      it('should be false if popups are disabled', function () {
+        this.map.disablePopups();
+        expect(this.map.isInteractive()).toBeFalsy();
+      });
+
+      it("should be false if layer doesn't have interaction", function () {
+        this.layer.hasInteraction.and.returnValue(false);
+        expect(this.map.isInteractive()).toBeFalsy();
+      });
     });
   });
 });

--- a/test/spec/geo/map/cartodb-layer.spec.js
+++ b/test/spec/geo/map/cartodb-layer.spec.js
@@ -78,7 +78,7 @@ describe('geo/map/cartodb-layer', function () {
       expect(this.layer.getInteractiveColumnNames()).toEqual([ 'cartodb_id', 'a', 'b', 'c' ]);
     });
 
-    it('should return an empty array if no fields are present', function () {
+    it("should return the 'cartodb_id' if no fields are present", function () {
       this.layer = new CartoDBLayer({
         infowindow: {
           fields: []
@@ -88,7 +88,7 @@ describe('geo/map/cartodb-layer', function () {
         }
       }, { vis: this.vis });
 
-      expect(this.layer.getInteractiveColumnNames()).toEqual([]);
+      expect(this.layer.getInteractiveColumnNames()).toEqual([ 'cartodb_id' ]);
     });
   });
 });

--- a/test/spec/vis/tooltip-manager-spec.js
+++ b/test/spec/vis/tooltip-manager-spec.js
@@ -194,6 +194,43 @@ describe('src/vis/tooltip-manager.js', function () {
     expect(tooltipView.enable).toHaveBeenCalled();
   });
 
+  it('should disable the tooltip if popups are disabled', function () {
+    spyOn(this.mapView, 'addOverlay');
+
+    var layer1 = new CartoDBLayer({
+      tooltip: {
+        template: 'template1',
+        template_type: 'underscore',
+        fields: [{
+          'name': 'name',
+          'title': true,
+          'position': 1
+        }],
+        alternative_names: 'alternative_names1'
+      }
+    }, { vis: this.vis });
+
+    var tooltipManager = new TooltipManager(this.vis);
+    tooltipManager.manage(this.mapView, this.map);
+
+    this.map.layers.reset([ layer1 ]);
+    this.map.disablePopups();
+
+    expect(this.mapView.addOverlay).toHaveBeenCalled();
+    var tooltipView = this.mapView.addOverlay.calls.mostRecent().args[0];
+
+    spyOn(tooltipView, 'disable');
+
+    this.layerView.model = new CartoDBLayerGroup({}, {
+      layersCollection: new LayersCollection([ layer1 ])
+    });
+
+    // Simulate the featureOver event on layer #0
+    this.layerView.trigger('featureOver', {}, [100, 200], undefined, { cartodb_id: 10 }, 0);
+
+    expect(tooltipView.disable).toHaveBeenCalled();
+  });
+
   it('should bind the featureOver event to the corresponding layerView only once', function () {
     spyOn(this.mapView, 'addOverlay');
 

--- a/test/spec/windshaft/anonymous-map.spec.js
+++ b/test/spec/windshaft/anonymous-map.spec.js
@@ -99,7 +99,7 @@ describe('windshaft/anonymous-map', function () {
             'options': {
               'cartocss': 'cartoCSS1',
               'cartocss_version': '2.0',
-              'interactivity': [],
+              'interactivity': [ 'cartodb_id' ],
               'sql': 'sql1'
             }
           },
@@ -109,7 +109,7 @@ describe('windshaft/anonymous-map', function () {
             'options': {
               'cartocss': 'cartoCSS2',
               'cartocss_version': '2.0',
-              'interactivity': [],
+              'interactivity': [ 'cartodb_id' ],
               'sql': 'sql2'
             }
           },
@@ -119,7 +119,7 @@ describe('windshaft/anonymous-map', function () {
             'options': {
               'cartocss': 'cartoCSS3',
               'cartocss_version': '2.0',
-              'interactivity': [],
+              'interactivity': [ 'cartodb_id' ],
               'sql': 'sql3'
             }
           }
@@ -138,7 +138,7 @@ describe('windshaft/anonymous-map', function () {
         'options': {
           'cartocss': 'cartoCSS1',
           'cartocss_version': '2.0',
-          'interactivity': [],
+          'interactivity': [ 'cartodb_id' ],
           'sql': 'sql1',
           'sql_wrap': 'sql_wrap_1'
         }
@@ -173,7 +173,7 @@ describe('windshaft/anonymous-map', function () {
             'options': {
               'cartocss': 'cartoCSS2',
               'cartocss_version': '2.0',
-              'interactivity': [],
+              'interactivity': [ 'cartodb_id' ],
               'sql': 'sql2'
             }
           },
@@ -183,7 +183,7 @@ describe('windshaft/anonymous-map', function () {
             'options': {
               'cartocss': 'cartoCSS3',
               'cartocss_version': '2.0',
-              'interactivity': [],
+              'interactivity': [ 'cartodb_id' ],
               'sql': 'sql3'
             }
           }


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb.js/issues/1438.

This PR implements a mechanism to:

1. Enable/disable popups (enabled by default):
  ```
  vis.map.enablePopups
  vis.map.disablePopups
  vis.map.arePopupsEnabled
  vis.map.arePopupsDisabled
  ```

2. Enabled/disable "clickable features" (disabled by default).
  ```
  vis.map.enableFeatureInteractivity
  vis.map.disableFeatureInteractivity
  vis.map.isFeatureInteractivityEnabled
  ```

  When "clickable features" are enabled, `vis.map` triggers the following events:
  ```
  featureOver
  featureClick
  featureOut
  ```

Mouse cursor is now changed to `pointer` when "clickable features" are enabled or popups are enabled and any visible layer has popups (infowindow/tooltips).

In order for "clickable features" to work, all visible layers have interactivity enabled by default, and `cartodb_id` is always set as the interactivity field. This will cause the map instantiation to fail if the `sql` of a layer doesn't include the `cartodb_id`. I opened https://github.com/CartoDB/cartodb.js/issues/1446 to discuss/fix this.

@matallo would you please take a look? thx!