### PR TITLE
Show custom infowindows/tooltips with no fields

### DIFF
--- a/src/geo/map/infowindow-template.js
+++ b/src/geo/map/infowindow-template.js
@@ -35,6 +35,10 @@ var InfowindowTemplate = Backbone.Model.extend({
 
   hasFields: function () {
     return !this.fields.isEmpty();
+  },
+
+  hasTemplate: function () {
+    return !!this.get('template');
   }
 });
 

--- a/src/geo/map/tooltip-template.js
+++ b/src/geo/map/tooltip-template.js
@@ -37,6 +37,10 @@ var TooltipTemplate = Backbone.Model.extend({
 
   hasFields: function () {
     return !this.fields.isEmpty();
+  },
+
+  hasTemplate: function () {
+    return !!this.get('template');
   }
 });
 

--- a/src/geo/ui/infowindow-model.js
+++ b/src/geo/ui/infowindow-model.js
@@ -9,7 +9,8 @@ var InfowindowModel = Backbone.Model.extend({
     autoPan: true,
     template_type: 'mustache',
     content: '',
-    alternative_names: { }
+    alternative_names: { },
+    visibility: false
   },
 
   DEFAULT_TEMPLATE: defaultInfowindowTemplate,

--- a/src/vis/infowindow-manager.js
+++ b/src/vis/infowindow-manager.js
@@ -54,40 +54,37 @@ InfowindowManager.prototype._addInfowindowOverlay = function (layerView, layerMo
 
 InfowindowManager.prototype._bindFeatureClickEvent = function (layerView) {
   layerView.bind('featureClick', function (e, latlng, pos, data, layerIndex) {
-    if (this._map.arePopupsEnabled()) {
-      var layerModel = layerView.model.getLayerAt(layerIndex);
-      if (!layerModel) {
-        throw new Error('featureClick event for layer ' + layerIndex + ' was captured but layerModel coudn\'t be retrieved');
-      }
-
-      if (!layerModel.infowindow.hasFields()) {
-        return;
-      }
-
-      this._updateInfowindowModel(layerModel.infowindow);
-
-      this._infowindowModel.set({
-        latlng: latlng,
-        visibility: true
-      });
-
-      this._fetchAttributes(layerView, layerModel, data.cartodb_id, latlng);
-
-      if (layerView.tooltipView) {
-        layerView.tooltipView.setFilter(function (feature) {
-          return feature.cartodb_id !== data.cartodb_id;
-        }).hide();
-      }
-
-      var clearFilter = function (infowindowModel) {
-        if (!infowindowModel.get('visibility')) {
-          layerView.tooltipView && layerView.tooltipView.setFilter(null);
-        }
-      };
-
-      this._infowindowModel.unbind('change:visibility', clearFilter);
-      this._infowindowModel.once('change:visibility', clearFilter);
+    var layerModel = layerView.model.getLayerAt(layerIndex);
+    if (!layerModel) {
+      throw new Error('featureClick event for layer ' + layerIndex + ' was captured but layerModel coudn\'t be retrieved');
     }
+    if (!this._map.arePopupsEnabled() || !layerModel.infowindow.hasTemplate()) {
+      return;
+    }
+
+    this._updateInfowindowModel(layerModel.infowindow);
+
+    this._infowindowModel.set({
+      latlng: latlng,
+      visibility: true
+    });
+
+    this._fetchAttributes(layerView, layerModel, data.cartodb_id, latlng);
+
+    if (layerView.tooltipView) {
+      layerView.tooltipView.setFilter(function (feature) {
+        return feature.cartodb_id !== data.cartodb_id;
+      }).hide();
+    }
+
+    var clearFilter = function (infowindowModel) {
+      if (!infowindowModel.get('visibility')) {
+        layerView.tooltipView && layerView.tooltipView.setFilter(null);
+      }
+    };
+
+    this._infowindowModel.unbind('change:visibility', clearFilter);
+    this._infowindowModel.once('change:visibility', clearFilter);
   }, this);
 };
 

--- a/src/vis/tooltip-manager.js
+++ b/src/vis/tooltip-manager.js
@@ -68,7 +68,7 @@ TooltipManager.prototype._bindFeatureOverEvent = function (layerView) {
       throw new Error('featureOver event for layer ' + layerIndex + ' was captured but layerModel coudn\'t be retrieved');
     }
 
-    if (this._map.arePopupsEnabled() && layerModel.tooltip.hasFields()) {
+    if (this._map.arePopupsEnabled() && layerModel.tooltip.hasTemplate()) {
       layerView.tooltipView.setTemplate(layerModel.tooltip.get('template'));
       layerView.tooltipView.setFields(layerModel.tooltip.fields.toJSON());
       layerView.tooltipView.setAlternativeNames(layerModel.tooltip.get('alternative_names'));

--- a/test/spec/vis/infowindow-manager-spec.js
+++ b/test/spec/vis/infowindow-manager-spec.js
@@ -13,7 +13,8 @@ var createCartoDBLayer = function (vis, infowindowAttrs) {
       'name': 'name',
       'title': true,
       'position': 1
-    }]
+    }],
+    template: '<p>{{ name }}</p>'
   };
   return new CartoDBLayer({
     infowindow: infowindowAttrs
@@ -213,6 +214,33 @@ describe('src/vis/infowindow-manager.js', function () {
       ],
       'visibility': true
     });
+  });
+
+  it('should not fetch attributes and show the infowindow if template is empty', function () {
+    var layer1 = createCartoDBLayer(this.vis, {
+      template: '',
+      template_type: 'underscore',
+      fields: [{
+        'name': 'name',
+        'title': true,
+        'position': 1
+      }],
+      alternative_names: 'alternative_names1'
+    });
+
+    var infowindowManager = new InfowindowManager(this.vis);
+    infowindowManager.manage(this.mapView, this.map);
+
+    this.map.layers.reset([ layer1 ]);
+
+    var infowindowView = this.mapView.addInfowindow.calls.mostRecent().args[0];
+    var infowindowModel = infowindowView.model;
+
+    // Simulate the featureClick event for layer #0
+    this.layerView.trigger('featureClick', {}, [100, 200], undefined, { cartodb_id: 10 }, 0);
+
+    expect(this.layerView.model.fetchAttributes).not.toHaveBeenCalled();
+    expect(infowindowModel.get('visibility')).toEqual(false);
   });
 
   it('should not fetch attributes and show the infowindow if popups are disabled', function () {

--- a/test/spec/vis/tooltip-manager-spec.js
+++ b/test/spec/vis/tooltip-manager-spec.js
@@ -237,6 +237,42 @@ describe('src/vis/tooltip-manager.js', function () {
     expect(tooltipView.disable).toHaveBeenCalled();
   });
 
+  it('should disable the tooltip if tooltip has no template', function () {
+    spyOn(this.mapView, 'addOverlay');
+
+    var layer1 = new CartoDBLayer({
+      tooltip: {
+        template: '',
+        template_type: 'underscore',
+        fields: [{
+          'name': 'name',
+          'title': true,
+          'position': 1
+        }],
+        alternative_names: 'alternative_names1'
+      }
+    }, { vis: this.vis });
+
+    var tooltipManager = new TooltipManager(this.vis);
+    tooltipManager.manage(this.mapView, this.map);
+
+    this.map.layers.reset([ layer1 ]);
+
+    expect(this.mapView.addOverlay).toHaveBeenCalled();
+    var tooltipView = this.mapView.addOverlay.calls.mostRecent().args[0];
+
+    spyOn(tooltipView, 'disable');
+
+    this.layerView.model = new CartoDBLayerGroup({}, {
+      layersCollection: new LayersCollection([ layer1 ])
+    });
+
+    // Simulate the featureOver event on layer #0
+    this.layerView.trigger('featureOver', {}, [100, 200], undefined, { cartodb_id: 10 }, 0);
+
+    expect(tooltipView.disable).toHaveBeenCalled();
+  });
+
   it('should bind the featureOver event to the corresponding layerView only once', function () {
     spyOn(this.mapView, 'addOverlay');
 


### PR DESCRIPTION
Fixes #1475

We're not showing infowindows/tooltips if they didn't have any `fields`. This wasn't working for `custom` infowindows/tooltips, where there's only the `template` attribute. We use that attribute now and, as long as its not empty, the infowindow/tooltip will be displayed.

@matallo could you please take a look? thanks!
