### PR TITLE
Added method to update geometry coordinates from a GeoJSON object

### DIFF
--- a/examples/v4/geometry-drawing.html
+++ b/examples/v4/geometry-drawing.html
@@ -535,7 +535,7 @@
       }
 
       function editGeometry (vis, geoJSON) {
-        var geometry = vis.map.editGeometry(geoJSON);
+        var geometry = window.geometry = vis.map.editGeometry(geoJSON);
         displayGeoJSON(geometry);
       }
 

--- a/src/geo/geometry-models/geojson-helper.js
+++ b/src/geo/geometry-models/geojson-helper.js
@@ -40,5 +40,45 @@ module.exports = {
   convertLatLngsToGeoJSONPolygonCoords: function (latlngs) {
     latlngs = latlngs.concat([ latlngs[0] ]);
     return this.convertLatlngsToLnglats(latlngs);
+  },
+
+  getPointLatLngFromGeoJSONCoords: function (geoJSON) {
+    var lnglat = this.getGeometryCoordinates(geoJSON);
+    return this.convertLngLatToLatLng(lnglat);
+  },
+
+  getPolylineLatLngsFromGeoJSONCoords: function (geoJSON) {
+    var lnglats = this.getGeometryCoordinates(geoJSON);
+    return this.convertLngLatsToLatLngs(lnglats);
+  },
+
+  getPolygonLatLngsFromGeoJSONCoords: function (geoJSON) {
+    var lnglats = this.getGeometryCoordinates(geoJSON)[0];
+    var latlngs = this.convertLngLatsToLatLngs(lnglats);
+    // Remove the last latlng, which is duplicated
+    latlngs = latlngs.slice(0, -1);
+    return latlngs;
+  },
+
+  getMultiPointLatLngFromGeoJSONCoords: function (geoJSON) {
+    var lnglats = this.getGeometryCoordinates(geoJSON);
+    return this.convertLngLatsToLatLngs(lnglats);
+  },
+
+  getMultiPolylineLatLngsFromGeoJSONCoords: function (geoJSON) {
+    var lnglats = this.getGeometryCoordinates(geoJSON);
+    return _.map(lnglats, function (lnglats) {
+      return this.convertLngLatsToLatLngs(lnglats);
+    }, this);
+  },
+
+  getMultiPolygonLatLngsFromGeoJSONCoords: function (geoJSON) {
+    var lnglats = this.getGeometryCoordinates(geoJSON);
+    return _.map(lnglats, function (lnglats) {
+      // Remove the last latlng, which is duplicated
+      var latlngs = this.convertLngLatsToLatLngs(lnglats[0]);
+      latlngs = latlngs.slice(0, -1);
+      return latlngs;
+    }, this);
   }
 };

--- a/src/geo/geometry-models/geojson-helper.js
+++ b/src/geo/geometry-models/geojson-helper.js
@@ -60,7 +60,7 @@ module.exports = {
     return latlngs;
   },
 
