### PR TITLE
unset feature events after layer remove

### DIFF
--- a/src/vis/feature-events.js
+++ b/src/vis/feature-events.js
@@ -16,6 +16,7 @@ var CartoDBFeatureEvents = function (deps) {
   this._mapModel = deps.mapModel;
 
   this._mapModel.layers.on('add', this._setLayerView, this);
+  this._mapModel.layers.on('remove', this._unsetLayerView, this);
   this._mapModel.layers.on('reset', this._setLayerView, this);
   this._setLayerView();
 };
@@ -33,6 +34,13 @@ CartoDBFeatureEvents.prototype._setLayerView = function () {
   if (cartoDBLayers.length > 0) {
     this._layerView = this._mapView.getLayerViewByLayerCid(cartoDBLayers[0].cid);
     this._bindCartoDBFeatureEvents();
+  }
+};
+
+CartoDBFeatureEvents.prototype._unsetLayerView = function () {
+  if (this._layerView) {
+    this._unbindCartoDBFeatureEvents();
+    delete this._layerView;
   }
 };
 


### PR DESCRIPTION
tracked down this issue https://github.com/CartoDB/cartodb/issues/10542 until the feature events

despite I could easily have checked the `layerModel` in https://github.com/CartoDB/cartodb.js/blob/v4/src/vis/map-cursor-manager.js#L70 to prevent the `undefined` I thought something could still be not ok, I realized we were firing `featureOut` events on the layer we had removed

I don't really know if this change will bring unintended consequences but looks like unbinding the events on layer remove fixes this, let's discuss the tests tomorrow @alonsogarciapablo 

/cc @xavijam @javisantana @nobuti 