### PR TITLE
Update message for error

### DIFF
--- a/src/geo/ui/legends/base/error-title.tpl
+++ b/src/geo/ui/legends/base/error-title.tpl
@@ -1,1 +1,1 @@
-<h2 class="CDB-Text CDB-Size-small is-semibold u-upperCase u-errorTextColor">Sorry, Something went wrong.</h2>
+<h2 class="CDB-Text CDB-Size-small is-semibold u-upperCase u-errorTextColor">Sorry, something went wrong.</h2>

--- a/src/geo/ui/legends/base/error-title.tpl
+++ b/src/geo/ui/legends/base/error-title.tpl
@@ -1,1 +1,1 @@
-<h2 class="CDB-Text CDB-Size-small is-semibold u-upperCase u-errorTextColor">Ops! Something went wrong</h2>
+<h2 class="CDB-Text CDB-Size-small is-semibold u-upperCase u-errorTextColor">Sorry, Something went wrong.</h2>


### PR DESCRIPTION
@nobuti here's the small fix. I like 'Oops' too but it seems that "Sorry..." is [used more consistently](https://github.com/CartoDB/cartodb/search?utf8=%E2%9C%93&q=%22something+went+wrong%22) across the product