### PR TITLE
Fixed not formatted label on legends

### DIFF
--- a/src/geo/ui/legends/choropleth/legend-template.tpl
+++ b/src/geo/ui/legends/choropleth/legend-template.tpl
@@ -3,8 +3,8 @@
     <p class="CDB-Text CDB-Size-small"><%- prefix %> <%= labels.left %> <%- suffix %></p>
     <p class="CDB-Text CDB-Size-small"><%- prefix %> <%= labels.right %> <%- suffix %></p>
   <% } else { %>
-    <p class="CDB-Text CDB-Size-small"><%- prefix %> <%- labels.left %> <%- suffix %></p>
-    <p class="CDB-Text CDB-Size-small"><%- prefix %> <%- labels.right %> <%- suffix %></p>
+    <p class="CDB-Text CDB-Size-small"><%- prefix %> <%= labels.left %> <%- suffix %></p>
+    <p class="CDB-Text CDB-Size-small"><%- prefix %> <%= labels.right %> <%- suffix %></p>
   <% } %>
 </div>
 <div class="Legend-choropleth" style="opacity:1; background: linear-gradient(90deg <% for(var i in colors) { %>,<%= colors[i].value %><% } %>);">

--- a/src/geo/ui/legends/choropleth/legend-view.js
+++ b/src/geo/ui/legends/choropleth/legend-view.js
@@ -1,6 +1,7 @@
 var LegendViewBase = require('../base/legend-view-base');
 var template = require('./legend-template.tpl');
 var formatter = require('../../../../util/formatter');
+var Sanitize = require('../../../../core/sanitize');
 
 var ChoroplethLegendView = LegendViewBase.extend({
   _getCompiledTemplate: function () {
@@ -27,8 +28,8 @@ var ChoroplethLegendView = LegendViewBase.extend({
     var leftLabel = this.model.get('leftLabel');
     var rightLabel = this.model.get('rightLabel');
     var o = {};
-    o.left = formatter.formatNumber(colors[0].label);
-    o.right = formatter.formatNumber(colors[colors.length - 1].label);
+    o.left = Sanitize.html(formatter.formatNumber(colors[0].label));
+    o.right = Sanitize.html(formatter.formatNumber(colors[colors.length - 1].label));
     if (leftLabel != null && leftLabel !== '') {
       o.left = leftLabel;
     }


### PR DESCRIPTION
Fixes #1533

The problem was that in the template the variable correspondent to the label wasn't being formatted correctly, so in case it had HTML inside it wasn't interpreted.

<img width="258" alt="screen shot 2016-12-13 at 12 00 17" src="https://cloud.githubusercontent.com/assets/2141690/21138467/73d00340-c12e-11e6-94d9-129c4f3a6d28.png">

### How to test

1. Go to Builder map
2. Create a gradient legend for a column with number type where at least one field has a decimal value (i.e. `0.0000000078`)
3. In "Creating you legend" step, select left label
4. The expected result is a decimal number formatted as mantissa and exponent (`[mantissa]x10^[exponent]`)