### PR TITLE
Use only field names to compare infowindow/tooltip fields when they are updated

### DIFF
--- a/src/geo/map/infowindow-template.js
+++ b/src/geo/map/infowindow-template.js
@@ -1,5 +1,6 @@
 var _ = require('underscore');
 var Backbone = require('backbone');
+var PopupFields = require('./popup-fields');
 
 var InfowindowTemplate = Backbone.Model.extend({
   defaults: {
@@ -10,14 +11,14 @@ var InfowindowTemplate = Backbone.Model.extend({
 
   initialize: function (attrs) {
     attrs = attrs || {};
-    this.fields = new Backbone.Collection(attrs.fields || []);
+    this.fields = new PopupFields(attrs.fields || []);
     this.unset('fields');
   },
 
   update: function (attrs) {
     attrs = _.clone(attrs);
 
-    if (!_.isEqual(attrs.fields, this.fields.toJSON())) {
+    if (!this.fields.equals(attrs.fields)) {
       this.fields.reset(attrs.fields);
     }
     delete attrs.fields;

--- a/src/geo/map/popup-fields.js
+++ b/src/geo/map/popup-fields.js
@@ -1,0 +1,15 @@
+var _ = require('underscore');
+var Backbone = require('backbone');
+
+var getFieldNames = function (fields) {
+  return _.map(fields, 'name');
+};
+
+var PopupFields = Backbone.Collection.extend({
+  equals: function (otherFields) {
+    var myFields = this.toJSON();
+    return _.isEqual(getFieldNames(myFields), getFieldNames(otherFields));
+  }
+});
+
+module.exports = PopupFields;

--- a/src/geo/map/tooltip-template.js
+++ b/src/geo/map/tooltip-template.js
@@ -1,5 +1,6 @@
 var _ = require('underscore');
 var Backbone = require('backbone');
+var PopupFields = require('./popup-fields');
 
 var TooltipTemplate = Backbone.Model.extend({
   defaults: {
@@ -12,14 +13,14 @@ var TooltipTemplate = Backbone.Model.extend({
 
   initialize: function (attrs) {
     attrs = attrs || {};
-    this.fields = new Backbone.Collection(attrs.fields || []);
+    this.fields = new PopupFields(attrs.fields || []);
     this.unset('fields');
   },
 
   update: function (attrs) {
     attrs = _.clone(attrs);
 
-    if (!_.isEqual(attrs.fields, this.fields.toJSON())) {
+    if (!this.fields.equals(attrs.fields)) {
       this.fields.reset(attrs.fields);
     }
     delete attrs.fields;

--- a/test/unit/geo/map/infowindow-template.spec.js
+++ b/test/unit/geo/map/infowindow-template.spec.js
@@ -42,6 +42,41 @@ describe('geo/map/infowindow-template', function () {
       expect(this.callback).not.toHaveBeenCalled();
     });
 
+    it('should NOT reset the fields when given the same fields with different `position`', function () {
+      this.infowindowTemplate.update({
+        fields: [
+          { name: 'Name', title: true, position: 0 }
+        ]
+      });
+
+      expect(this.infowindowTemplate.fields.toJSON()).toEqual([
+        { name: 'Name', title: true, position: 1 }
+      ]);
+
+      expect(this.callback).not.toHaveBeenCalled();
+    });
+
+    it('should reset the fields when given the same fields with different `position` and order', function () {
+      this.infowindowTemplate.update({
+        fields: [
+          { name: 'Name', title: true, position: 0 },
+          { name: 'Description', title: true, position: 1 }
+        ]
+      });
+
+      expect(this.callback).toHaveBeenCalled();
+      this.callback.calls.reset();
+
+      this.infowindowTemplate.update({
+        fields: [
+          { name: 'Description', title: true, position: 0 },
+          { name: 'Name', title: true, position: 1 }
+        ]
+      });
+
+      expect(this.callback).toHaveBeenCalled();
+    });
+
     it('should clone alternative names', function () {
       var callback = jasmine.createSpy('callback');
       this.infowindowTemplate.bind('change', callback);

--- a/test/unit/geo/map/tooltip-template.spec.js
+++ b/test/unit/geo/map/tooltip-template.spec.js
@@ -42,6 +42,41 @@ describe('geo/map/tooltip-template', function () {
       expect(this.callback).not.toHaveBeenCalled();
     });
 
+    it('should NOT reset the fields when given the same fields with different `position`', function () {
+      this.tooltipTemplate.update({
+        fields: [
+          { name: 'Name', title: true, position: 2 }
+        ]
+      });
+
+      expect(this.tooltipTemplate.fields.toJSON()).toEqual([
+        { name: 'Name', title: true, position: 1 }
+      ]);
+
+      expect(this.callback).not.toHaveBeenCalled();
+    });
+
+    it('should reset the fields when given the same fields with different `position` and order', function () {
+      this.tooltipTemplate.update({
+        fields: [
+          { name: 'Name', title: true, position: 0 },
+          { name: 'Description', title: true, position: 1 }
+        ]
+      });
+
+      expect(this.callback).toHaveBeenCalled();
+      this.callback.calls.reset();
+
+      this.tooltipTemplate.update({
+        fields: [
+          { name: 'Description', title: true, position: 0 },
+          { name: 'Name', title: true, position: 1 }
+        ]
+      });
+
+      expect(this.callback).toHaveBeenCalled();
+    });
+
     it('should clone alternative names', function () {
       var callback = jasmine.createSpy('callback');
       this.tooltipTemplate.bind('change', callback);


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb.js/issues/1499. Please read the issue for some context.

@matallo 👍  ? Thanks!