### PR TITLE
Fine tune layer selector

### DIFF
--- a/src/api/create-vis.js
+++ b/src/api/create-vis.js
@@ -64,9 +64,9 @@ var loadVizJSON = function (el, visModel, vizjsonData, options) {
     showLayerSelector = vizjson.options.layer_selector;
   }
 
-  var isEmbed = true;
-  if (_.isBoolean(options.embedMode)) {
-    isEmbed = options.embedMode;
+  var layerSelectorEnabled = true;
+  if (_.isBoolean(options.layerSelectorEnabled)) {
+    layerSelectorEnabled = options.layerSelectorEnabled;
   }
 
   visModel.set({
@@ -75,13 +75,13 @@ var loadVizJSON = function (el, visModel, vizjsonData, options) {
     apiKey: options.apiKey,
     authToken: options.authToken,
     showEmptyInfowindowFields: options.show_empty_infowindow_fields === true,
-    https: isProtocolHTTPs || options.https === true || vizjson.https === true,
-    isEmbed: isEmbed
+    https: isProtocolHTTPs || options.https === true || vizjson.https === true
   });
 
   visModel.setSettings({
     showLegends: showLegends,
-    showLayerSelector: showLayerSelector
+    showLayerSelector: showLayerSelector,
+    layerSelectorEnabled: layerSelectorEnabled
   });
 
   new VisView({ // eslint-disable-line

--- a/src/api/create-vis.js
+++ b/src/api/create-vis.js
@@ -64,7 +64,7 @@ var loadVizJSON = function (el, visModel, vizjsonData, options) {
     showLayerSelector = vizjson.options.layer_selector;
   }
 
-  var isEmbed = false;
+  var isEmbed = true;
   if (_.isBoolean(options.embedMode)) {
     isEmbed = options.embedMode;
   }

--- a/src/api/create-vis.js
+++ b/src/api/create-vis.js
@@ -64,13 +64,19 @@ var loadVizJSON = function (el, visModel, vizjsonData, options) {
     showLayerSelector = vizjson.options.layer_selector;
   }
 
+  var isEmbed = false;
+  if (_.isBoolean(options.embedMode)) {
+    isEmbed = options.embedMode;
+  }
+
   visModel.set({
     title: options.title || vizjson.title,
     description: options.description || vizjson.description,
     apiKey: options.apiKey,
     authToken: options.authToken,
     showEmptyInfowindowFields: options.show_empty_infowindow_fields === true,
-    https: isProtocolHTTPs || options.https === true || vizjson.https === true
+    https: isProtocolHTTPs || options.https === true || vizjson.https === true,
+    isEmbed: isEmbed
   });
 
   visModel.setSettings({

--- a/src/geo/ui/legends/base/legend-view-base.js
+++ b/src/geo/ui/legends/base/legend-view-base.js
@@ -89,14 +89,6 @@ var LegendViewBase = Backbone.View.extend({
     return sanitize.html(html);
   },
 
-  enable: function () {
-    this.$el.removeClass('is-disabled');
-  },
-
-  disable: function () {
-    this.$el.addClass('is-disabled');
-  },
-
   _toggleLoadingClass: function () {
     this.$el.toggleClass('is-loading', this.model.isLoading());
   }

--- a/src/geo/ui/legends/layer-legends-template.tpl
+++ b/src/geo/ui/legends/layer-legends-template.tpl
@@ -1,14 +1,14 @@
 <h2 class="CDB-Text CDB-Size-medium is-semibold u-bSpace--xl u-flex u-alignCenter">
+  <% if (showLayerSelector) { %>
   <span class="u-iBlock u-rSpace--m">
-    <% if (showLayerSelector) { %>
       <% if (isLayerVisible) { %>
         <input class="CDB-Checkbox js-toggle-layer" type="checkbox" checked>
       <% } else { %>
         <input class="CDB-Checkbox js-toggle-layer" type="checkbox">
       <% } %>
     <span class="u-iBlock CDB-Checkbox-face"></span>
-    <% } %>
   </span>
+  <% } %>
   <span class="u-ellipsis"><%- layerName %></span>
 </h2>
 

--- a/src/geo/ui/legends/layer-legends-template.tpl
+++ b/src/geo/ui/legends/layer-legends-template.tpl
@@ -1,3 +1,4 @@
+<% if (shouldVisible) { %>
 <h2 class="CDB-Text CDB-Size-medium is-semibold u-bSpace--xl u-flex u-alignCenter">
   <% if (showLayerSelector) { %>
   <span class="u-iBlock u-rSpace--m">
@@ -14,4 +15,5 @@
 
 <% if (showLegends) { %>
 <div class="Legends js-legends"></div>
+<% } %>
 <% } %>

--- a/src/geo/ui/legends/layer-legends-template.tpl
+++ b/src/geo/ui/legends/layer-legends-template.tpl
@@ -1,4 +1,3 @@
-<% if (shouldVisible) { %>
 <h2 class="CDB-Text CDB-Size-medium is-semibold u-bSpace--xl u-flex u-alignCenter">
   <% if (showLayerSelector) { %>
   <span class="u-iBlock u-rSpace--m">
@@ -15,5 +14,4 @@
 
 <% if (showLegends) { %>
 <div class="Legends js-legends"></div>
-<% } %>
 <% } %>

--- a/src/geo/ui/legends/layer-legends-view.js
+++ b/src/geo/ui/legends/layer-legends-view.js
@@ -15,6 +15,8 @@ var LayerLegendsView = Backbone.View.extend({
     this._legendViews = [];
 
     this.settingsModel = options.settingsModel;
+    this._isEmbed = options.isEmbed;
+
     this.tryContainerVisibility = options.tryContainerVisibility;
 
     this.model.on('change:visible', this._onLayerVisibilityChanged, this);
@@ -30,7 +32,7 @@ var LayerLegendsView = Backbone.View.extend({
 
   render: function () {
     var showLegends = this.settingsModel.get('showLegends');
-    var showLayerSelector = this.settingsModel.get('showLayerSelector');
+    var showLayerSelector = this._shouldLayerSelectorBeVisible();
     var shouldVisible = showLayerSelector || this.model.legends.hasAnyLegend() && showLegends;
 
     if (shouldVisible) {
@@ -50,6 +52,19 @@ var LayerLegendsView = Backbone.View.extend({
 
     this.tryContainerVisibility();
     return this;
+  },
+
+  _shouldLayerSelectorBeVisible: function () {
+    var isEmbed = this._isEmbed;
+    var isSettingsView = !!this.settingsModel.get('settingsView');
+    var showLayerSelector = this.settingsModel.get('showLayerSelector');
+    var shouldVisible = showLayerSelector;
+
+    if (!isEmbed) {
+      shouldVisible = isSettingsView && showLayerSelector;
+    }
+
+    return shouldVisible;
   },
 
   _renderLegends: function () {

--- a/src/geo/ui/legends/layer-legends-view.js
+++ b/src/geo/ui/legends/layer-legends-view.js
@@ -33,18 +33,20 @@ var LayerLegendsView = Backbone.View.extend({
     var showLayerSelector = this._shouldLayerSelectorBeVisible();
     var shouldVisible = this._shouldLayerLegendsBeVisible();
 
-    this.$el.html(
-      template({
-        shouldVisible: shouldVisible,
-        layerName: this.model.getName(),
-        isLayerVisible: this._isLayerVisible(),
-        showLegends: showLegends,
-        showLayerSelector: showLayerSelector
-      })
-    );
-
     if (shouldVisible) {
+      this.$el.html(
+        template({
+          shouldVisible: shouldVisible,
+          layerName: this.model.getName(),
+          isLayerVisible: this._isLayerVisible(),
+          showLegends: showLegends,
+          showLayerSelector: showLayerSelector
+        })
+      );
+
       this._renderLegends();
+    } else {
+      this.$el.html('');
     }
 
     this.tryContainerVisibility();
@@ -57,19 +59,9 @@ var LayerLegendsView = Backbone.View.extend({
   },
 
   _shouldLayerLegendsBeVisible: function () {
-    var isLayerSelectorEnabled = this.settingsModel.get('layerSelectorEnabled');
-    var showLayerSelector = this.settingsModel.get('showLayerSelector');
     var showLegends = this.settingsModel.get('showLegends');
     var hasLegends = this.model.legends.hasAnyLegend();
-    var shouldVisible;
-
-    if (!isLayerSelectorEnabled) {
-      shouldVisible = this._isLayerVisible() && showLegends && hasLegends;
-    } else {
-      shouldVisible = showLayerSelector || this._isLayerVisible() && showLegends && hasLegends;
-    }
-
-    return shouldVisible;
+    return this._shouldLayerSelectorBeVisible() || (this._isLayerVisible() && showLegends && hasLegends);
   },
 
   _shouldLayerSelectorBeVisible: function () {

--- a/src/geo/ui/legends/layer-legends-view.js
+++ b/src/geo/ui/legends/layer-legends-view.js
@@ -15,8 +15,6 @@ var LayerLegendsView = Backbone.View.extend({
     this._legendViews = [];
 
     this.settingsModel = options.settingsModel;
-    this._isEmbed = options.isEmbed;
-
     this.tryContainerVisibility = options.tryContainerVisibility;
 
     this.model.on('change:visible', this.render, this);
@@ -59,19 +57,14 @@ var LayerLegendsView = Backbone.View.extend({
   },
 
   _shouldLayerLegendsBeVisible: function () {
-    var isEmbed = this._isEmbed;
+    var isLayerSelectorEnabled = this.settingsModel.get('layerSelectorEnabled');
     var showLayerSelector = this.settingsModel.get('showLayerSelector');
     var showLegends = this.settingsModel.get('showLegends');
-    var isSettingsView = !!this.settingsModel.get('settingsView');
     var hasLegends = this.model.legends.hasAnyLegend();
     var shouldVisible;
 
-    if (!isEmbed) {
-      if (!isSettingsView) {
-        shouldVisible = this._isLayerVisible() && showLegends && hasLegends;
-      } else {
-        shouldVisible = showLayerSelector || this._isLayerVisible() && showLegends && hasLegends;
-      }
+    if (!isLayerSelectorEnabled) {
+      shouldVisible = this._isLayerVisible() && showLegends && hasLegends;
     } else {
       shouldVisible = showLayerSelector || this._isLayerVisible() && showLegends && hasLegends;
     }
@@ -80,14 +73,9 @@ var LayerLegendsView = Backbone.View.extend({
   },
 
   _shouldLayerSelectorBeVisible: function () {
-    var isEmbed = this._isEmbed;
-    var isSettingsView = !!this.settingsModel.get('settingsView');
+    var isLayerSelectorEnabled = this.settingsModel.get('layerSelectorEnabled');
     var showLayerSelector = this.settingsModel.get('showLayerSelector');
-    var shouldVisible = showLayerSelector;
-
-    if (!isEmbed) {
-      shouldVisible = isSettingsView && showLayerSelector;
-    }
+    var shouldVisible = showLayerSelector && isLayerSelectorEnabled;
 
     return shouldVisible;
   },

--- a/src/geo/ui/legends/layer-legends-view.js
+++ b/src/geo/ui/legends/layer-legends-view.js
@@ -23,6 +23,7 @@ var LayerLegendsView = Backbone.View.extend({
     this.model.on('change:layer_name', this.render, this);
 
     this._getLegendModels().forEach(function (model) {
+      model.on('change:state', _.debounce(this.render, 150), this);
       model.on('change:visible', _.debounce(this.render, 150), this);
     }, this);
 

--- a/src/geo/ui/legends/layer-legends-view.js
+++ b/src/geo/ui/legends/layer-legends-view.js
@@ -23,7 +23,6 @@ var LayerLegendsView = Backbone.View.extend({
     this.model.on('change:layer_name', this.render, this);
 
     this._getLegendModels().forEach(function (model) {
-      model.on('change:state', _.debounce(this.render, 150), this);
       model.on('change:visible', _.debounce(this.render, 150), this);
     }, this);
 

--- a/src/geo/ui/legends/legends-view.js
+++ b/src/geo/ui/legends/legends-view.js
@@ -14,7 +14,7 @@ var LegendsView = Backbone.View.extend({
     this._layersCollection = options.layersCollection;
 
     this._isRendered = false;
-
+    this._isEmbed = options.isEmbed;
     this.settingsModel = options.settingsModel;
     this._initBinds();
   },
@@ -94,6 +94,7 @@ var LegendsView = Backbone.View.extend({
     var layerLegendsView = new LayerLegendsView({
       model: layerModel,
       settingsModel: this.settingsModel,
+      isEmbed: this._isEmbed,
       tryContainerVisibility: this._tryVisibility.bind(this)
     });
 

--- a/src/geo/ui/legends/legends-view.js
+++ b/src/geo/ui/legends/legends-view.js
@@ -14,7 +14,6 @@ var LegendsView = Backbone.View.extend({
     this._layersCollection = options.layersCollection;
 
     this._isRendered = false;
-    this._isEmbed = options.isEmbed;
     this.settingsModel = options.settingsModel;
     this._initBinds();
   },
@@ -94,7 +93,6 @@ var LegendsView = Backbone.View.extend({
     var layerLegendsView = new LayerLegendsView({
       model: layerModel,
       settingsModel: this.settingsModel,
-      isEmbed: this._isEmbed,
       tryContainerVisibility: this._tryVisibility.bind(this)
     });
 

--- a/src/vis/vis-view.js
+++ b/src/vis/vis-view.js
@@ -85,8 +85,7 @@ var Vis = View.extend({
   _renderLegends: function () {
     this._legendsView = new LegendsView({
       layersCollection: this.model.map.layers,
-      settingsModel: this.settingsModel,
-      isEmbed: this.model.get('isEmbed')
+      settingsModel: this.settingsModel
     });
 
     this.$el.append(this._legendsView.render().$el);

--- a/src/vis/vis-view.js
+++ b/src/vis/vis-view.js
@@ -85,7 +85,8 @@ var Vis = View.extend({
   _renderLegends: function () {
     this._legendsView = new LegendsView({
       layersCollection: this.model.map.layers,
-      settingsModel: this.settingsModel
+      settingsModel: this.settingsModel,
+      isEmbed: this.model.get('isEmbed')
     });
 
     this.$el.append(this._legendsView.render().$el);

--- a/test/spec/geo/ui/legends/layer-legends-view.spec.js
+++ b/test/spec/geo/ui/legends/layer-legends-view.spec.js
@@ -10,7 +10,8 @@ describe('geo/ui/legends/layer-legends-view', function () {
 
     this.settingsModel = new Backbone.Model({
       showLegends: true,
-      showLayerSelector: true
+      showLayerSelector: true,
+      layerSelectorEnabled: true
     });
 
     this.cartoDBLayer = new CartoDBLayer({
@@ -24,7 +25,6 @@ describe('geo/ui/legends/layer-legends-view', function () {
     this.tryContainerVisibility = jasmine.createSpy('tryContainerVisibility');
 
     this.layerLegendsView = new LayerLegendsView({
-      isEmbed: true,
       model: this.cartoDBLayer,
       settingsModel: this.settingsModel,
       tryContainerVisibility: this.tryContainerVisibility
@@ -93,7 +93,7 @@ describe('geo/ui/legends/layer-legends-view', function () {
   });
 
   it('should not render layer selector checkbox if not embed', function () {
-    this.layerLegendsView._isEmbed = false;
+    this.settingsModel.set('layerSelectorEnabled', false);
     this.layerLegendsView.render();
     expect(this.layerLegendsView.$('.js-toggle-layer').length).toBe(0);
   });

--- a/test/spec/geo/ui/legends/layer-legends-view.spec.js
+++ b/test/spec/geo/ui/legends/layer-legends-view.spec.js
@@ -24,13 +24,13 @@ describe('geo/ui/legends/layer-legends-view', function () {
     this.tryContainerVisibility = jasmine.createSpy('tryContainerVisibility');
 
     this.layerLegendsView = new LayerLegendsView({
+      isEmbed: true,
       model: this.cartoDBLayer,
       settingsModel: this.settingsModel,
       tryContainerVisibility: this.tryContainerVisibility
     });
 
     this.layerLegendsView.render();
-    this.toggleLayerCheck = this.layerLegendsView.$('.js-toggle-layer');
 
     $('body').append(this.layerLegendsView.$el);
   });
@@ -56,42 +56,33 @@ describe('geo/ui/legends/layer-legends-view', function () {
   it('should hide/show the layer if check next to title is clicked', function () {
     expect(this.cartoDBLayer.isVisible()).toBeTruthy();
 
-    this.toggleLayerCheck.trigger('click');
+    this.layerLegendsView.$('.js-toggle-layer').trigger('click');
 
     expect(this.cartoDBLayer.isVisible()).toBeFalsy();
 
-    this.toggleLayerCheck.trigger('click');
+    this.layerLegendsView.$('.js-toggle-layer').trigger('click');
 
     expect(this.cartoDBLayer.isVisible()).toBeTruthy();
   });
 
   it('should uncheck/check the check if layer is hidden/shown', function () {
-    expect(this.toggleLayerCheck.is(':checked')).toBe(true);
+    expect(this.layerLegendsView.$('.js-toggle-layer').is(':checked')).toBe(true);
 
     this.cartoDBLayer.hide();
 
-    expect(this.toggleLayerCheck.is(':checked')).toBe(false);
+    expect(this.layerLegendsView.$('.js-toggle-layer').is(':checked')).toBe(false);
 
     this.cartoDBLayer.show();
 
-    expect(this.toggleLayerCheck.is(':checked')).toBe(true);
+    expect(this.layerLegendsView.$('.js-toggle-layer').is(':checked')).toBe(true);
   });
 
-  it('should disable/enable itself and legend views when layer is hidden/shown', function () {
-    expect(this.layerLegendsView.$el.hasClass('is-disabled')).toBeFalsy();
-    expect(this.layerLegendsView.$('.is-disabled').length).toEqual(0);
-
+  it('should hide/show legend views when layer is hidden/shown', function () {
     this.cartoDBLayer.hide();
-
-    // View is disabled
-    expect(this.layerLegendsView.$el.hasClass('is-disabled')).toBeTruthy();
-    // Legend views are also disabled
-    expect(this.layerLegendsView.$('.is-disabled').length).toEqual(5);
+    expect(this.layerLegendsView.$('.js-legends').length).toBe(0);
 
     this.cartoDBLayer.show();
-
-    expect(this.layerLegendsView.$el.hasClass('is-disabled')).toBeFalsy();
-    expect(this.layerLegendsView.$('.is-disabled').length).toEqual(0);
+    expect(this.layerLegendsView.$('.js-legends').length).toBe(1);
   });
 
   it('should be hidden if no legends are rendered', function () {
@@ -99,5 +90,11 @@ describe('geo/ui/legends/layer-legends-view', function () {
     this.settingsModel.set('showLayerSelector', false);
     this.layerLegendsView.render();
     expect(this.layerLegendsView.$el.is(':empty')).toBe(true);
+  });
+
+  it('should not render layer selector checkbox if not embed', function () {
+    this.layerLegendsView._isEmbed = false;
+    this.layerLegendsView.render();
+    expect(this.layerLegendsView.$('.js-toggle-layer').length).toBe(0);
   });
 });

--- a/test/spec/geo/ui/legends/legends-view.spec.js
+++ b/test/spec/geo/ui/legends/legends-view.spec.js
@@ -24,7 +24,8 @@ describe('geo/ui/legends/legends-view', function () {
 
     this.legendsView = new LegendsView({
       layersCollection: this.layersCollection,
-      settingsModel: this.settingsModel
+      settingsModel: this.settingsModel,
+      isEmbed: true
     });
 
     this.legendsView.render();

--- a/test/spec/geo/ui/legends/legends-view.spec.js
+++ b/test/spec/geo/ui/legends/legends-view.spec.js
@@ -19,13 +19,13 @@ describe('geo/ui/legends/legends-view', function () {
 
     this.settingsModel = new Backbone.Model({
       showLegends: true,
-      showLayerSelector: true
+      showLayerSelector: true,
+      layerSelectorEnabled: true
     });
 
     this.legendsView = new LegendsView({
       layersCollection: this.layersCollection,
-      settingsModel: this.settingsModel,
-      isEmbed: true
+      settingsModel: this.settingsModel
     });
 
     this.legendsView.render();

--- a/themes/scss/map/overlays.scss
+++ b/themes/scss/map/overlays.scss
@@ -235,15 +235,15 @@ $maxLegendContainerHeight: 300px;
   z-index: 20000;
 }
 .CDB-Legends-canvasInner {
+  position: relative;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  max-height: calc(100vh - 20px);
   padding: 12px 24px;
   border-radius: $baseSize / 2;
   box-sizing: border-box;
-  position: relative;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  max-height: calc(100vh - 20px);
   overflow: hidden;
 }
 .CDB-Legends-canvasShadow {

--- a/themes/scss/map/overlays.scss
+++ b/themes/scss/map/overlays.scss
@@ -231,20 +231,20 @@ $maxLegendContainerHeight: 300px;
   background: #FFF;
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.24);
   box-sizing: border-box;
-  z-index: 20000;
   overflow: hidden;
+  z-index: 20000;
 }
 .CDB-Legends-canvasInner {
-  overflow: hidden;
   padding: 12px 24px;
   border-radius: $baseSize / 2;
   box-sizing: border-box;
   position: relative;
-  top: 0px;
-  left: 0px;
-  right: 0px;
-  bottom: 0px;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
   max-height: calc(100vh - 20px);
+  overflow: hidden;
 }
 .CDB-Legends-canvasShadow {
   display: none;
@@ -291,7 +291,11 @@ $maxLegendContainerHeight: 300px;
 }
 
 .CDB-LayerLegends {
-  margin-top: 12px;
+  margin-bottom: 12px;
+}
+
+.CDB-LayerLegends:empty {
+  margin-bottom: 0;
 }
 
 .CDB-Legend-item {

--- a/themes/scss/map/overlays.scss
+++ b/themes/scss/map/overlays.scss
@@ -236,7 +236,7 @@ $maxLegendContainerHeight: 300px;
 }
 .CDB-Legends-canvasInner {
   overflow: hidden;
-  padding: 24px;
+  padding: 12px 24px;
   border-radius: $baseSize / 2;
   box-sizing: border-box;
   position: relative;
@@ -293,14 +293,9 @@ $maxLegendContainerHeight: 300px;
 .CDB-LayerLegends {
   margin-top: 12px;
 }
-.CDB-LayerLegends:first-child {
-  margin-top: 0;
-}
+
 .CDB-Legend-item {
   margin-bottom: 16px;
-  &:last-child {
-    margin-bottom: 32px;
-  }
 }
 
 .CDB-Legend-item.is-disabled {


### PR DESCRIPTION
This PR fixes cartodb.js side of https://github.com/CartoDB/cartodb/issues/10093

In addition to the issue's description, the layer selector should only be visible in the settings view in the Builder. That's why we need to segment when the vis is rendered from an embed view (by default) or by Builder.

cc @alonsogarciapablo @xavijam 