### PR TITLE
Only set coordinates when given a GeoJSON with different coordinates

### DIFF
--- a/src/geo/geometry-models/geometry-base.js
+++ b/src/geo/geometry-models/geometry-base.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var Model = require('../../core/model');
 
 var GeometryBase = Model.extend({
@@ -21,8 +22,15 @@ var GeometryBase = Model.extend({
     throw new Error('subclasses of GeometryBase must implement toGeoJSON');
   },
 
-  setCoordinatesFromGeoJSON: function () {
-    throw new Error('subclasses of GeometryBase must implement toGeoJSON');
+  setCoordinatesFromGeoJSON: function (geoJSON) {
+    var coordinates = this.getCoordinatesFromGeoJSONCoords(geoJSON);
+    if (!_.isEqual(coordinates, this.getCoordinates())) {
+      this.setCoordinates(coordinates);
+    }
+  },
+
+  getCoordinatesFromGeoJSONCoords: function (geoJSON) {
+    throw new Error('subclasses of GeometryBase must implement getCoordinatesFromGeoJSONCoords');
   },
 
   _triggerChangeEvent: function () {

--- a/src/geo/geometry-models/multi-point.js
+++ b/src/geo/geometry-models/multi-point.js
@@ -25,8 +25,12 @@ var MultiPoint = MultiGeometryBase.extend({
   },
 
   setCoordinatesFromGeoJSON: function (geoJSON) {
-    var latlngs = GeoJSONHelper.getMultiPointLatLngsFromGeoJSONCoords(geoJSON);
+    var latlngs = this.getCoordinatesFromGeoJSONCoords(geoJSON);
     this.geometries.reset(this._createGeometries(latlngs));
+  },
+
+  getCoordinatesFromGeoJSONCoords: function (geoJSON) {
+    return GeoJSONHelper.getMultiPointLatLngsFromGeoJSONCoords(geoJSON);
   }
 });
 

--- a/src/geo/geometry-models/multi-polygon.js
+++ b/src/geo/geometry-models/multi-polygon.js
@@ -26,8 +26,12 @@ var MultiPolygon = MultiGeometryBase.extend({
   },
 
   setCoordinatesFromGeoJSON: function (geoJSON) {
-    var latlngs = GeoJSONHelper.getMultiPolygonLatLngsFromGeoJSONCoords(geoJSON);
+    var latlngs = this.getCoordinatesFromGeoJSONCoords(geoJSON);
     this.geometries.reset(this._createGeometries(latlngs));
+  },
+
+  getCoordinatesFromGeoJSONCoords: function (geoJSON) {
+    return GeoJSONHelper.getMultiPolygonLatLngsFromGeoJSONCoords(geoJSON);
   }
 });
 

--- a/src/geo/geometry-models/multi-polyline.js
+++ b/src/geo/geometry-models/multi-polyline.js
@@ -26,8 +26,12 @@ var MultiPolyline = MultiGeometryBase.extend({
   },
 
   setCoordinatesFromGeoJSON: function (geoJSON) {
-    var latlngs = GeoJSONHelper.getMultiPolylineLatLngsFromGeoJSONCoords(geoJSON);
+    var latlngs = this.getCoordinatesFromGeoJSONCoords(geoJSON);
     this.geometries.reset(this._createGeometries(latlngs));
+  },
+
+  getCoordinatesFromGeoJSONCoords: function (geoJSON) {
+    return GeoJSONHelper.getMultiPolylineLatLngsFromGeoJSONCoords(geoJSON);
   }
 });
 

--- a/src/geo/geometry-models/point.js
+++ b/src/geo/geometry-models/point.js
@@ -34,9 +34,8 @@ var Point = GeometryBase.extend({
     };
   },
 
-  setCoordinatesFromGeoJSON: function (geoJSON) {
-    var latlng = GeoJSONHelper.getPointLatLngFromGeoJSONCoords(geoJSON);
-    this.setCoordinates(latlng);
+  getCoordinatesFromGeoJSONCoords: function (geoJSON) {
+    return GeoJSONHelper.getPointLatLngFromGeoJSONCoords(geoJSON);
   }
 });
 

--- a/src/geo/geometry-models/polygon.js
+++ b/src/geo/geometry-models/polygon.js
@@ -19,9 +19,8 @@ var Polygon = PathBase.extend({
     };
   },
 
-  setCoordinatesFromGeoJSON: function (geoJSON) {
-    var latlngs = GeoJSONHelper.getPolygonLatLngsFromGeoJSONCoords(geoJSON);
-    this.setCoordinates(latlngs);
+  getCoordinatesFromGeoJSONCoords: function (geoJSON) {
+    return GeoJSONHelper.getPolygonLatLngsFromGeoJSONCoords(geoJSON);
   }
 });
 

