### PR TITLE
Improve precision

### DIFF
--- a/src/geo/ui/legends/bubble/legend-view.js
+++ b/src/geo/ui/legends/bubble/legend-view.js
@@ -85,7 +85,7 @@ var BubbleLegendView = LegendViewBase.extend({
 
     // Inside the range, we position it lineal
     var offset = (avg - values[index - 1]) / (values[index] - values[index - 1]);
-    return minValue + maxValue * offset;
+    return minValue + (maxValue - minValue) * offset;
   }
 });
 

--- a/src/geo/ui/legends/bubble/legend-view.js
+++ b/src/geo/ui/legends/bubble/legend-view.js
@@ -69,10 +69,23 @@ var BubbleLegendView = LegendViewBase.extend({
   },
 
   _calculateAverageSize: function () {
+    var sizes = this._calculateBubbleSizes().reverse();
+    sizes.unshift(0);
+
     var values = this.model.get('values').slice(0);
-    var maxValue = _.max(values);
-    var minValue = _.min(values);
-    return (this.model.get('avg') - minValue) * 100 / (maxValue - minValue);
+    var avg = this.model.get('avg');
+
+    // we need to position it in the rigth range
+    var index = _.reduce(values, function (memo, value, index) {
+      return value > avg ? memo : index + 1;
+    }, 0);
+
+    var minValue = sizes[index - 1];
+    var maxValue = sizes[index];
+
+    // Inside the range, we position it lineal
+    var offset = (avg - values[index - 1]) / (values[index] - values[index - 1]);
+    return minValue + maxValue * offset;
   }
 });
 

