### PR TITLE
Take layer visibility into account to determine the mouse cursor

### DIFF
--- a/src/vis/map-cursor-manager.js
+++ b/src/vis/map-cursor-manager.js
@@ -22,7 +22,8 @@ var MapCursorManager = function (deps) {
 };
 
 MapCursorManager.prototype._onFeatureOver = function (featureEvent) {
-  if (this._isLayerClickable(featureEvent.layer)) {
+  if (this._isLayerClickable(featureEvent.layer) &&
+    !this._isLayerBeingFeatureOvered(featureEvent.layer)) {
     this._markLayerAsFeatureOvered(featureEvent.layer);
     this._updateMousePointer();
   }
@@ -49,10 +50,8 @@ MapCursorManager.prototype._updateMousePointer = function () {
 };
 
 MapCursorManager.prototype._markLayerAsFeatureOvered = function (layerModel) {
-  if (!this._clickableLayersBeingFeatureOvered[layerModel.cid]) {
-    this._clickableLayersBeingFeatureOvered[layerModel.cid] = layerModel;
-    layerModel.once('change:visible', this._onLayerVisibilityChanged, this);
-  }
+  this._clickableLayersBeingFeatureOvered[layerModel.cid] = layerModel;
+  layerModel.once('change:visible', this._onLayerVisibilityChanged, this);
 };
 
 MapCursorManager.prototype._unmarkLayerAsFeatureOvered = function (layerModel) {
@@ -63,6 +62,10 @@ MapCursorManager.prototype._unmarkLayerAsFeatureOvered = function (layerModel) {
 MapCursorManager.prototype._isLayerClickable = function (layerModel) {
   return this._mapModel.isFeatureInteractivityEnabled() ||
     this._mapModel.arePopupsEnabled() && layerModel.isInfowindowEnabled();
+};
+
+MapCursorManager.prototype._isLayerBeingFeatureOvered = function (layerModel) {
+  return this._clickableLayersBeingFeatureOvered[layerModel.cid];
 };
 
 MapCursorManager.prototype._isAnyClickableLayerBeingFeatureOvered = function () {

--- a/src/vis/map-cursor-manager.js
+++ b/src/vis/map-cursor-manager.js
@@ -17,16 +17,47 @@ var MapCursorManager = function (deps) {
   this._featureEvents.on('featureOver', this._onFeatureOver, this);
   this._featureEvents.on('featureOut', this._onFeatureOut, this);
 
-  // Map to keep track of layers that are being featured overed
+  // Map to keep track of clickable layers that are being feature overed
   this._clickableLayersBeingFeatureOvered = {};
 };
 
 MapCursorManager.prototype._onFeatureOver = function (featureEvent) {
-  var layerModel = featureEvent.layer;
-  if (this._isLayerClickable(layerModel)) {
-    this._clickableLayersBeingFeatureOvered[layerModel.cid] = layerModel;
-    this._mapView.setCursor('pointer');
+  if (this._isLayerClickable(featureEvent.layer)) {
+    this._markLayerAsFeatureOvered(featureEvent.layer);
+    this._updateMousePointer();
   }
+};
+
+MapCursorManager.prototype._onFeatureOut = function (featureEvent) {
+  this._unmarkLayerAsFeatureOvered(featureEvent.layer);
+  this._updateMousePointer();
+};
+
+MapCursorManager.prototype._onLayerVisibilityChanged = function (layerModel) {
+  if (!layerModel.isVisible()) {
+    this._unmarkLayerAsFeatureOvered(layerModel);
+    this._updateMousePointer();
+  }
+};
+
+MapCursorManager.prototype._updateMousePointer = function () {
+  if (this._isAnyClickableLayerBeingFeatureOvered()) {
+    this._mapView.setCursor('pointer');
+  } else {
+    this._mapView.setCursor('auto');
+  }
+};
+
+MapCursorManager.prototype._markLayerAsFeatureOvered = function (layerModel) {
+  if (!this._clickableLayersBeingFeatureOvered[layerModel.cid]) {
+    this._clickableLayersBeingFeatureOvered[layerModel.cid] = layerModel;
+    layerModel.once('change:visible', this._onLayerVisibilityChanged, this);
+  }
+};
+
+MapCursorManager.prototype._unmarkLayerAsFeatureOvered = function (layerModel) {
+  delete this._clickableLayersBeingFeatureOvered[layerModel.cid];
+  layerModel.off('change:visible', this._onLayerVisibilityChanged, this);
 };
 
 MapCursorManager.prototype._isLayerClickable = function (layerModel) {
@@ -34,16 +65,8 @@ MapCursorManager.prototype._isLayerClickable = function (layerModel) {
     this._mapModel.arePopupsEnabled() && layerModel.isInfowindowEnabled();
 };
 
-MapCursorManager.prototype._onFeatureOut = function (featureEvent) {
-  var layerModel = featureEvent.layer;
-  delete this._clickableLayersBeingFeatureOvered[layerModel.cid];
-  if (this._allClickableLayersHaveBeenFeaturedOut()) {
-    this._mapView.setCursor('auto');
-  }
-};
-
-MapCursorManager.prototype._allClickableLayersHaveBeenFeaturedOut = function () {
-  return _.isEmpty(this._clickableLayersBeingFeatureOvered);
+MapCursorManager.prototype._isAnyClickableLayerBeingFeatureOvered = function () {
+  return !_.isEmpty(this._clickableLayersBeingFeatureOvered);
 };
 
 module.exports = MapCursorManager;

--- a/src/vis/map-cursor-manager.js
+++ b/src/vis/map-cursor-manager.js
@@ -30,8 +30,10 @@ MapCursorManager.prototype._onFeatureOver = function (featureEvent) {
 };
 
 MapCursorManager.prototype._onFeatureOut = function (featureEvent) {
-  this._unmarkLayerAsFeatureOvered(featureEvent.layer);
-  this._updateMousePointer();
+  if (this._isLayerBeingFeatureOvered(featureEvent.layer)) {
+    this._unmarkLayerAsFeatureOvered(featureEvent.layer);
+    this._updateMousePointer();
+  }
 };
 
 MapCursorManager.prototype._onLayerVisibilityChanged = function (layerModel) {
@@ -65,7 +67,7 @@ MapCursorManager.prototype._isLayerClickable = function (layerModel) {
 };
 
 MapCursorManager.prototype._isLayerBeingFeatureOvered = function (layerModel) {
-  return this._clickableLayersBeingFeatureOvered[layerModel.cid];
+  return !!this._clickableLayersBeingFeatureOvered[layerModel.cid];
 };
 
 MapCursorManager.prototype._isAnyClickableLayerBeingFeatureOvered = function () {

--- a/test/unit/vis/map-cursor-manager.spec.js
+++ b/test/unit/vis/map-cursor-manager.spec.js
@@ -72,7 +72,18 @@ describe('src/vis/map-cursor-manager.js', function () {
   });
 
   describe('when a feature is not overed anymore', function () {
-    it('should change the cursor to auto', function () {
+    beforeEach(function () {
+      this.mapModel.isFeatureInteractivityEnabled.and.returnValue(true);
+
+      this.featureEvents.trigger('featureOver', {
+        layer: this.layerModel
+      });
+
+      expect(this.mapView.setCursor).toHaveBeenCalledWith('pointer');
+      this.mapView.setCursor.calls.reset();
+    });
+
+    it('should change the cursor to auto if no other layer is being overed', function () {
       this.featureEvents.trigger('featureOut', {
         layer: this.layerModel
       });
@@ -80,43 +91,23 @@ describe('src/vis/map-cursor-manager.js', function () {
       expect(this.mapView.setCursor).toHaveBeenCalledWith('auto');
     });
 
-    describe('when one or more clickable layers where overed', function () {
-      beforeEach(function () {
-        this.mapModel.isFeatureInteractivityEnabled.and.returnValue(true);
+    it('should change the cursor to pointer if other clickable layers are still being overed', function () {
+      var anotherLayerModel = createLayerModel();
 
-        this.featureEvents.trigger('featureOver', {
-          layer: this.layerModel
-        });
-
-        expect(this.mapView.setCursor).toHaveBeenCalledWith('pointer');
-        this.mapView.setCursor.calls.reset();
+      // Another layer is being overed
+      this.featureEvents.trigger('featureOver', {
+        layer: anotherLayerModel
       });
 
-      it('should change the cursor to auto if no other clickable layers have been overed', function () {
-        this.featureEvents.trigger('featureOut', {
-          layer: this.layerModel
-        });
+      expect(this.mapView.setCursor).toHaveBeenCalledWith('pointer');
+      expect(this.mapView.setCursor.calls.reset());
 
-        expect(this.mapView.setCursor).toHaveBeenCalledWith('auto');
+      // First layer is not overed anymore
+      this.featureEvents.trigger('featureOut', {
+        layer: this.layerModel
       });
 
-      it('should change the cursor to pointer if other clickable layers are still being overed', function () {
-        var anotherLayerModel = createLayerModel();
-
-        // Another layer is being overed
-        this.featureEvents.trigger('featureOver', {
-          layer: anotherLayerModel
-        });
-
-        expect(this.mapView.setCursor.calls.reset());
-
-        // First layer is not overed anymore
-        this.featureEvents.trigger('featureOut', {
-          layer: this.layerModel
-        });
-
-        expect(this.mapView.setCursor).toHaveBeenCalledWith('pointer');
-      });
+      expect(this.mapView.setCursor).toHaveBeenCalledWith('pointer');
     });
   });
 

--- a/test/unit/vis/map-cursor-manager.spec.js
+++ b/test/unit/vis/map-cursor-manager.spec.js
@@ -1,14 +1,20 @@
 var _ = require('underscore');
 var Backbone = require('backbone');
 var MapCursorManager = require('../../../src/vis/map-cursor-manager');
+var CartoDBLayer = require('../../../src/geo/map/cartodb-layer');
+
+var createLayerModel = function () {
+  var layerModel = new CartoDBLayer(null, { vis: { reload: function () {}, on: function () {} } });
+  layerModel.isInfowindowEnabled = jasmine.createSpy('isInfowindowEnabled');
+  return layerModel;
+};
 
 describe('src/vis/map-cursor-manager.js', function () {
   beforeEach(function () {
     this.mapView = jasmine.createSpyObj('mapView', ['setCursor']);
     this.mapModel = jasmine.createSpyObj('map', ['arePopupsEnabled', 'isFeatureInteractivityEnabled']);
     this.featureEvents = _.extend({}, Backbone.Events);
-    this.layerModel = jasmine.createSpyObj('layerModel', ['isInfowindowEnabled']);
-    this.layerModel.cid = 'layer1';
+    this.layerModel = createLayerModel();
 
     this.mapCursorManager = new MapCursorManager({
       mapView: this.mapView,
@@ -54,7 +60,7 @@ describe('src/vis/map-cursor-manager.js', function () {
         expect(this.mapView.setCursor).not.toHaveBeenCalled();
       });
 
-      it('should change the cursor to pointer if layer has NO infowindow enabled', function () {
+      it('should change the cursor to pointer if layer infowindows enabled', function () {
         this.layerModel.isInfowindowEnabled.and.returnValue(true);
         this.featureEvents.trigger('featureOver', {
           layer: this.layerModel
@@ -94,9 +100,8 @@ describe('src/vis/map-cursor-manager.js', function () {
         expect(this.mapView.setCursor).toHaveBeenCalledWith('auto');
       });
 
-      it('should NOT change the cursor if other clickable layers are still being overed', function () {
-        var anotherLayerModel = jasmine.createSpyObj('layerModel', ['isInfowindowEnabled']);
-        anotherLayerModel.cid = 'layer2';
+      it('should change the cursor to pointer if other clickable layers are still being overed', function () {
+        var anotherLayerModel = createLayerModel();
 
         // Another layer is being overed
         this.featureEvents.trigger('featureOver', {
@@ -110,8 +115,42 @@ describe('src/vis/map-cursor-manager.js', function () {
           layer: this.layerModel
         });
 
-        expect(this.mapView.setCursor).not.toHaveBeenCalled();
+        expect(this.mapView.setCursor).toHaveBeenCalledWith('pointer');
       });
+    });
+  });
+
+  describe('when a feature was overed and layer visibility changes', function () {
+    beforeEach(function () {
+      this.mapModel.isFeatureInteractivityEnabled.and.returnValue(true);
+      this.featureEvents.trigger('featureOver', {
+        layer: this.layerModel
+      });
+
+      expect(this.mapView.setCursor).toHaveBeenCalledWith('pointer');
+    });
+
+    it('should change the cursor to auto if layer is hidden', function () {
+      this.mapView.setCursor.calls.reset();
+
+      this.layerModel.set('visible', false);
+
+      expect(this.mapView.setCursor).toHaveBeenCalledWith('auto');
+    });
+
+    it('should keep the cursor as pointer if layer is hidden but other clickable layers are visible', function () {
+      var anotherLayerModel = createLayerModel();
+
+      // Another layer is being overed
+      this.featureEvents.trigger('featureOver', {
+        layer: anotherLayerModel
+      });
+
+      this.mapView.setCursor.calls.reset();
+
+      this.layerModel.set('visible', false);
+
+      expect(this.mapView.setCursor).toHaveBeenCalledWith('pointer');
     });
   });
 });


### PR DESCRIPTION
If features of an interactive layer were being overed and the layer is hidden, the cursor wasn't being set to `auto` again. This PR solves that issue by setting the cursor back to `auto` if a layer that was being "feature overed" is hidden and no other clickable layer is being "feature overed".

@matallo can you please take a look?