### PR TITLE
Fix avg position.

### DIFF
--- a/src/geo/ui/legends/bubble/legend-view.js
+++ b/src/geo/ui/legends/bubble/legend-view.js
@@ -71,7 +71,8 @@ var BubbleLegendView = LegendViewBase.extend({
   _calculateAverageSize: function () {
     var values = this.model.get('values').slice(0);
     var maxValue = _.max(values);
-    return this.model.get('avg') * 100 / maxValue;
+    var minValue = _.min(values);
+    return (this.model.get('avg') - minValue) * 100 / (maxValue - minValue);
   }
 });
 

--- a/themes/scss/map/overlays.scss
+++ b/themes/scss/map/overlays.scss
@@ -326,7 +326,9 @@ $maxLegendContainerHeight: 300px;
 
 .Bubble-item {
   @include opacity(0.5);
+  @include transform(translateX(-50%));
   position: absolute;
+  left: 50%;
   bottom: 0;
   cursor: pointer;
 }

--- a/themes/scss/map/overlays.scss
+++ b/themes/scss/map/overlays.scss
@@ -328,8 +328,8 @@ $maxLegendContainerHeight: 300px;
   @include opacity(0.5);
   @include transform(translateX(-50%));
   position: absolute;
-  left: 50%;
   bottom: 0;
+  left: 50%;
   cursor: pointer;
 }
 


### PR DESCRIPTION
This PR fixes #1452. Also, it fixes the avg label position for bubbles. In the same manner we did for choropleths, we are including the full range to calculate the position, not assuming that the min value is always 0.

Before:

![screen shot 2016-10-20 at 11 59 43](https://cloud.githubusercontent.com/assets/1366843/19555472/39f831ec-96bd-11e6-9b1e-5957b191e5c5.png)

After:

![screen shot 2016-10-20 at 12 00 03](https://cloud.githubusercontent.com/assets/1366843/19555457/2bada806-96bd-11e6-9d4f-a5e364172dc6.png)

CR @alonsogarciapablo @piensaenpixel 