### PR TITLE
We have to bind errors in the instantiation of the map

### DIFF
--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -280,6 +280,9 @@ var VisModel = Backbone.Model.extend({
         options.success && options.success();
         this._onMapInstantiatedForTheFirstTime();
       }.bind(this),
+      error: function () {
+        options.error && options.error();
+      },
       includeFilters: false
     });
   },


### PR DESCRIPTION
Basically trying to fix [this problem](https://github.com/CartoDB/cartodb/issues/10432), I've realized that if a map is broken, for example, styling by a column, and then applying a query without that column, if we reload the map, the map is not initialized, basically due to the problem that we weren't binded the error in the map instantiation.

cc @alonsogarciapablo @nobuti 