--- a/src/geo/geometry-models/polyline.js
+++ b/src/geo/geometry-models/polyline.js
@@ -19,9 +19,8 @@ var Polyline = PathBase.extend({
     };
   },
 
-  setCoordinatesFromGeoJSON: function (geoJSON) {
-    var latlngs = GeoJSONHelper.getPolylineLatLngsFromGeoJSONCoords(geoJSON);
-    this.setCoordinates(latlngs);
+  getCoordinatesFromGeoJSONCoords: function (geoJSON) {
+    return GeoJSONHelper.getPolylineLatLngsFromGeoJSONCoords(geoJSON);
   }
 });
 

--- a/test/unit/geo/geometry-models/point-spec.js
+++ b/test/unit/geo/geometry-models/point-spec.js
@@ -17,13 +17,42 @@ describe('src/geo/geometry-models/point', function () {
   });
 
   describe('.setCoordinatesFromGeoJSON', function () {
-    it('should update the coordinates', function () {
-      var newAndExpectedGeoJSON = {
-        type: 'Point',
-        coordinates: [ 0, 300 ]
-      };
-      this.point.setCoordinatesFromGeoJSON(newAndExpectedGeoJSON);
-      expect(this.point.toGeoJSON()).toEqual(newAndExpectedGeoJSON);
+    beforeEach(function () {
+      this.changeCallback = jasmine.createSpy('changeCallback');
+      this.point.on('change', this.changeCallback);
+    });
+
+    describe('when given a GeoJSON with the same coordinates', function () {
+      beforeEach(function () {
+        var newAndExpectedGeoJSON = this.point.toGeoJSON();
+        this.point.setCoordinatesFromGeoJSON(newAndExpectedGeoJSON);
+      });
+
+      it('should NOT trigger a "change" event', function () {
+        expect(this.changeCallback).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when given a GeoJSON with different coordinates', function () {
+      beforeEach(function () {
+        var newAndExpectedGeoJSON = {
+          type: 'Point',
+          coordinates: [ 0, 300 ]
+        };
+        this.point.setCoordinatesFromGeoJSON(newAndExpectedGeoJSON);
+        expect(this.point.toGeoJSON()).toEqual(newAndExpectedGeoJSON);
+      });
+
+      it('should trigger a "change" event', function () {
+        expect(this.changeCallback).toHaveBeenCalled();
+      });
+
+      it('should update the coordinates', function () {
+        expect(this.point.toGeoJSON()).toEqual({
+          type: 'Point',
+          coordinates: [ 0, 300 ]
+        });
+      });
     });
   });
 });

--- a/test/unit/geo/geometry-models/polygon.spec.js
+++ b/test/unit/geo/geometry-models/polygon.spec.js
@@ -21,15 +21,46 @@ describe('src/geo/geometry-models/polygon', function () {
   });
 
   describe('.setCoordinatesFromGeoJSON', function () {
-    it('should update the coordinates', function () {
-      var newAndExpectedGeoJSON = {
-        type: 'Polygon',
-        coordinates: [
-          [ [ 0, 0 ], [ 10, 10 ], [ 20, 20 ], [ 0, 0 ] ]
-        ]
-      };
-      this.polygon.setCoordinatesFromGeoJSON(newAndExpectedGeoJSON);
-      expect(this.polygon.toGeoJSON()).toEqual(newAndExpectedGeoJSON);
+    beforeEach(function () {
+      this.changeCallback = jasmine.createSpy('changeCallback');
+      this.polygon.on('change', this.changeCallback);
+    });
+
+    describe('when given a GeoJSON with the same coordinates', function () {
+      beforeEach(function () {
+        var newAndExpectedGeoJSON = this.polygon.toGeoJSON();
+        this.polygon.setCoordinatesFromGeoJSON(newAndExpectedGeoJSON);
+      });
+
+      it('should NOT trigger a "change" event', function () {
+        expect(this.changeCallback).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when given a GeoJSON with different coordinates', function () {
+      beforeEach(function () {
+        var newAndExpectedGeoJSON = {
+          type: 'Polygon',
+          coordinates: [
+            [ [ 0, 0 ], [ 10, 10 ], [ 20, 20 ], [ 0, 0 ] ]
+          ]
+        };
+        this.polygon.setCoordinatesFromGeoJSON(newAndExpectedGeoJSON);
+        expect(this.polygon.toGeoJSON()).toEqual(newAndExpectedGeoJSON);
+      });
+
+      it('should trigger a "change" event', function () {
+        expect(this.changeCallback).toHaveBeenCalled();
+      });
+
+      it('should update the coordinates', function () {
+        expect(this.polygon.toGeoJSON()).toEqual({
+          type: 'Polygon',
+          coordinates: [
+            [ [ 0, 0 ], [ 10, 10 ], [ 20, 20 ], [ 0, 0 ] ]
+          ]
+        });
+      });
     });
   });
 });

--- a/test/unit/geo/geometry-models/polyline.spec.js
+++ b/test/unit/geo/geometry-models/polyline.spec.js
@@ -21,15 +21,44 @@ describe('src/geo/geometry-models/polyline', function () {
   });
 
   describe('.setCoordinatesFromGeoJSON', function () {
-    it('should update the coordinates', function () {
-      var newAndExpectedGeoJSON = {
-        type: 'LineString',
-        coordinates: [
-          [ 0, 0 ], [ 1, 1 ], [ 2, 2 ]
-        ]
-      };
-      this.polyline.setCoordinatesFromGeoJSON(newAndExpectedGeoJSON);
-      expect(this.polyline.toGeoJSON()).toEqual(newAndExpectedGeoJSON);
+    beforeEach(function () {
+      this.changeCallback = jasmine.createSpy('changeCallback');
+      this.polyline.on('change', this.changeCallback);
+    });
+
+    describe('when given a GeoJSON with the same coordinates', function () {
+      beforeEach(function () {
+        var newAndExpectedGeoJSON = this.polyline.toGeoJSON();
+        this.polyline.setCoordinatesFromGeoJSON(newAndExpectedGeoJSON);
+      });
+
+      it('should NOT trigger a "change" event', function () {
+        expect(this.changeCallback).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when given a GeoJSON with different coordinates', function () {
+      beforeEach(function () {
+        var newAndExpectedGeoJSON = {
+          type: 'LineString',
+          coordinates: [
+            [ 0, 0 ], [ 1, 1 ], [ 2, 2 ]
+          ]
+        };
+        this.polyline.setCoordinatesFromGeoJSON(newAndExpectedGeoJSON);
+        expect(this.polyline.toGeoJSON()).toEqual(newAndExpectedGeoJSON);
+      });
+
+      it('should trigger a "change" event', function () {
+        expect(this.changeCallback).toHaveBeenCalled();
+      });
+
+      it('should update the coordinates', function () {
+        expect(this.polyline.toGeoJSON()).toEqual({
+          type: 'LineString',
+          coordinates: [ [ 0, 0 ], [ 1, 1 ], [ 2, 2 ] ]
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
To prevent triggering of unnecessary 'change' events.

@matallo please take a look. Thanks!