### PR TITLE
Fixed bug & tests

### DIFF
--- a/src/api/sql.js
+++ b/src/api/sql.js
@@ -3,6 +3,10 @@ var $ = require('jquery');
 var Mustache = require('mustache');
 var Promise = require('./promise');
 
+var errorMessages = {
+  NO_BOUNDS: 'No bounds'
+};
+
 function SQL(options) {
   if(window.cdb === this || window === this) {
     return new SQL(options);
@@ -201,6 +205,10 @@ SQL.prototype.getBounds = function(sql, vars, options, callback) {
         var bounds = [[lat0, lon0], [lat1, lon1]];
         promise.trigger('done', bounds);
         callback && callback(null, bounds);
+      } else {
+        var err = [errorMessages.NO_BOUNDS];
+        promise.trigger('error', err);
+        callback && callback(err);
       }
     })
     .error(function(err) {

--- a/src/api/sql.js
+++ b/src/api/sql.js
@@ -3,9 +3,7 @@ var $ = require('jquery');
 var Mustache = require('mustache');
 var Promise = require('./promise');
 
-var errorMessages = {
-  NO_BOUNDS: 'No bounds'
-};
+var NO_BOUNDS_ERROR_MESSAGE = 'No bounds';
 
 function SQL(options) {
   if(window.cdb === this || window === this) {
@@ -206,7 +204,7 @@ SQL.prototype.getBounds = function(sql, vars, options, callback) {
         promise.trigger('done', bounds);
         callback && callback(null, bounds);
       } else {
-        var err = [errorMessages.NO_BOUNDS];
+        var err = [NO_BOUNDS_ERROR_MESSAGE];
         promise.trigger('error', err);
         callback && callback(err);
       }

--- a/test/spec/api/sql.spec.js
+++ b/test/spec/api/sql.spec.js
@@ -264,6 +264,7 @@ describe('api/sql', function() {
       var prevTestData = TEST_DATA;
       var actualErrors = null;
       TEST_DATA = NO_BOUNDS;
+      throwError = false;
 
       s = new SQL({ user: 'jaja' });
       s.getBounds('SELECT * FROM somewhere')
@@ -284,6 +285,7 @@ describe('api/sql', function() {
       var prevTestData = TEST_DATA;
       var actualErrors = null;
       TEST_DATA = NO_BOUNDS;
+      throwError = false;
 
       function cb(err) {
         actualErrors = err;


### PR DESCRIPTION
Fixes a corner case in the SQL.getBounds function: when the API returns no bounds, neither the promise was resolved nor the callback was called.

CR @alonsogarciapablo 
CC @xavijam 