--- a/src/geo/ui/legends/bubble/legend-view.js
+++ b/src/geo/ui/legends/bubble/legend-view.js
@@ -69,17 +69,30 @@ var BubbleLegendView = LegendViewBase.extend({
   },
 
   _calculateAverageSize: function () {
+    // we build the size range, and reverse it to be able to normalize it with values.
     var sizes = this._calculateBubbleSizes().reverse();
+
+    // we put 0 as the initial of the range
     sizes.unshift(0);
 
+    // we need values and sizes because avg is a value and we need to place it taking sizes as reference.
     var values = this.model.get('values').slice(0);
     var avg = this.model.get('avg');
 
-    // we need to position it in the rigth range
+    // we need to position it in the right range
+    // this reduce thing search the index of the range (index base) that avg belongs to
+    // while avg is greater than the current value, memo is the next index, if not, memo doesn't change anymore
+    // index + 1 because we pushed 0 to sizes and we need both arrays to have the same length
     var index = _.reduce(values, function (memo, value, index) {
       return value > avg ? memo : index + 1;
     }, 0);
 
+    // avg it's at least equal to the last item
+    if (index === values.length) {
+      return 100;
+    }
+
+    // with the index calculate above, we get the % of the sizes we have to place the avg
     var minValue = sizes[index - 1];
     var maxValue = sizes[index];
 

--- a/src/geo/ui/legends/choropleth/legend-template.tpl
+++ b/src/geo/ui/legends/choropleth/legend-template.tpl
@@ -1,10 +1,9 @@
 <div class="u-flex u-justifySpace u-bSpace--m">
-  <p class="CDB-Text CDB-Size-small"><%- prefix %> <%= formatter.formatNumber(colors[0].label) %> <%- suffix %></p>
-  <p class="CDB-Text CDB-Size-small"><%- prefix %> <%= formatter.formatNumber(colors[colors.length-1].label) %> <%- suffix %></p>
+  <p class="CDB-Text CDB-Size-small"><%- prefix %> <%= formatter.formatNumber(colors[0].label * 1) %> <%- suffix %></p>
+  <p class="CDB-Text CDB-Size-small"><%- prefix %> <%= formatter.formatNumber(colors[colors.length-1].label * 1) %> <%- suffix %></p>
 </div>
 <div class="Legend-choropleth" style="background: linear-gradient(90deg <% for(var i in colors) { %>,<%= colors[i].value %><% } %>)">
   <span class="Legend-choroplethAverage CDB-Text CDB-Size-small u-altTextColor" style="left: <%- avgPercentage %>%;">
-    <span class="Legend-choroplethAverageText"><%- formatter.formatNumber(avg) %> AVG</span>
+    <span class="Legend-choroplethAverageText"><%= formatter.formatNumber(avg * 1) %> AVG</span>
   </span>
 </div>
- 

--- a/src/geo/ui/legends/choropleth/legend-template.tpl
+++ b/src/geo/ui/legends/choropleth/legend-template.tpl
@@ -1,9 +1,9 @@
 <div class="u-flex u-justifySpace u-bSpace--m">
-  <p class="CDB-Text CDB-Size-small"><%- prefix %> <%= formatter.formatNumber(colors[0].label * 1) %> <%- suffix %></p>
-  <p class="CDB-Text CDB-Size-small"><%- prefix %> <%= formatter.formatNumber(colors[colors.length-1].label * 1) %> <%- suffix %></p>
+  <p class="CDB-Text CDB-Size-small"><%- prefix %> <%= formatter.formatNumber(colors[0].label) %> <%- suffix %></p>
+  <p class="CDB-Text CDB-Size-small"><%- prefix %> <%= formatter.formatNumber(colors[colors.length-1].label) %> <%- suffix %></p>
 </div>
 <div class="Legend-choropleth" style="background: linear-gradient(90deg <% for(var i in colors) { %>,<%= colors[i].value %><% } %>)">
   <span class="Legend-choroplethAverage CDB-Text CDB-Size-small u-altTextColor" style="left: <%- avgPercentage %>%;">
-    <span class="Legend-choroplethAverageText"><%= formatter.formatNumber(avg * 1) %> AVG</span>
+    <span class="Legend-choroplethAverageText"><%= formatter.formatNumber(avg) %> AVG</span>
   </span>
 </div>

--- a/src/util/formatter.js
+++ b/src/util/formatter.js
@@ -3,12 +3,27 @@ var d3 = require('d3');
 
 var format = {};
 
+var formatExponential = function (value) {
+  if (!_.isNumber(value)) {
+    value = value * 1;
+  }
+
+  var template = _.template('<%= mantissa %><span class="Legend-choroplethSup">x</span>10<sup class="Legend-choroplethSup"><%= decimals %></sup>');
+  var exp = value.toExponential(10);
+  var parts = exp.split('e');
+  return template({
+    mantissa: (parts[0] * 1).toFixed(1),
+    decimals: parts[1] || 0
+  });
+};
+
 format.formatNumber = function (value, unit) {
   if (!_.isNumber(value) || value === 0) {
     return value;
   }
 
   var format = d3.format('.2s');
+
   var p = 0;
   var abs_v = Math.abs(value);
 
@@ -17,9 +32,19 @@ format.formatNumber = function (value, unit) {
     return value;
   }
 
+  if (value < 0 && value <= 0.1) {
+    value = value + (unit ? ' ' + unit : '');
+    return value;
+  }
+
+  if (value < 0.1) {
+    value = formatExponential(value) + (unit ? ' ' + unit : '');
+    return value;
+  }
+
   if (abs_v > 100) {
     p = 0;
-  } else if (abs_v > 1) {
+  } else if (abs_v > 10) {
     p = 1;
   } else if (abs_v > 0) {
     p = Math.min(Math.ceil(Math.abs(Math.log(abs_v) / Math.log(10))) + 2, 2);

--- a/src/util/formatter.js
+++ b/src/util/formatter.js
@@ -4,11 +4,7 @@ var d3 = require('d3');
 var format = {};
 
 var formatExponential = function (value) {
-  if (!_.isNumber(value)) {
-    value = value * 1;
-  }
-
-  var template = _.template('<%= mantissa %><span class="Legend-choroplethSup">x</span>10<sup class="Legend-choroplethSup"><%= decimals %></sup>');
+  var template = _.template('<%= mantissa %><span class="Legend-exponential">x</span>10<sup class="Legend-exponential"><%= decimals %></sup>');
   var exp = value.toExponential(10);
   var parts = exp.split('e');
   return template({
@@ -18,9 +14,13 @@ var formatExponential = function (value) {
 };
 
 format.formatNumber = function (value, unit) {
-  if (!_.isNumber(value) || value === 0) {
+  // we are using here the unary operator because parseInt fails to handle exponential number
+  var converted = +value;
+  if (isNaN(converted) || converted === 0) {
     return value;
   }
+
+  value = converted;
 
   var format = d3.format('.2s');
 
@@ -32,12 +32,7 @@ format.formatNumber = function (value, unit) {
     return value;
   }
 
-  if (value < 0 && value <= 0.1) {
-    value = value + (unit ? ' ' + unit : '');
-    return value;
-  }
-
-  if (value < 0.1) {
+  if (abs_v < 0.001) {
     value = formatExponential(value) + (unit ? ' ' + unit : '');
     return value;
   }

--- a/test/spec/geo/ui/legends/bubble/legend-view-spec.js
+++ b/test/spec/geo/ui/legends/bubble/legend-view-spec.js
@@ -1,0 +1,78 @@
+var Backbone = require('backbone');
+var LegendViewBubble = require('../../../../../../src/geo/ui/legends/bubble/legend-view.js');
+var BubbleLegendModel = require('../../../../../../src/geo/map/legends/bubble-legend-model.js');
+
+describe('geo/ui/legends/legend-view-base.js', function () {
+  beforeEach(function () {
+    this.visModel = new Backbone.Model();
+
+    this.model = new BubbleLegendModel({
+      title: 'Bubble',
+      type: 'bubble',
+      avg: 30,
+      fillColor: '#fabada',
+      postHTMLSnippet: '',
+      preHTMLSnippet: '',
+      prefix: '',
+      suffix: '',
+      sizes: [2, 4, 8],
+      values: [5, 10, 20, 40],
+      visible: true
+    }, {
+      visModel: this.visModel
+    });
+
+    spyOn(this.model, 'isAvailable').and.returnValue(true);
+
+    this.legendView = new LegendViewBubble({
+      model: this.model,
+      placeholderTemplate: function () {
+        return '<p>Placeholder</p>';
+      }
+    });
+  });
+
+  describe('render', function () {
+    beforeEach(function () {
+      this.model.set('state', 'success');
+      this.legendView.render();
+    });
+
+    it('should render bubbles', function () {
+      expect(this.legendView.$('.js-bubbleItem').length).toBe(3);
+      expect(this.legendView._calculateBubbleSizes()).toEqual([100, 50, 25]);
+    });
+
+    it('should place avg properly', function () {
+      // values: [5, 10, 20, 40];
+      // range: [0, 25, 50, 100];
+
+      this.model.set('avg', 5); // at the beginning of range [0, 25]
+      expect(this.legendView._calculateAverageSize()).toBe(0);
+
+      this.model.set('avg', 7.5); // in the middle of range [0, 25]
+      expect(this.legendView._calculateAverageSize()).toBe(12.5);
+
+      this.model.set('avg', 10); // at the end of range [0, 25]
+      expect(this.legendView._calculateAverageSize()).toBe(25);
+
+      this.model.set('avg', 15); // in the middle of range [25, 50]
+      expect(this.legendView._calculateAverageSize()).toBe(37.5);
+
+      this.model.set('avg', 19); // almost at the top of [25, 50]
+      expect(this.legendView._calculateAverageSize()).toBe(25 + (50 - 25) * (9 / 10));
+
+      this.model.set('avg', 25); // in a quarter of range [50, 100]
+      expect(this.legendView._calculateAverageSize()).toBe(62.5);
+
+      this.model.set('avg', 30); // in the middle of range [50, 100]
+      expect(this.legendView._calculateAverageSize()).toBe(75); // (50 + (100 - 50) * 0.5)
+
+      this.model.set('avg', 35); // in the three quarter of range [50, 100]
+      expect(this.legendView._calculateAverageSize()).toBe(87.5); // (50 + (100 - 50) * (15 / 20)
+
+      this.model.set('avg', 40);
+      expect(this.legendView._calculateAverageSize()).toBe(100);
+    });
+  });
+});

--- a/test/unit/util/formatter.spec.js
+++ b/test/unit/util/formatter.spec.js
@@ -10,12 +10,36 @@ describe('src/util/formatter', function () {
     expect(formatter.formatNumber(5)).toBe('5');
     expect(formatter.formatNumber(5.0)).toBe('5');
     expect(formatter.formatNumber(5.00)).toBe('5');
-    expect(formatter.formatNumber(5.71)).toBe('5.7');
-    expect(formatter.formatNumber(-5.71)).toBe('-5.7');
+    expect(formatter.formatNumber(5.71)).toBe('5.71');
+    expect(formatter.formatNumber(-5.71)).toBe('-5.71');
     expect(formatter.formatNumber(186.7)).toBe('187');
     expect(formatter.formatNumber(96.7)).toBe('96.7');
     expect(formatter.formatNumber(500)).toBe('500');
     expect(formatter.formatNumber(1234)).toBe('1.2k');
+    expect(formatter.formatNumber(0.0071)).toBe('0.01');
+  });
+
+  it('should format strings', function () {
+    expect(formatter.formatNumber('0')).toBe('0');
+    expect(formatter.formatNumber('0.001')).toBe('0');
+    expect(formatter.formatNumber('0.071')).toBe('0.07');
+    expect(formatter.formatNumber('0.71')).toBe('0.71');
+    expect(formatter.formatNumber('-0.71')).toBe('-0.71');
+    expect(formatter.formatNumber('5')).toBe('5');
+    expect(formatter.formatNumber('5.0')).toBe('5');
+    expect(formatter.formatNumber('5.00')).toBe('5');
+    expect(formatter.formatNumber('5.71')).toBe('5.71');
+    expect(formatter.formatNumber('-5.71')).toBe('-5.71');
+    expect(formatter.formatNumber('186.7')).toBe('187');
+    expect(formatter.formatNumber('96.7')).toBe('96.7');
+    expect(formatter.formatNumber('500')).toBe('500');
+    expect(formatter.formatNumber('1234')).toBe('1.2k');
+    expect(formatter.formatNumber('0.0071')).toBe('0.01');
+  });
+
+  it('should format exponentials', function () {
+    expect(formatter.formatNumber(0.0001)).toBe('1.0<span class="Legend-exponential">x</span>10<sup class="Legend-exponential">-4</sup>');
+    expect(formatter.formatNumber(7.1e-5)).toBe('7.1<span class="Legend-exponential">x</span>10<sup class="Legend-exponential">-5</sup>');
   });
 
   it('shouldn\'t format non numbers', function () {

--- a/themes/scss/map/overlays.scss
+++ b/themes/scss/map/overlays.scss
@@ -466,6 +466,9 @@ $index-items: 7 6 5 4 3 2 1;
   border-left: 1px dotted rgba(#000, 0.4);
   content: '';
 }
+.Legend-choroplethSup {
+  font-size: 80%;
+}
 
 .Legend-categoryListItem {
   margin-bottom: 6px;

--- a/themes/scss/map/overlays.scss
+++ b/themes/scss/map/overlays.scss
@@ -443,7 +443,7 @@ $index-items: 7 6 5 4 3 2 1;
   border-left: 1px dotted rgba(#000, 0.4);
   content: '';
 }
-.Legend-choroplethSup {
+.Legend-exponential {
   font-size: 80%;
 }
 

--- a/themes/scss/map/overlays.scss
+++ b/themes/scss/map/overlays.scss
@@ -363,6 +363,7 @@ $maxLegendContainerHeight: 300px;
   position: relative;
 }
 .Bubble-average {
+  @include transform(translateY(50%));
   display: block;
   position: absolute;
   right: 105px;


### PR DESCRIPTION
This fixes #1456. Another round about precision, because if the input is string, the formatter didn't do anything, so we tried to convert to number always in order to apply the format. Also we introduce the exponential numbers:

![screen shot 2016-10-20 at 19 11 28](https://cloud.githubusercontent.com/assets/1366843/19595050/51fd9b44-9788-11e6-871d-9a99dfd2793c.png)

This PR also fixes the avg bubble position. I was assuming a lineal scale, but the thing is it's not, so we need to place it in the right range (bubble).

cc @alonsogarciapablo 