-  getMultiPointLatLngFromGeoJSONCoords: function (geoJSON) {
+  getMultiPointLatLngsFromGeoJSONCoords: function (geoJSON) {
     var lnglats = this.getGeometryCoordinates(geoJSON);
     return this.convertLngLatsToLatLngs(lnglats);
   },

--- a/src/geo/geometry-models/geometry-base.js
+++ b/src/geo/geometry-models/geometry-base.js
@@ -21,6 +21,10 @@ var GeometryBase = Model.extend({
     throw new Error('subclasses of GeometryBase must implement toGeoJSON');
   },
 
+  setCoordinatesFromGeoJSON: function () {
+    throw new Error('subclasses of GeometryBase must implement toGeoJSON');
+  },
+
   _triggerChangeEvent: function () {
     this.trigger('change', this);
   }

--- a/src/geo/geometry-models/geometry-factory.js
+++ b/src/geo/geometry-models/geometry-factory.js
@@ -32,56 +32,30 @@ var createMultiPolyline = function (attrs, options) {
 };
 
 var createPointFromGeoJSON = function (geoJSON) {
-  var lnglat = GeoJSONHelper.getGeometryCoordinates(geoJSON);
-  var latlng = GeoJSONHelper.convertLngLatToLatLng(lnglat);
+  var latlng = GeoJSONHelper.getPointLatLngFromGeoJSONCoords(geoJSON);
   return createPoint({
     latlng: latlng,
-    geojson: geoJSON,
     editable: true
   });
 };
 
 var createPolylineFromGeoJSON = function (geoJSON) {
-  var lnglats = GeoJSONHelper.getGeometryCoordinates(geoJSON);
-  var latlngs = GeoJSONHelper.convertLngLatsToLatLngs(lnglats);
+  var latlngs = GeoJSONHelper.getPolylineLatLngsFromGeoJSONCoords(geoJSON);
   return createPolyline({
-    geojson: geoJSON,
     editable: true
   }, { latlngs: latlngs });
 };
 
 var createPolygonFromGeoJSON = function (geoJSON) {
-  var lnglats = GeoJSONHelper.getGeometryCoordinates(geoJSON)[0];
-  var latlngs = GeoJSONHelper.convertLngLatsToLatLngs(lnglats);
-  // Remove the last latlng, which is duplicated
-  latlngs = latlngs.slice(0, -1);
+  var latlngs = GeoJSONHelper.getPolygonLatLngsFromGeoJSONCoords(geoJSON);
   return createPolygon({
-    geojson: geoJSON,
     editable: true
   }, { latlngs: latlngs });
 };
 
 var createMultiPointFromGeoJSON = function (geoJSON) {
-  var lnglats = GeoJSONHelper.getGeometryCoordinates(geoJSON);
-  var latlngs = GeoJSONHelper.convertLngLatsToLatLngs(lnglats);
+  var latlngs = GeoJSONHelper.getMultiPointLatLngFromGeoJSONCoords(geoJSON);
   return createMultiPoint({
-    geojson: geoJSON,
-    editable: true
-  }, {
-    latlngs: latlngs
-  });
-};
-
-var createMultiPolygonFromGeoJSON = function (geoJSON) {
-  var lnglats = GeoJSONHelper.getGeometryCoordinates(geoJSON);
-  var latlngs = _.map(lnglats, function (lnglats) {
-    // Remove the last latlng, which is duplicated
-    latlngs = GeoJSONHelper.convertLngLatsToLatLngs(lnglats[0]);
-    latlngs = latlngs.slice(0, -1);
-    return latlngs;
-  }, this);
-  return createMultiPolygon({
-    geojson: geoJSON,
     editable: true
   }, {
     latlngs: latlngs
@@ -89,12 +63,17 @@ var createMultiPolygonFromGeoJSON = function (geoJSON) {
 };
 
 var createMultiPolylineFromGeoJSON = function (geoJSON) {
-  var lnglats = GeoJSONHelper.getGeometryCoordinates(geoJSON);
-  var latlngs = _.map(lnglats, function (lnglats) {
-    return GeoJSONHelper.convertLngLatsToLatLngs(lnglats);
-  }, this);
+  var latlngs = GeoJSONHelper.getMultiPolylineLatLngsFromGeoJSONCoords(geoJSON);
   return createMultiPolyline({
-    geojson: geoJSON,
+    editable: true
+  }, {
+    latlngs: latlngs
+  });
+};
+
+var createMultiPolygonFromGeoJSON = function (geoJSON) {
+  var latlngs = GeoJSONHelper.getMultiPolygonLatLngsFromGeoJSONCoords(geoJSON);
+  return createMultiPolygon({
     editable: true
   }, {
     latlngs: latlngs

--- a/src/geo/geometry-models/geometry-factory.js
+++ b/src/geo/geometry-models/geometry-factory.js
@@ -1,4 +1,3 @@
-var _ = require('underscore');
 var Point = require('./point');
 var Polyline = require('./polyline');
 var Polygon = require('./polygon');
@@ -54,7 +53,7 @@ var createPolygonFromGeoJSON = function (geoJSON) {
 };
 
 var createMultiPointFromGeoJSON = function (geoJSON) {
-  var latlngs = GeoJSONHelper.getMultiPointLatLngFromGeoJSONCoords(geoJSON);
+  var latlngs = GeoJSONHelper.getMultiPointLatLngsFromGeoJSONCoords(geoJSON);
   return createMultiPoint({
     editable: true
   }, {

--- a/src/geo/geometry-models/multi-point.js
+++ b/src/geo/geometry-models/multi-point.js
@@ -16,7 +16,7 @@ var MultiPoint = MultiGeometryBase.extend({
 
   toGeoJSON: function () {
     var coords = this.geometries.map(function (path) {
-      return GeoJSONHelper.convertLatLngsToGeoJSONPointCoords(path.getLatLng());
+      return GeoJSONHelper.convertLatLngsToGeoJSONPointCoords(path.getCoordinates());
     });
     return {
       'type': 'MultiPoint',

--- a/src/geo/geometry-models/multi-point.js
+++ b/src/geo/geometry-models/multi-point.js
@@ -22,6 +22,11 @@ var MultiPoint = MultiGeometryBase.extend({
       'type': 'MultiPoint',
       'coordinates': coords
     };
+  },
+
+  setCoordinatesFromGeoJSON: function (geoJSON) {
+    var latlngs = GeoJSONHelper.getMultiPointLatLngsFromGeoJSONCoords(geoJSON);
+    this.geometries.reset(this._createGeometries(latlngs));
   }
 });
 

--- a/src/geo/geometry-models/multi-polygon.js
+++ b/src/geo/geometry-models/multi-polygon.js
@@ -17,7 +17,7 @@ var MultiPolygon = MultiGeometryBase.extend({
 
   toGeoJSON: function () {
     var coords = this.geometries.map(function (path) {
-      return [ GeoJSONHelper.convertLatLngsToGeoJSONPolygonCoords(path.getLatLngs()) ];
+      return [ GeoJSONHelper.convertLatLngsToGeoJSONPolygonCoords(path.getCoordinates()) ];
     });
     return {
       'type': 'MultiPolygon',

--- a/src/geo/geometry-models/multi-polygon.js
+++ b/src/geo/geometry-models/multi-polygon.js
@@ -23,6 +23,11 @@ var MultiPolygon = MultiGeometryBase.extend({
       'type': 'MultiPolygon',
       'coordinates': coords
     };
+  },
+
+  setCoordinatesFromGeoJSON: function (geoJSON) {
+    var latlngs = GeoJSONHelper.getMultiPolygonLatLngsFromGeoJSONCoords(geoJSON);
+    this.geometries.reset(this._createGeometries(latlngs));
   }
 });
 

--- a/src/geo/geometry-models/multi-polyline.js
+++ b/src/geo/geometry-models/multi-polyline.js
@@ -17,7 +17,7 @@ var MultiPolyline = MultiGeometryBase.extend({
 
   toGeoJSON: function () {
     var coords = this.geometries.map(function (path) {
-      return GeoJSONHelper.convertLatLngsToGeoJSONPolylineCoords(path.getLatLngs());
+      return GeoJSONHelper.convertLatLngsToGeoJSONPolylineCoords(path.getCoordinates());
     });
     return {
       'type': 'MultiLineString',

--- a/src/geo/geometry-models/multi-polyline.js
+++ b/src/geo/geometry-models/multi-polyline.js
@@ -23,6 +23,11 @@ var MultiPolyline = MultiGeometryBase.extend({
       'type': 'MultiLineString',
       'coordinates': coords
     };
+  },
+
+  setCoordinatesFromGeoJSON: function (geoJSON) {
+    var latlngs = GeoJSONHelper.getMultiPolylineLatLngsFromGeoJSONCoords(geoJSON);
+    this.geometries.reset(this._createGeometries(latlngs));
   }
 });
 

--- a/src/geo/geometry-models/multi-polyline.js
+++ b/src/geo/geometry-models/multi-polyline.js
@@ -17,7 +17,7 @@ var MultiPolyline = MultiGeometryBase.extend({
 
   toGeoJSON: function () {
     var coords = this.geometries.map(function (path) {
-      return [ GeoJSONHelper.convertLatLngsToGeoJSONPolylineCoords(path.getLatLngs()) ];
+      return GeoJSONHelper.convertLatLngsToGeoJSONPolylineCoords(path.getLatLngs());
     });
     return {
       'type': 'MultiLineString',

--- a/src/geo/geometry-models/path-base.js
+++ b/src/geo/geometry-models/path-base.js
@@ -8,13 +8,12 @@ var PathBase = GeometryBase.extend({
     GeometryBase.prototype.initialize.apply(this, arguments);
     options = options || {};
 
-    var points = [];
+    this.points = new Backbone.Collection();
     if (options.latlngs) {
-      points = _.map(options.latlngs, this._createPoint, this);
+      this.points.reset(this._createPoints(options.latlngs));
     }
-    this.points = new Backbone.Collection(points);
     this.points.on('change', this._triggerChangeEvent, this);
-    this.points.on('reset', this._onPointsResetted, this);
+    this.points.on('reset', this._onPointsReset, this);
   },
 
   getLatLngs: function () {
@@ -24,7 +23,7 @@ var PathBase = GeometryBase.extend({
   },
 
   setLatLngs: function (latlngs) {
-    this.points.reset(_.map(latlngs, this._createPoint, this));
+    this.points.reset(this._createPoints(latlngs));
     this._triggerChangeEvent();
   },
 
@@ -39,6 +38,10 @@ var PathBase = GeometryBase.extend({
     this._removePoints();
   },
 
+  _createPoints: function (latlngs) {
+    return _.map(latlngs, this._createPoint, this);
+  },
+
   _createPoint: function (latlng) {
     return new Point({
       latlng: latlng,
@@ -46,7 +49,7 @@ var PathBase = GeometryBase.extend({
     });
   },
 
-  _onPointsResetted: function (collection, options) {
+  _onPointsReset: function (collection, options) {
     this._removePoints(options.previousModels);
   },
 

--- a/src/geo/geometry-models/path-base.js
+++ b/src/geo/geometry-models/path-base.js
@@ -16,21 +16,21 @@ var PathBase = GeometryBase.extend({
     this.points.on('reset', this._onPointsReset, this);
   },
 
-  getLatLngs: function () {
+  getCoordinates: function () {
     return this.points.map(function (point) {
-      return point.get('latlng');
+      return point.getCoordinates();
     });
   },
 
-  setLatLngs: function (latlngs) {
+  setCoordinates: function (latlngs) {
     this.points.reset(this._createPoints(latlngs));
     this._triggerChangeEvent();
   },
 
   update: function (latlng) {
-    var latlngs = this.getLatLngs();
+    var latlngs = this.getCoordinates();
     latlngs.push(latlng);
-    this.setLatLngs(latlngs);
+    this.setCoordinates(latlngs);
   },
 
   remove: function () {

--- a/src/geo/geometry-models/point.js
+++ b/src/geo/geometry-models/point.js
@@ -14,7 +14,6 @@ var Point = GeometryBase.extend({
 
   setLatLng: function (latlng) {
     this.set('latlng', latlng);
-    this._triggerChangeEvent();
   },
 
   update: function (latlng) {
@@ -33,6 +32,11 @@ var Point = GeometryBase.extend({
       'type': 'Point',
       'coordinates': coords
     };
+  },
+
+  setCoordinatesFromGeoJSON: function (geoJSON) {
+    var latlng = GeoJSONHelper.getPointLatLngFromGeoJSONCoords(geoJSON);
+    this.setLatLng(latlng);
   }
 });
 

--- a/src/geo/geometry-models/point.js
+++ b/src/geo/geometry-models/point.js
@@ -8,17 +8,17 @@ var Point = GeometryBase.extend({
     iconAnchor: [ 11, 11 ]
   },
 
-  getLatLng: function () {
+  getCoordinates: function () {
     return this.get('latlng');
   },
 
-  setLatLng: function (latlng) {
+  setCoordinates: function (latlng) {
     this.set('latlng', latlng);
   },
 
   update: function (latlng) {
     if (!this.get('latlng')) {
-      this.setLatLng(latlng);
+      this.setCoordinates(latlng);
     }
   },
 
@@ -27,7 +27,7 @@ var Point = GeometryBase.extend({
   },
 
   toGeoJSON: function () {
-    var coords = GeoJSONHelper.convertLatLngsToGeoJSONPointCoords(this.getLatLng());
+    var coords = GeoJSONHelper.convertLatLngsToGeoJSONPointCoords(this.getCoordinates());
     return {
       'type': 'Point',
       'coordinates': coords
@@ -36,7 +36,7 @@ var Point = GeometryBase.extend({
 
   setCoordinatesFromGeoJSON: function (geoJSON) {
     var latlng = GeoJSONHelper.getPointLatLngFromGeoJSONCoords(geoJSON);
-    this.setLatLng(latlng);
+    this.setCoordinates(latlng);
   }
 });
 

--- a/src/geo/geometry-models/polygon.js
+++ b/src/geo/geometry-models/polygon.js
@@ -17,6 +17,11 @@ var Polygon = PathBase.extend({
       'type': 'Polygon',
       'coordinates': [ coords ]
     };
+  },
+
+  setCoordinatesFromGeoJSON: function (geoJSON) {
+    var latlngs = GeoJSONHelper.getPolygonLatLngsFromGeoJSONCoords(geoJSON);
+    this.setLatLngs(latlngs);
   }
 });
 

--- a/src/geo/geometry-models/polygon.js
+++ b/src/geo/geometry-models/polygon.js
@@ -12,7 +12,7 @@ var Polygon = PathBase.extend({
   },
 
   toGeoJSON: function () {
-    var coords = GeoJSONHelper.convertLatLngsToGeoJSONPolygonCoords(this.getLatLngs());
+    var coords = GeoJSONHelper.convertLatLngsToGeoJSONPolygonCoords(this.getCoordinates());
     return {
       'type': 'Polygon',
       'coordinates': [ coords ]
@@ -21,7 +21,7 @@ var Polygon = PathBase.extend({
 
   setCoordinatesFromGeoJSON: function (geoJSON) {
     var latlngs = GeoJSONHelper.getPolygonLatLngsFromGeoJSONCoords(geoJSON);
-    this.setLatLngs(latlngs);
+    this.setCoordinates(latlngs);
   }
 });
 

--- a/src/geo/geometry-models/polyline.js
+++ b/src/geo/geometry-models/polyline.js
@@ -12,7 +12,7 @@ var Polyline = PathBase.extend({
   },
 
   toGeoJSON: function () {
-    var coords = GeoJSONHelper.convertLatLngsToGeoJSONPolylineCoords(this.getLatLngs());
+    var coords = GeoJSONHelper.convertLatLngsToGeoJSONPolylineCoords(this.getCoordinates());
     return {
       'type': 'LineString',
       'coordinates': coords
@@ -21,7 +21,7 @@ var Polyline = PathBase.extend({
 
   setCoordinatesFromGeoJSON: function (geoJSON) {
     var latlngs = GeoJSONHelper.getPolylineLatLngsFromGeoJSONCoords(geoJSON);
-    this.setLatLngs(latlngs);
+    this.setCoordinates(latlngs);
   }
 });
 

--- a/src/geo/geometry-models/polyline.js
+++ b/src/geo/geometry-models/polyline.js
@@ -17,6 +17,11 @@ var Polyline = PathBase.extend({
       'type': 'LineString',
       'coordinates': coords
     };
+  },
+
+  setCoordinatesFromGeoJSON: function (geoJSON) {
+    var latlngs = GeoJSONHelper.getPolylineLatLngsFromGeoJSONCoords(geoJSON);
+    this.setLatLngs(latlngs);
   }
 });
 

--- a/src/geo/leaflet/geometries/multi-geometry-view-base.js
+++ b/src/geo/leaflet/geometries/multi-geometry-view-base.js
@@ -4,6 +4,7 @@ var MultiGeometryViewBase = GeometryViewBase.extend({
   initialize: function (options) {
     GeometryViewBase.prototype.initialize.apply(this, arguments);
     if (!this.GeometryViewClass) throw new Error('subclasses of MultiGeometryViewBase must declare the GeometryViewClass instance variable');
+    this.model.geometries.on('reset', this._renderGeometries, this);
   },
 
   render: function () {

--- a/src/geo/leaflet/geometries/path-view-base.js
+++ b/src/geo/leaflet/geometries/path-view-base.js
@@ -43,7 +43,7 @@ var PathViewBase = GeometryViewBase.extend({
   },
 
   _updateGeometry: function () {
-    this._geometry.setLatLngs(this.model.getLatLngs());
+    this._geometry.setLatLngs(this.model.getCoordinates());
   },
 
   _onGeometryRemoved: function () {

--- a/src/geo/leaflet/geometries/polygon-view.js
+++ b/src/geo/leaflet/geometries/polygon-view.js
@@ -3,7 +3,7 @@ var PathViewBase = require('./path-view-base');
 
 var PolygonView = PathViewBase.extend({
   _createGeometry: function () {
-    return L.polygon(this.model.getLatLngs(), { color: this.model.get('color') });
+    return L.polygon(this.model.getCoordinates(), { color: this.model.get('color') });
   }
 });
 

--- a/src/geo/leaflet/geometries/polyline-view.js
+++ b/src/geo/leaflet/geometries/polyline-view.js
@@ -3,7 +3,7 @@ var PathViewBase = require('./path-view-base');
 
 var PolylineView = PathViewBase.extend({
   _createGeometry: function () {
-    return L.polyline(this.model.getLatLngs(), { color: this.model.get('color') });
+    return L.polyline(this.model.getCoordinates(), { color: this.model.get('color') });
   }
 });
 

--- a/test/spec/geo/leaflet/geometries/point-view-spec.js
+++ b/test/spec/geo/leaflet/geometries/point-view-spec.js
@@ -25,7 +25,7 @@ describe('src/geo/leaflet/geometries/point-view.js', function () {
   it('should add a marker to the map', function () {
     expect(this.leafletMap.addLayer).toHaveBeenCalled();
     var marker = this.leafletMap.addLayer.calls.argsFor(0)[0];
-    expect(marker.getLatLng()).toEqual({
+    expect(marker.getCoordinates()).toEqual({
       lat: -40,
       lng: 40
     });
@@ -38,7 +38,7 @@ describe('src/geo/leaflet/geometries/point-view.js', function () {
 
       this.point.set('latlng', [ -45, 45 ]);
 
-      expect(marker.getLatLng()).toEqual({
+      expect(marker.getCoordinates()).toEqual({
         lat: -45,
         lng: 45
       });
@@ -86,7 +86,7 @@ describe('src/geo/leaflet/geometries/point-view.js', function () {
     });
 
     it("should update model's latlng when the marker is dragged & dropped", function () {
-      spyOn(this.marker, 'getLatLng').and.returnValue({
+      spyOn(this.marker, 'getCoordinates').and.returnValue({
         lat: -90,
         lng: 90
       });
@@ -106,8 +106,8 @@ describe('src/geo/leaflet/geometries/point-view.js', function () {
         50
       ]);
 
-      expect(this.marker.getLatLng().lat).toEqual(-40);
-      expect(this.marker.getLatLng().lng).toEqual(40);
+      expect(this.marker.getCoordinates().lat).toEqual(-40);
+      expect(this.marker.getCoordinates().lng).toEqual(40);
 
       this.marker.fire('drag');
       this.marker.fire('dragend');
@@ -117,8 +117,8 @@ describe('src/geo/leaflet/geometries/point-view.js', function () {
         50
       ]);
 
-      expect(this.marker.getLatLng().lat).toEqual(-50);
-      expect(this.marker.getLatLng().lng).toEqual(50);
+      expect(this.marker.getCoordinates().lat).toEqual(-50);
+      expect(this.marker.getCoordinates().lng).toEqual(50);
     });
   });
 });

--- a/test/spec/geo/leaflet/geometries/point-view-spec.js
+++ b/test/spec/geo/leaflet/geometries/point-view-spec.js
@@ -25,7 +25,7 @@ describe('src/geo/leaflet/geometries/point-view.js', function () {
   it('should add a marker to the map', function () {
     expect(this.leafletMap.addLayer).toHaveBeenCalled();
     var marker = this.leafletMap.addLayer.calls.argsFor(0)[0];
-    expect(marker.getCoordinates()).toEqual({
+    expect(marker.getLatLng()).toEqual({
       lat: -40,
       lng: 40
     });
@@ -38,7 +38,7 @@ describe('src/geo/leaflet/geometries/point-view.js', function () {
 
       this.point.set('latlng', [ -45, 45 ]);
 
-      expect(marker.getCoordinates()).toEqual({
+      expect(marker.getLatLng()).toEqual({
         lat: -45,
         lng: 45
       });
@@ -86,7 +86,7 @@ describe('src/geo/leaflet/geometries/point-view.js', function () {
     });
 
     it("should update model's latlng when the marker is dragged & dropped", function () {
-      spyOn(this.marker, 'getCoordinates').and.returnValue({
+      spyOn(this.marker, 'getLatLng').and.returnValue({
         lat: -90,
         lng: 90
       });
@@ -106,8 +106,8 @@ describe('src/geo/leaflet/geometries/point-view.js', function () {
         50
       ]);
 
-      expect(this.marker.getCoordinates().lat).toEqual(-40);
-      expect(this.marker.getCoordinates().lng).toEqual(40);
+      expect(this.marker.getLatLng().lat).toEqual(-40);
+      expect(this.marker.getLatLng().lng).toEqual(40);
 
       this.marker.fire('drag');
       this.marker.fire('dragend');
@@ -117,8 +117,8 @@ describe('src/geo/leaflet/geometries/point-view.js', function () {
         50
       ]);
 
-      expect(this.marker.getCoordinates().lat).toEqual(-50);
-      expect(this.marker.getCoordinates().lng).toEqual(50);
+      expect(this.marker.getLatLng().lat).toEqual(-50);
+      expect(this.marker.getLatLng().lng).toEqual(50);
     });
   });
 });

--- a/test/spec/geo/leaflet/geometries/shared-tests-for-path-views.js
+++ b/test/spec/geo/leaflet/geometries/shared-tests-for-path-views.js
@@ -17,13 +17,13 @@ module.exports = function () {
   it('should render some markers and a polygon', function () {
     expect(this.leafletMap.addLayer).toHaveBeenCalled();
     expect(this.leafletMap.addLayer.calls.count()).toEqual(4); // 3 markers and 1 polygon
-    expect(this.leafletMarker1.getCoordinates()).toEqual({ lat: -1, lng: 1 });
+    expect(this.leafletMarker1.getLatLng()).toEqual({ lat: -1, lng: 1 });
     expect(this.leafletMarker1.options.draggable).toBe(false);
-    expect(this.leafletMarker2.getCoordinates()).toEqual({ lat: 1, lng: 2 });
+    expect(this.leafletMarker2.getLatLng()).toEqual({ lat: 1, lng: 2 });
     expect(this.leafletMarker2.options.draggable).toBe(false);
-    expect(this.leafletMarker3.getCoordinates()).toEqual({ lat: 3, lng: 4 });
+    expect(this.leafletMarker3.getLatLng()).toEqual({ lat: 3, lng: 4 });
     expect(this.leafletMarker3.options.draggable).toBe(false);
-    expect(this.leafletPolygon.getCoordinates()).toEqual([
+    expect(this.leafletPolygon.getLatLngs()).toEqual([
       { lat: -1, lng: 1 }, { lat: 1, lng: 2 }, { lat: 3, lng: 4 }
     ]);
   });

--- a/test/spec/geo/leaflet/geometries/shared-tests-for-path-views.js
+++ b/test/spec/geo/leaflet/geometries/shared-tests-for-path-views.js
@@ -17,20 +17,20 @@ module.exports = function () {
   it('should render some markers and a polygon', function () {
     expect(this.leafletMap.addLayer).toHaveBeenCalled();
     expect(this.leafletMap.addLayer.calls.count()).toEqual(4); // 3 markers and 1 polygon
-    expect(this.leafletMarker1.getLatLng()).toEqual({ lat: -1, lng: 1 });
+    expect(this.leafletMarker1.getCoordinates()).toEqual({ lat: -1, lng: 1 });
     expect(this.leafletMarker1.options.draggable).toBe(false);
-    expect(this.leafletMarker2.getLatLng()).toEqual({ lat: 1, lng: 2 });
+    expect(this.leafletMarker2.getCoordinates()).toEqual({ lat: 1, lng: 2 });
     expect(this.leafletMarker2.options.draggable).toBe(false);
-    expect(this.leafletMarker3.getLatLng()).toEqual({ lat: 3, lng: 4 });
+    expect(this.leafletMarker3.getCoordinates()).toEqual({ lat: 3, lng: 4 });
     expect(this.leafletMarker3.options.draggable).toBe(false);
-    expect(this.leafletPolygon.getLatLngs()).toEqual([
+    expect(this.leafletPolygon.getCoordinates()).toEqual([
       { lat: -1, lng: 1 }, { lat: 1, lng: 2 }, { lat: 3, lng: 4 }
     ]);
   });
 
   it('should not render duplicated markers', function () {
     this.leafletMap.addLayer.calls.reset();
-    this.geometry.setLatLngs([
+    this.geometry.setCoordinates([
       [-1, 1], [1, 2], [3, 4], [-1, 1]
     ]);
 
@@ -44,7 +44,7 @@ module.exports = function () {
       });
 
       it("should update the polygon's latlng", function () {
-        expect(this.geometry.getLatLngs()).toEqual([
+        expect(this.geometry.getCoordinates()).toEqual([
           [ -45, 45 ], [ 1, 2 ], [ 3, 4 ]
         ]);
       });
@@ -62,7 +62,7 @@ module.exports = function () {
       });
 
       it("should update the polygon's latlng", function () {
-        expect(this.geometry.getLatLngs()).toEqual([
+        expect(this.geometry.getCoordinates()).toEqual([
           [ -1, 1 ], [ 1, 2 ], [ 3, 4 ], [ -40, 40 ]
         ]);
       });
@@ -70,13 +70,13 @@ module.exports = function () {
 
     describe('when points are resetted, function', function () {
       beforeEach(function () {
-        this.geometry.setLatLngs([
+        this.geometry.setCoordinates([
           [ -10, 10 ], [ 10, 20 ], [ 30, 40 ]
         ]);
       });
 
       it("should update the polygon's latlng", function () {
-        expect(this.geometry.getLatLngs()).toEqual([
+        expect(this.geometry.getCoordinates()).toEqual([
           [ -10, 10 ], [ 10, 20 ], [ 30, 40 ]
         ]);
       });

--- a/test/unit/geo/geometry-models/geometry-factory.spec.js
+++ b/test/unit/geo/geometry-models/geometry-factory.spec.js
@@ -30,7 +30,7 @@ describe('src/geo/geometry-models/geometry-factory', function () {
         var geometry = GeometryFactory.createGeometryFromGeoJSON(geoJSON);
 
         expect(geometry instanceof Point).toBeTruthy();
-        expect(geometry.getLatLng()).toEqual([ 40.245991504199026, -3.779296875 ]);
+        expect(geometry.getCoordinates()).toEqual([ 40.245991504199026, -3.779296875 ]);
       });
     });
 
@@ -53,7 +53,7 @@ describe('src/geo/geometry-models/geometry-factory', function () {
         var geometry = GeometryFactory.createGeometryFromGeoJSON(geoJSON);
 
         expect(geometry instanceof Polyline).toBeTruthy();
-        expect(geometry.getLatLngs()).toEqual([
+        expect(geometry.getCoordinates()).toEqual([
           [ 43.51668853502906, -2.021484375 ],
           [ 42.293564192170095, 3.6035156249999996 ]
         ]);
@@ -89,7 +89,7 @@ describe('src/geo/geometry-models/geometry-factory', function () {
         var geometry = GeometryFactory.createGeometryFromGeoJSON(geoJSON);
 
         expect(geometry instanceof Polygon).toBeTruthy();
-        expect(geometry.getLatLngs()).toEqual([
+        expect(geometry.getCoordinates()).toEqual([
           [ 41.918628865183045, -8.96484375 ],
           [ 43.74728909225908, -7.84423828125 ],
           [ 43.34914966389313, -1.69189453125 ]
@@ -107,8 +107,8 @@ describe('src/geo/geometry-models/geometry-factory', function () {
 
       expect(geometry instanceof MultiPoint).toBeTruthy();
       expect(geometry.geometries.length).toEqual(2);
-      expect(geometry.geometries.at(0).getLatLng()).toEqual([ 0, 100 ]);
-      expect(geometry.geometries.at(1).getLatLng()).toEqual([ 1, 101 ]);
+      expect(geometry.geometries.at(0).getCoordinates()).toEqual([ 0, 100 ]);
+      expect(geometry.geometries.at(1).getCoordinates()).toEqual([ 1, 101 ]);
     });
 
     var multiPolygonGeometry = {
@@ -124,8 +124,8 @@ describe('src/geo/geometry-models/geometry-factory', function () {
 
       expect(geometry instanceof MultiPolygon).toBeTruthy();
       expect(geometry.geometries.length).toEqual(2);
-      expect(geometry.geometries.at(0).getLatLngs()).toEqual([ [ 2, 102 ], [ 2, 103 ], [ 3, 103 ], [ 3, 102 ] ]);
-      expect(geometry.geometries.at(1).getLatLngs()).toEqual([ [ 0, 100 ], [ 0, 101 ], [ 1, 101 ], [ 1, 100 ] ]);
+      expect(geometry.geometries.at(0).getCoordinates()).toEqual([ [ 2, 102 ], [ 2, 103 ], [ 3, 103 ], [ 3, 102 ] ]);
+      expect(geometry.geometries.at(1).getCoordinates()).toEqual([ [ 0, 100 ], [ 0, 101 ], [ 1, 101 ], [ 1, 100 ] ]);
     });
 
     var multiPolylineGeometry = {
@@ -141,8 +141,8 @@ describe('src/geo/geometry-models/geometry-factory', function () {
 
       expect(geometry instanceof MultiPolyline).toBeTruthy();
       expect(geometry.geometries.length).toEqual(2);
-      expect(geometry.geometries.at(0).getLatLngs()).toEqual([ [ 0, 100 ], [ 1, 101 ] ]);
-      expect(geometry.geometries.at(1).getLatLngs()).toEqual([ [ 2, 102 ], [ 3, 103 ] ]);
+      expect(geometry.geometries.at(0).getCoordinates()).toEqual([ [ 0, 100 ], [ 1, 101 ] ]);
+      expect(geometry.geometries.at(1).getCoordinates()).toEqual([ [ 2, 102 ], [ 3, 103 ] ]);
     });
   });
 });

--- a/test/unit/geo/geometry-models/multi-point.spec.js
+++ b/test/unit/geo/geometry-models/multi-point.spec.js
@@ -18,4 +18,15 @@ describe('src/geo/geometry-models/multi-point', function () {
       });
     });
   });
+
+  describe('.setCoordinatesFromGeoJSON', function () {
+    it('should update the coordinates', function () {
+      var newAndExpectedGeoJSON = {
+        type: 'MultiPoint',
+        coordinates: [ [ 0, 0 ], [ 10, 10 ] ]
+      };
+      this.multiPoint.setCoordinatesFromGeoJSON(newAndExpectedGeoJSON);
+      expect(this.multiPoint.toGeoJSON()).toEqual(newAndExpectedGeoJSON);
+    });
+  });
 });

--- a/test/unit/geo/geometry-models/multi-polygon.spec.js
+++ b/test/unit/geo/geometry-models/multi-polygon.spec.js
@@ -34,4 +34,21 @@ describe('src/geo/geometry-models/multi-polygon', function () {
       });
     });
   });
+
+  describe('.setCoordinatesFromGeoJSON', function () {
+    it('should update the coordinates', function () {
+      var newAndExpectedGeoJSON = {
+        type: 'MultiPolygon',
+        coordinates: [
+          [
+            [ [ 0, 0 ], [ 2, 1 ], [ 3, 2 ], [ 4, 3 ], [ 0, 0 ] ]
+          ], [
+            [ [ 100, 0 ], [ 20, 10 ], [ 30, 20 ], [ 40, 30 ], [ 100, 0 ] ]
+          ]
+        ]
+      };
+      this.multiPolygon.setCoordinatesFromGeoJSON(newAndExpectedGeoJSON);
+      expect(this.multiPolygon.toGeoJSON()).toEqual(newAndExpectedGeoJSON);
+    });
+  });
 });

--- a/test/unit/geo/geometry-models/multi-polyline.spec.js
+++ b/test/unit/geo/geometry-models/multi-polyline.spec.js
@@ -26,9 +26,9 @@ describe('src/geo/geometry-models/multi-polyline', function () {
         type: 'MultiLineString',
         coordinates: [
           [
-            [ [ 1, 0 ], [ 2, 1 ], [ 3, 2 ], [ 4, 3 ] ]
+            [ 1, 0 ], [ 2, 1 ], [ 3, 2 ], [ 4, 3 ]
           ], [
-            [ [ 10, 0 ], [ 20, 10 ], [ 30, 20 ], [ 40, 30 ] ]
+            [ 10, 0 ], [ 20, 10 ], [ 30, 20 ], [ 40, 30 ]
           ]
         ]
       });

--- a/test/unit/geo/geometry-models/multi-polyline.spec.js
+++ b/test/unit/geo/geometry-models/multi-polyline.spec.js
@@ -34,4 +34,21 @@ describe('src/geo/geometry-models/multi-polyline', function () {
       });
     });
   });
+
+  describe('.setCoordinatesFromGeoJSON', function () {
+    it('should update the coordinates', function () {
+      var newAndExpectedGeoJSON = {
+        type: 'MultiLineString',
+        coordinates: [
+          [
+            [ 100, 0 ], [ 2, 1 ], [ 3, 2 ], [ 40, 30 ]
+          ], [
+            [ 100, 0 ], [ 20, 10 ], [ 30, 20 ], [ 40, 30 ]
+          ]
+        ]
+      };
+      this.multiPolyline.setCoordinatesFromGeoJSON(newAndExpectedGeoJSON);
+      expect(this.multiPolyline.toGeoJSON()).toEqual(newAndExpectedGeoJSON);
+    });
+  });
 });

--- a/test/unit/geo/geometry-models/point-spec.js
+++ b/test/unit/geo/geometry-models/point-spec.js
@@ -15,4 +15,15 @@ describe('src/geo/geometry-models/point', function () {
       });
     });
   });
+
+  describe('.setCoordinatesFromGeoJSON', function () {
+    it('should update the coordinates', function () {
+      var newAndExpectedGeoJSON = {
+        type: 'Point',
+        coordinates: [ 0, 300 ]
+      };
+      this.point.setCoordinatesFromGeoJSON(newAndExpectedGeoJSON);
+      expect(this.point.toGeoJSON()).toEqual(newAndExpectedGeoJSON);
+    });
+  });
 });

--- a/test/unit/geo/geometry-models/polygon.spec.js
+++ b/test/unit/geo/geometry-models/polygon.spec.js
@@ -19,4 +19,17 @@ describe('src/geo/geometry-models/polygon', function () {
       });
     });
   });
+
+  describe('.setCoordinatesFromGeoJSON', function () {
+    it('should update the coordinates', function () {
+      var newAndExpectedGeoJSON = {
+        type: 'Polygon',
+        coordinates: [
+          [ [ 0, 0 ], [ 10, 10 ], [ 20, 20 ], [ 0, 0 ] ]
+        ]
+      };
+      this.polygon.setCoordinatesFromGeoJSON(newAndExpectedGeoJSON);
+      expect(this.polygon.toGeoJSON()).toEqual(newAndExpectedGeoJSON);
+    });
+  });
 });

--- a/test/unit/geo/geometry-models/polyline.spec.js
+++ b/test/unit/geo/geometry-models/polyline.spec.js
@@ -19,4 +19,17 @@ describe('src/geo/geometry-models/polyline', function () {
       });
     });
   });
+
+  describe('.setCoordinatesFromGeoJSON', function () {
+    it('should update the coordinates', function () {
+      var newAndExpectedGeoJSON = {
+        type: 'LineString',
+        coordinates: [
+          [ 0, 0 ], [ 1, 1 ], [ 2, 2 ]
+        ]
+      };
+      this.polyline.setCoordinatesFromGeoJSON(newAndExpectedGeoJSON);
+      expect(this.polyline.toGeoJSON()).toEqual(newAndExpectedGeoJSON);
+    });
+  });
 });


### PR DESCRIPTION
Required for https://github.com/CartoDB/cartodb/issues/10530.

Usage example:

```
polygon.setCoordinatesFromGeoJSON({
  type: 'Polygon',
  coordinates: [
    [ [ 0, 0 ], [ 10, 10 ], [ 20, 20 ], [ 0, 0 ] ]
  ]
});
```

Also, I renamed methods to get coordinates from points, polylines and polygons to `getCoordinates` and `setCoordinates`. Names were a bit inconsistent before.

@matallo could you please take a look? Thanks!