### PR TITLE
More prep work for Google Maps support

### DIFF
--- a/examples/v4/leaflet-layergroup.html
+++ b/examples/v4/leaflet-layergroup.html
@@ -32,18 +32,8 @@
           "legends":true,
           "url":null,
           "map_provider":"leaflet",
-          "bounds":[
-            [
-              -18.979025953255253,
-              -155.7421875
-            ],
-            [
-              80.58972691308571,
-              261.2109375
-            ]
-          ],
           "center":"[52.5897007687178, 52.734375]",
-          "zoom":2,
+          "zoom":4,
           "updated_at":"2015-03-13T11:24:37+00:00",
           "datasource": {
             "user_name": "documentation",

--- a/src/geo/cartodb-layer-group-view-base.js
+++ b/src/geo/cartodb-layer-group-view-base.js
@@ -1,9 +1,14 @@
 function CartoDBLayerGroupViewBase (layerGroupModel) {
+  this.interaction = [];
+
   layerGroupModel.on('change:urls', this._reload, this);
   layerGroupModel.onLayerVisibilityChanged(this._reload.bind(this));
+
+  this._reload();
 }
 
 CartoDBLayerGroupViewBase.prototype = {
+  // TODO: Rename to something else
   _reload: function () {
     throw new Error('_reload must be implemented');
   },

--- a/src/geo/cartodb-layer-group-view-base.js
+++ b/src/geo/cartodb-layer-group-view-base.js
@@ -8,7 +8,6 @@ function CartoDBLayerGroupViewBase (layerGroupModel) {
 }
 
 CartoDBLayerGroupViewBase.prototype = {
-  // TODO: Rename to something else
   _reload: function () {
     throw new Error('_reload must be implemented');
   },

--- a/src/geo/gmaps/gmaps-cartodb-layer-group-view.js
+++ b/src/geo/gmaps/gmaps-cartodb-layer-group-view.js
@@ -78,7 +78,6 @@ var GMapsCartoDBLayerGroupView = function (layerModel, gmapsMap) {
 
   this.options = _.defaults(opts, CartoDBDefaultOptions);
   this.tiles = 0;
-  this.interaction = [];
 
   wax.g.connector.call(this, opts);
 
@@ -209,10 +208,6 @@ _.extend(
     clear: function () {
       this._clearInteraction();
       this.finishLoading && this.finishLoading();
-    },
-
-    update: function () {
-      this._reload.apply(this, arguments);
     },
 
     _reload: function () {

--- a/src/geo/gmaps/gmaps-map-view.js
+++ b/src/geo/gmaps/gmaps-map-view.js
@@ -8,56 +8,36 @@ var GMapsLayerViewFactory = require('./gmaps-layer-view-factory');
 var GoogleMapsMapView = MapView.extend({
   initialize: function () {
     MapView.prototype.initialize.call(this);
-
     _.bindAll(this, '_ready');
     this._isReady = false;
+  },
+
+  _createNativeMap: function () {
     var self = this;
-
-    var bounds = this.map.getViewBounds();
-
-    if (bounds) {
-      this.showBounds(bounds);
-    }
-
     var center = this.map.get('center');
 
-    if (!this.isMapAlreadyCreated()) {
-      this._gmapsMap = new google.maps.Map(this.el, {
-        center: new google.maps.LatLng(center[0], center[1]),
-        zoom: this.map.get('zoom'),
-        minZoom: this.map.get('minZoom'),
-        maxZoom: this.map.get('maxZoom'),
-        disableDefaultUI: true,
-        scrollwheel: this.map.get('scrollwheel'),
-        draggable: this.map.get('drag'),
-        disableDoubleClickZoom: !this.map.get('drag'),
-        mapTypeControl: false,
-        mapTypeId: google.maps.MapTypeId.ROADMAP,
-        backgroundColor: 'white',
-        tilt: 0
-      });
+    this._gmapsMap = new google.maps.Map(this.el, {
+      center: new google.maps.LatLng(center[0], center[1]),
+      zoom: this.map.get('zoom'),
+      minZoom: this.map.get('minZoom'),
+      maxZoom: this.map.get('maxZoom'),
+      disableDefaultUI: true,
+      scrollwheel: this.map.get('scrollwheel'),
+      draggable: this.map.get('drag'),
+      disableDoubleClickZoom: !this.map.get('drag'),
+      mapTypeControl: false,
+      mapTypeId: google.maps.MapTypeId.ROADMAP,
+      backgroundColor: 'white',
+      tilt: 0
+    });
 
-      this.map.bind('change:maxZoom', function () {
-        self._gmapsMap.setOptions({ maxZoom: self.map.get('maxZoom') });
-      }, this);
+    this.map.bind('change:maxZoom', function () {
+      self._gmapsMap.setOptions({ maxZoom: self.map.get('maxZoom') });
+    }, this);
 
-      this.map.bind('change:minZoom', function () {
-        self._gmapsMap.setOptions({ minZoom: self.map.get('minZoom') });
-      }, this);
-    } else {
-      this._gmapsMap = this.options.map_object;
-      this.setElement(this._gmapsMap.getDiv());
-
-      // fill variables
-      var c = self._gmapsMap.getCenter();
-
-      self._setModelProperty({ center: [c.lat(), c.lng()] });
-      self._setModelProperty({ zoom: self._gmapsMap.getZoom() });
-
-      // unset bounds to not change mapbounds
-      self.map.unset('view_bounds_sw', { silent: true });
-      self.map.unset('view_bounds_ne', { silent: true });
-    }
+    this.map.bind('change:minZoom', function () {
+      self._gmapsMap.setOptions({ minZoom: self.map.get('minZoom') });
+    }, this);
 
     google.maps.event.addListener(this._gmapsMap, 'center_changed', function () {
       var c = self._gmapsMap.getCenter();
@@ -85,9 +65,6 @@ var GoogleMapsMapView = MapView.extend({
     google.maps.event.addListener(this._gmapsMap, 'dblclick', function (e) {
       self.trigger('dblclick', e);
     });
-
-    this._bindModel();
-    this.setAttribution();
 
     this.projector = new Projector(this._gmapsMap);
 
@@ -190,7 +167,7 @@ var GoogleMapsMapView = MapView.extend({
     return [ [0, 0], [0, 0] ];
   },
 
-  setAttribution: function () {
+  _setAttribution: function () {
     // There is no control over Google Maps attribution component, so we can't add
     // any attribution text there (if Map is already created using createLayer for example)
     // and there is no CartoDB attribution component.

--- a/src/geo/gmaps/projector.js
+++ b/src/geo/gmaps/projector.js
@@ -8,14 +8,14 @@ Projector.prototype.latLngToPixel = function (point) {
   if (p) {
     return p.fromLatLngToContainerPixel(point);
   }
-  return [0, 0];
+  return new google.maps.Point(0, 0);
 };
 Projector.prototype.pixelToLatLng = function (point) {
   var p = this.getProjection();
   if (p) {
     return p.fromContainerPixelToLatLng(point);
   }
-  return [0, 0];
+  return new google.maps.LatLng(0, 0);
 };
 
 module.exports = Projector;

--- a/src/geo/leaflet/leaflet-cartodb-layer-group-view.js
+++ b/src/geo/leaflet/leaflet-cartodb-layer-group-view.js
@@ -41,7 +41,6 @@ var LeafletCartoDBLayerGroupView = L.TileLayer.extend({
   initialize: function (layerModel, leafletMap) {
     var self = this;
     var hovers = [];
-    this.interaction = [];
 
     // TODO: Be more explicit about the options that are really used by the L.TileLayer
     var opts = _.clone(layerModel.attributes);
@@ -99,9 +98,9 @@ var LeafletCartoDBLayerGroupView = L.TileLayer.extend({
 
     this.addProfiling();
 
-    CartoDBLayerGroupViewBase.call(this, layerModel);
-    L.TileLayer.prototype.initialize.call(this);
     LeafletLayerView.call(this, layerModel, this, leafletMap);
+    L.TileLayer.prototype.initialize.call(this);
+    CartoDBLayerGroupViewBase.call(this, layerModel);
   },
 
   featureOver: function (e, latlon, pixelPos, data, layer) {
@@ -215,19 +214,22 @@ var LeafletCartoDBLayerGroupView = L.TileLayer.extend({
    * @param {Event} Wax event
    */
   _manageOnEvents: function (map, o) {
-    var layer_point = this._findPos(map, o);
+    var layerPoint = this._findPos(map, o);
 
-    if (!layer_point || isNaN(layer_point.x) || isNaN(layer_point.y)) {
-      // If layer_point doesn't contain x and y,
+    if (!layerPoint || isNaN(layerPoint.x) || isNaN(layerPoint.y)) {
+      // If layerPoint doesn't contain x and y,
       // we can't calculate event map position
       return false;
     }
 
-    var latlng = map.layerPointToLatLng(layer_point);
-    var event_type = o.e.type.toLowerCase();
-    var screenPos = map.layerPointToContainerPoint(layer_point);
-
-    switch (event_type) {
+    var latlng = map.layerPointToLatLng(layerPoint);
+    var containerPoint = map.layerPointToContainerPoint(layerPoint);
+    var screenPos = {
+      x: containerPoint.x,
+      y: containerPoint.y
+    };
+    var eventType = o.e.type.toLowerCase();
+    switch (eventType) {
       case 'mousemove':
         if (this.options.featureOver) {
           return this.options.featureOver(o.e, latlng, screenPos, o.data, o.layer);

--- a/src/geo/leaflet/leaflet-map-view.js
+++ b/src/geo/leaflet/leaflet-map-view.js
@@ -147,10 +147,11 @@ var LeafletMapView = MapView.extend({
 
     // remove layer views
     for (var layer in this._layerViews) {
-      var layerView = this._layerViews[layer];
-      layerView.remove();
       delete this._layerViews[layer];
     }
+
+    // destroy the map and clear all related event listeners
+    this._leafletMap.remove();
 
     View.prototype.clean.call(this);
   },

--- a/src/geo/leaflet/leaflet-map-view.js
+++ b/src/geo/leaflet/leaflet-map-view.js
@@ -2,7 +2,6 @@ var $ = require('jquery');
 var _ = require('underscore');
 var L = require('leaflet');
 var MapView = require('../map-view');
-var View = require('../../core/view');
 var Sanitize = require('../../core/sanitize');
 var LeafletLayerViewFactory = require('./leaflet-layer-view-factory');
 
@@ -153,7 +152,7 @@ var LeafletMapView = MapView.extend({
     // destroy the map and clear all related event listeners
     this._leafletMap.remove();
 
-    View.prototype.clean.call(this);
+    MapView.prototype.clean.call(this);
   },
 
   _setKeyboard: function (model, z) {

--- a/src/geo/leaflet/leaflet-map-view.js
+++ b/src/geo/leaflet/leaflet-map-view.js
@@ -144,11 +144,6 @@ var LeafletMapView = MapView.extend({
     // see https://github.com/CloudMade/Leaflet/issues/1101
     L.DomEvent.off(window, 'resize', this._leafletMap._onResize, this._leafletMap);
 
-    // remove layer views
-    for (var layer in this._layerViews) {
-      delete this._layerViews[layer];
-    }
-
     // destroy the map and clear all related event listeners
     this._leafletMap.remove();
 

--- a/src/geo/map-view-factory.js
+++ b/src/geo/map-view-factory.js
@@ -3,7 +3,7 @@ var cdb = require('cdb');
 
 var MapViewFactory = function () {};
 
-MapViewFactory.prototype.createMapView = function (provider, mapModel, el, layerGroupModel) {
+MapViewFactory.prototype.createMapView = function (provider, mapModel, layerGroupModel) {
   var MapViewClass;
 
   if (provider === 'leaflet') {
@@ -19,7 +19,6 @@ MapViewFactory.prototype.createMapView = function (provider, mapModel, el, layer
   }
 
   return new MapViewClass({
-    el: el,
     map: mapModel,
     layerGroupModel: layerGroupModel
   });

--- a/src/geo/map-view.js
+++ b/src/geo/map-view.js
@@ -3,6 +3,9 @@ var View = require('../core/view');
 var GeometryViewFactory = require('./geometry-views/geometry-view-factory');
 
 var MapView = View.extend({
+
+  className: 'CDB-Map-wrapper',
+
   initialize: function () {
     this.options = this.options || {};
     if (this.options.map === undefined) throw new Error('map is required');
@@ -18,6 +21,8 @@ var MapView = View.extend({
     // The cid of the layer model is used as the key for this mapping.
     this._layerViews = {};
 
+    this._bindModel();
+
     this.map.layers.bind('reset', this._addLayers, this);
     this.map.layers.bind('add', this._addLayer, this);
     this.map.layers.bind('remove', this._removeLayer, this);
@@ -31,56 +36,20 @@ var MapView = View.extend({
     this.add_related_model(this.map.geometries);
   },
 
-  _getLayerViewFactory: function () {
-    throw new Error('subclasses of MapView must implement _getLayerViewFactory');
-  },
-
-  setCursor: function () {
-    throw new Error('subclasses of MapView must implement setCursor');
-  },
-
-  addMarker: function (marker) {
-    throw new Error('subclasses of MapView must implement addMarker');
-  },
-
-  removeMarker: function (marker) {
-    throw new Error('subclasses of MapView must implement removeMarker');
-  },
-
-  hasMarker: function (marker) {
-    throw new Error('subclasses of MapView must implement hasMarker');
-  },
-
-  addPath: function (path) {
-    throw new Error('subclasses of MapView must implement addPath');
-  },
-
-  removePath: function (path) {
-    throw new Error('subclasses of MapView must implement removePath');
-  },
-
-  // returns { x: 100, y: 200 }
-  latLngToContainerPoint: function (latlng) {
-    throw new Error('subclasses of MapView must implement latLngToContainerPoint');
-  },
-
-  // returns { lat: 0, lng: 0}
-  containerPointToLatLng: function (point) {
-    throw new Error('subclasses of MapView must implement containerPointToLatLng');
+  render: function () {
+    this._createNativeMap();
+    this._setAttribution();
+    var bounds = this.map.getViewBounds();
+    if (bounds) {
+      this._fitBounds(bounds);
+    }
+    this._addLayers();
+    return this;
   },
 
   _onGeometryAdded: function (geometry) {
     var geometryView = GeometryViewFactory.createGeometryView(this.map.get('provider'), geometry, this);
     geometryView.render();
-  },
-
-  render: function () {
-    this._addLayers();
-    return this;
-  },
-
-  isMapAlreadyCreated: function () {
-    return this.options.map_object;
   },
 
   /**
@@ -108,7 +77,7 @@ var MapView = View.extend({
     this.map.bind('change:scrollwheel', this._setScrollWheel, this);
     this.map.bind('change:keyboard', this._setKeyboard, this);
     this.map.bind('change:center', this._setCenter, this);
-    this.map.bind('change:attribution', this.setAttribution, this);
+    this.map.bind('change:attribution', this._setAttribution, this);
   },
 
   /** unbind model properties */
@@ -125,11 +94,11 @@ var MapView = View.extend({
   _changeBounds: function () {
     var bounds = this.map.getViewBounds();
     if (bounds) {
-      this.showBounds(bounds);
+      this._fitBounds(bounds);
     }
   },
 
-  showBounds: function (bounds) {
+  _fitBounds: function (bounds) {
     this.map.fitBounds(bounds, this.getSize());
   },
 
@@ -215,32 +184,74 @@ var MapView = View.extend({
     return l;
   },
 
-  setAttribution: function () {
-    throw new Error('Subclasses of src/geo/map-view.js must implement .setAttribution');
+  setCursor: function () {
+    throw new Error('subclasses of MapView must implement setCursor');
+  },
+
+  addMarker: function (marker) {
+    throw new Error('subclasses of MapView must implement addMarker');
+  },
+
+  removeMarker: function (marker) {
+    throw new Error('subclasses of MapView must implement removeMarker');
+  },
+
+  hasMarker: function (marker) {
+    throw new Error('subclasses of MapView must implement hasMarker');
+  },
+
+  addPath: function (path) {
+    throw new Error('subclasses of MapView must implement addPath');
+  },
+
+  removePath: function (path) {
+    throw new Error('subclasses of MapView must implement removePath');
+  },
+
+  // returns { x: 100, y: 200 }
+  latLngToContainerPoint: function (latlng) {
+    throw new Error('subclasses of MapView must implement latLngToContainerPoint');
+  },
+
+  // returns { lat: 0, lng: 0}
+  containerPointToLatLng: function (point) {
+    throw new Error('subclasses of MapView must implement containerPointToLatLng');
+  },
+
+  _setAttribution: function () {
+    throw new Error('Subclasses of src/geo/map-view.js must implement _setAttribution');
   },
 
   getNativeMap: function () {
-    throw new Error('Subclasses of src/geo/map-view.js must implement .getNativeMap');
+    throw new Error('Subclasses of src/geo/map-view.js must implement getNativeMap');
+  },
+
+  _getLayerViewFactory: function () {
+    throw new Error('subclasses of MapView must implement _getLayerViewFactory');
   },
 
   _addLayerToMap: function () {
-    throw new Error('Subclasses of src/geo/map-view.js must implement ._addLayerToMap');
+    throw new Error('Subclasses of src/geo/map-view.js must implement _addLayerToMap');
   },
 
   _setZoom: function (model, z) {
-    throw new Error('Subclasses of src/geo/map-view.js must implement ._setZoom');
+    throw new Error('Subclasses of src/geo/map-view.js must implement _setZoom');
   },
 
   _setCenter: function (model, center) {
-    throw new Error('Subclasses of src/geo/map-view.js must implement ._setCenter');
+    throw new Error('Subclasses of src/geo/map-view.js must implement _setCenter');
   },
 
   _addGeomToMap: function (geom) {
-    throw new Error('Subclasses of src/geo/map-view.js must implement ._addGeomToMap');
+    throw new Error('Subclasses of src/geo/map-view.js must implement _addGeomToMap');
   },
 
   _removeGeomFromMap: function (geo) {
-    throw new Error('Subclasses of src/geo/map-view.js must implement ._removeGeomFromMap');
+    throw new Error('Subclasses of src/geo/map-view.js must implement _removeGeomFromMap');
+  },
+
+  _createNativeMap: function () {
+    throw new Error('Subclasses of src/geo/map-view.js must implement _createNativeMap');
   }
 });
 

--- a/src/geo/map-view.js
+++ b/src/geo/map-view.js
@@ -37,6 +37,12 @@ var MapView = View.extend({
   },
 
   clean: function () {
+    // remove layer views
+    for (var layer in this._layerViews) {
+      this._layerViews[layer].remove();
+      delete this._layerViews[layer];
+    }
+
     delete this._cartoDBLayerGroupView;
 
     View.prototype.clean.call(this);

--- a/src/geo/map-view.js
+++ b/src/geo/map-view.js
@@ -7,6 +7,9 @@ var MapView = View.extend({
   className: 'CDB-Map-wrapper',
 
   initialize: function () {
+    // For debugging purposes
+    window.mapView = this;
+
     this.options = this.options || {};
     if (this.options.map === undefined) throw new Error('map is required');
     if (this.options.layerGroupModel === undefined) throw new Error('layerGroupModel is required');

--- a/src/geo/map-view.js
+++ b/src/geo/map-view.js
@@ -36,6 +36,12 @@ var MapView = View.extend({
     this.add_related_model(this.map.geometries);
   },
 
+  clean: function () {
+    delete this._cartoDBLayerGroupView;
+
+    View.prototype.clean.call(this);
+  },
+
   render: function () {
     this._createNativeMap();
     this._setAttribution();

--- a/src/vis/vis-view.js
+++ b/src/vis/vis-view.js
@@ -33,34 +33,12 @@ var Vis = View.extend({
   },
 
   render: function () {
-    // Create the MapView
-    var div = $('<div>').css({
-      position: 'relative',
-      width: '100%',
-      height: '100%'
-    });
-
-    this.container = div;
-
-    // Another div to prevent leaflet grabbing the div
-    var div_hack = $('<div>')
-      .addClass('cartodb-map-wrapper')
-      .css({
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        width: '100%'
-      });
-
-    div.append(div_hack);
-
-    this.$el.html(div);
-
     var mapViewFactory = new MapViewFactory();
 
-    this.mapView = mapViewFactory.createMapView(this.model.map.get('provider'), this.model.map, div_hack, this.model.layerGroupModel);
+    this.mapView = mapViewFactory.createMapView(this.model.map.get('provider'), this.model.map, this.model.layerGroupModel);
+    // Add the element to the DOM before the native map is created
+    this.$el.html(this.mapView.el);
+
     // Bind events before the view is rendered and layer views are added to the map
     this.mapView.bind('newLayerView', this._bindLayerViewToLoader, this);
     this.mapView.render();

--- a/test/spec/geo/fake-wax.js
+++ b/test/spec/geo/fake-wax.js
@@ -1,0 +1,38 @@
+var _ = require('underscore');
+
+var fakeWax = {
+  _eventCallbacks: {},
+
+  map: jasmine.createSpy('map'),
+
+  tilejson: jasmine.createSpy('tilejson'),
+
+  on: function (eventName, callback) {
+    this._eventCallbacks[eventName] = this._eventCallbacks[eventName] || [];
+    this._eventCallbacks[eventName].push(callback);
+    return this;
+  },
+
+  fire: function (eventName, event) {
+    this._eventCallbacks[eventName] = this._eventCallbacks[eventName] || [];
+    _.each(this._eventCallbacks[eventName], function (callback) {
+      callback(event);
+    });
+  },
+
+  unbindEvents: function () {
+    this._eventCallbacks = {};
+  },
+
+  remove: jasmine.createSpy('remove')
+};
+
+fakeWax.map.returnValue(fakeWax);
+fakeWax.tilejson.and.returnValue(fakeWax);
+fakeWax.remove.and.returnValue(fakeWax);
+
+var FakeWax = function () {
+  return fakeWax;
+};
+
+module.exports = FakeWax;

--- a/test/spec/geo/fake-wax.js
+++ b/test/spec/geo/fake-wax.js
@@ -27,7 +27,7 @@ var fakeWax = {
   remove: jasmine.createSpy('remove')
 };
 
-fakeWax.map.returnValue(fakeWax);
+fakeWax.map.and.returnValue(fakeWax);
 fakeWax.tilejson.and.returnValue(fakeWax);
 fakeWax.remove.and.returnValue(fakeWax);
 

--- a/test/spec/geo/geometry-views/shared-tests-for-multi-point-views.js
+++ b/test/spec/geo/geometry-views/shared-tests-for-multi-point-views.js
@@ -11,6 +11,7 @@ module.exports = function (MapView, MultiPointView) {
       ]
     });
     this.mapView = createMapView(MapView);
+    this.mapView.render();
 
     this.geometryView = new MultiPointView({
       model: this.geometry,

--- a/test/spec/geo/geometry-views/shared-tests-for-multi-polygon-views.js
+++ b/test/spec/geo/geometry-views/shared-tests-for-multi-polygon-views.js
@@ -21,6 +21,7 @@ module.exports = function (MapView, MultiPolygonView) {
       ]
     });
     this.mapView = createMapView(MapView);
+    this.mapView.render();
 
     this.geometryView = new MultiPolygonView({
       model: this.geometry,

--- a/test/spec/geo/geometry-views/shared-tests-for-multi-polyline-views.js
+++ b/test/spec/geo/geometry-views/shared-tests-for-multi-polyline-views.js
@@ -21,6 +21,7 @@ module.exports = function (MapView, MultiPolylineView) {
       ]
     });
     this.mapView = createMapView(MapView);
+    this.mapView.render();
 
     this.geometryView = new MultiPolylineView({
       model: this.geometry,

--- a/test/spec/geo/geometry-views/shared-tests-for-path-views.js
+++ b/test/spec/geo/geometry-views/shared-tests-for-path-views.js
@@ -8,6 +8,7 @@ module.exports = function (Path, MapView, PathView) {
     spyOn(_, 'debounce').and.callFake(function (func) { return function () { func.apply(this, arguments); }; });
 
     this.mapView = createMapView(MapView);
+    this.mapView.render();
 
     this.geometry = new Path(null, {
       latlngs: [
@@ -144,6 +145,7 @@ module.exports = function (Path, MapView, PathView) {
   describe('expandable paths', function () {
     beforeEach(function () {
       this.mapView = createMapView(MapView);
+      this.mapView.render();
 
       this.geometry = new Path({
         editable: true,

--- a/test/spec/geo/geometry-views/shared-tests-for-point-views.js
+++ b/test/spec/geo/geometry-views/shared-tests-for-point-views.js
@@ -13,6 +13,7 @@ module.exports = function (MapView, PointView) {
       ]
     });
     this.mapView = createMapView(MapView);
+    this.mapView.render();
 
     this.pointView = new PointView({
       model: this.point,
@@ -35,6 +36,7 @@ module.exports = function (MapView, PointView) {
   it('should add a marker to the map when the model gets a lat and lng', function () {
     this.point = new Point();
     this.mapView = createMapView(MapView);
+    this.mapView.render();
 
     this.pointView = new PointView({
       model: this.point,
@@ -101,6 +103,7 @@ module.exports = function (MapView, PointView) {
       });
 
       this.mapView = createMapView(MapView);
+      this.mapView.render();
 
       this.pointView = new PointView({
         model: this.point,

--- a/test/spec/geo/geometry-views/shared-tests-for-polygon-views.js
+++ b/test/spec/geo/geometry-views/shared-tests-for-polygon-views.js
@@ -9,6 +9,7 @@ module.exports = function (MapView, PathView) {
   describe('expandable paths', function () {
     beforeEach(function () {
       this.mapView = createMapView(MapView);
+      this.mapView.render();
 
       this.geometry = new Polygon({
         editable: true,

--- a/test/spec/geo/geometry-views/shared-tests-for-polyline-views.js
+++ b/test/spec/geo/geometry-views/shared-tests-for-polyline-views.js
@@ -9,6 +9,7 @@ module.exports = function (MapView, PathView) {
   describe('expandable paths', function () {
     beforeEach(function () {
       this.mapView = createMapView(MapView);
+      this.mapView.render();
 
       this.geometry = new Polyline({
         editable: true,

--- a/test/spec/geo/gmaps/gmaps-cartodb-layer-group.spec.js
+++ b/test/spec/geo/gmaps/gmaps-cartodb-layer-group.spec.js
@@ -1,0 +1,39 @@
+/* global google */
+var GmapsCartoDBLayerGroupView = require('../../../../src/geo/gmaps/gmaps-cartodb-layer-group-view');
+var SharedTestsForCartoDBLayerGroupViews = require('../shared-tests-for-cartodb-layer-group-views');
+var FakeWax = require('../fake-wax');
+
+GmapsCartoDBLayerGroupView.prototype.interactionClass = FakeWax;
+
+var removeSubdomainFromTileURL = function (tileURL) {
+  return tileURL.replace(/\/[01234]\./, '0.');
+};
+
+var createLayerGroupView = function (layerGroupModel, container) {
+  var gmapsMap = new google.maps.Map(container, {
+    center: new google.maps.LatLng(0, 0),
+    zoom: 3,
+    disableDefaultUI: true,
+    mapTypeControl: false,
+    mapTypeId: google.maps.MapTypeId.ROADMAP,
+    backgroundColor: 'white',
+    tilt: 0
+  });
+
+  var layerGroupView = new GmapsCartoDBLayerGroupView(layerGroupModel, gmapsMap);
+  gmapsMap.overlayMapTypes.setAt(1, layerGroupView.gmapsLayer);
+  return layerGroupView;
+};
+
+var expectTileURLTemplateToMatch = function (layerGroupView, expectedTileURLTemplate) {
+  var x = 0;
+  var y = 10;
+  var z = 3;
+  var expectedTileURL = expectedTileURLTemplate.replace('{x}', x).replace('{y}', y).replace('{z}', z);
+  var actualTileURL = layerGroupView.getTile({ x: x, y: y }, z).src;
+  expect(removeSubdomainFromTileURL(actualTileURL)).toEqual(removeSubdomainFromTileURL(expectedTileURL));
+};
+
+describe('src/geo/gmaps/gmaps-cartodb-layer-group-view.js', function () {
+  SharedTestsForCartoDBLayerGroupViews.call(this, createLayerGroupView, expectTileURLTemplateToMatch);
+});

--- a/test/spec/geo/gmaps/gmaps-map-view.spec.js
+++ b/test/spec/geo/gmaps/gmaps-map-view.spec.js
@@ -25,6 +25,7 @@ describe('geo/gmaps/gmaps-map-view', function () {
       map: map,
       layerGroupModel: new Backbone.Model()
     });
+    mapView.render();
 
     var layerURL = 'http://localhost/{s}/light_nolabels/{z}/{x}/{y}.png';
     layer = new TileLayer({ urlTemplate: layerURL });
@@ -142,6 +143,7 @@ describe('geo/gmaps/gmaps-map-view', function () {
       map: map,
       layerGroupModel: new Backbone.Model()
     });
+    mapView.render();
 
     expect(mapView._gmapsMap.get('draggable')).toBeFalsy();
     expect(mapView._gmapsMap.get('disableDoubleClickZoom')).toBeTruthy();
@@ -162,6 +164,7 @@ describe('geo/gmaps/gmaps-map-view', function () {
       map: map,
       layerGroupModel: new Backbone.Model()
     });
+    mapView.render();
 
     spyOn(map, 'trigger');
     spyOn(mapView, 'trigger');

--- a/test/spec/geo/leaflet/leaflet-cartodb-layer-group-view.spec.js
+++ b/test/spec/geo/leaflet/leaflet-cartodb-layer-group-view.spec.js
@@ -1,0 +1,43 @@
+var L = require('leaflet');
+
+var SharedTestsForCartoDBLayerGroupViews = require('../shared-tests-for-cartodb-layer-group-views');
+var FakeWax = require('../fake-wax');
+
+var OriginalLeafletCartoDBLayerGroupView = require('../../../../src/geo/leaflet/leaflet-cartodb-layer-group-view');
+
+var LeafletCartoDBLayerGroupView = OriginalLeafletCartoDBLayerGroupView.extend({
+  interactionClass: FakeWax,
+
+  initialize: function () {
+    this.__templateURL = null;
+    OriginalLeafletCartoDBLayerGroupView.prototype.initialize.apply(this, arguments);
+  },
+
+  setUrl: function (url) {
+    this.__templateURL = url;
+    OriginalLeafletCartoDBLayerGroupView.prototype.setUrl.apply(this, arguments);
+  },
+
+  getUrl: function () {
+    return this.__templateURL;
+  }
+});
+
+var expectTileURLTemplateToMatch = function (layerGroupView, expectedTileURLTemplate) {
+  expect(layerGroupView.getUrl()).toEqual(expectedTileURLTemplate);
+};
+
+var createLayerGroupView = function (layerGroupModel, container) {
+  var leafletMap = new L.Map(container, {
+    center: [0, 0],
+    zoom: 3
+  });
+
+  var layerGroupView = new LeafletCartoDBLayerGroupView(layerGroupModel, leafletMap);
+  layerGroupView.addTo(leafletMap);
+  return layerGroupView;
+};
+
+describe('src/geo/leaflet/leaflet-cartodb-layer-group-view.js', function () {
+  SharedTestsForCartoDBLayerGroupViews.call(this, createLayerGroupView, expectTileURLTemplateToMatch);
+});

--- a/test/spec/geo/leaflet/leaflet-map-view.spec.js
+++ b/test/spec/geo/leaflet/leaflet-map-view.spec.js
@@ -9,6 +9,7 @@ var VisModel = require('../../../../src/vis/vis');
 var TileLayer = require('../../../../src/geo/map/tile-layer');
 var CartoDBLayer = require('../../../../src/geo/map/cartodb-layer');
 var PlainLayer = require('../../../../src/geo/map/plain-layer');
+var LayersCollection = require('../../../../src/geo/map/layers');
 var GMapsBaseLayer = require('../../../../src/geo/map/gmaps-base-layer');
 var CartoDBLayerGroup = require('../../../../src/geo/cartodb-layer-group');
 var LeafletMapView = require('../../../../src/geo/leaflet/leaflet-map-view');
@@ -33,7 +34,7 @@ describe('geo/leaflet/leaflet-map-view', function () {
       attribution: [ '© CARTO' ]
     });
 
-    this.layerGroupModel = new CartoDBLayerGroup({}, { layersCollection: new Backbone.Collection() });
+    this.layerGroupModel = new CartoDBLayerGroup({}, { layersCollection: new LayersCollection() });
     spyOn(this.layerGroupModel, 'hasTileURLTemplates').and.returnValue(true);
     spyOn(this.layerGroupModel, 'getTileURLTemplates').and.returnValue([ 'http://documentation.cartodb.com/api/v1/map/90e64f1b9145961af7ba36d71b887dd2:0/0/{z}/{x}/{y}.png' ]);
 

--- a/test/spec/geo/leaflet/leaflet-map-view.spec.js
+++ b/test/spec/geo/leaflet/leaflet-map-view.spec.js
@@ -29,7 +29,8 @@ describe('geo/leaflet/leaflet-map-view', function () {
     });
 
     map = new Map(null, {
-      layersFactory: {}
+      layersFactory: {},
+      attribution: [ '© CARTO' ]
     });
 
     this.layerGroupModel = new CartoDBLayerGroup({}, { layersCollection: new Backbone.Collection() });
@@ -41,6 +42,8 @@ describe('geo/leaflet/leaflet-map-view', function () {
       map: map,
       layerGroupModel: this.layerGroupModel
     });
+
+    mapView.render();
 
     var layerURL = 'http://{s}.tiles.mapbox.com/v3/cartodb.map-1nh578vv/{z}/{x}/{y}.png';
     layer = new TileLayer({ urlTemplate: layerURL });
@@ -313,75 +316,16 @@ describe('geo/leaflet/leaflet-map-view', function () {
   });
 
   describe('attributions', function () {
-    var container;
-
-    beforeEach(function () {
-      container = $('<div>').css({
-        'height': '200px',
-        'width': '200px'
-      });
-    });
-
     it('should not render Leaflet attributions', function () {
       var attributions = mapView.$el.find('.leaflet-control-attribution');
-      expect(attributions.length).toBe(0);
+      expect(attributions.text()).toEqual('© CARTO');
     });
 
-    it('should respect the attribution of existing Leaflet layers', function () {
-      var leafletMap = new L.Map(container[0], {
-        center: [43, 0],
-        zoom: 3
-      });
+    it('should update the attribution when map attribution changes', function () {
+      map.set('attribution', [ '© CARTO', 'Another attribution' ]);
 
-      // Add a tile layer with some attribution
-      L.tileLayer('http://tile.stamen.com/toner/{z}/{x}/{y}.png', {
-        attribution: 'Stamen'
-      }).addTo(leafletMap);
-
-      mapView = new LeafletMapView({
-        el: container,
-        map: map,
-        map_object: leafletMap,
-        layerGroupModel: this.layerGroupModel
-      });
-
-      // Add a CartoDB layer with some custom attribution
-      layer = new CartoDBLayer({
-        attribution: 'custom attribution'
-      }, { vis: this.vis });
-      map.addLayer(layer);
-
-      var attributions = mapView.$el.find('.leaflet-control-attribution').text();
-      expect(attributions).toEqual('Leaflet | Stamen, © CARTO, custom attribution');
-    });
-
-    it('should not render attributions when the Leaflet map has attributionControl disabled', function () {
-      var leafletMap = new L.Map(container[0], {
-        center: [43, 0],
-        zoom: 3,
-        attributionControl: false
-      });
-
-      // Add a tile layer with some attribution
-      L.tileLayer('http://tile.stamen.com/toner/{z}/{x}/{y}.png', {
-        attribution: 'Stamen'
-      }).addTo(leafletMap);
-
-      mapView = new LeafletMapView({
-        el: container,
-        map: map,
-        map_object: leafletMap,
-        layerGroupModel: this.layerGroupModel
-      });
-
-      // Add a CartoDB layer with some custom attribution
-      layer = new CartoDBLayer({
-        attribution: 'custom attribution'
-      }, { vis: this.vis });
-      map.addLayer(layer);
-
-      var attributions = mapView.$el.find('.leaflet-control-attribution').text();
-      expect(attributions).toEqual('');
+      var attributions = mapView.$el.find('.leaflet-control-attribution');
+      expect(attributions.text()).toEqual('© CARTO, Another attribution');
     });
   });
 
@@ -400,6 +344,7 @@ describe('geo/leaflet/leaflet-map-view', function () {
       map: map,
       layerGroupModel: new Backbone.Model()
     });
+    mapView.render();
 
     expect(mapView._leafletMap.dragging.enabled()).toBeFalsy();
     expect(mapView._leafletMap.doubleClickZoom.enabled()).toBeFalsy();
@@ -420,6 +365,7 @@ describe('geo/leaflet/leaflet-map-view', function () {
       map: map,
       layerGroupModel: new Backbone.Model()
     });
+    mapView.render();
 
     spyOn(map, 'trigger');
 

--- a/test/spec/geo/leaflet/leaflet-torque-layer-view.spec.js
+++ b/test/spec/geo/leaflet/leaflet-torque-layer-view.spec.js
@@ -24,6 +24,7 @@ describe('geo/leaflet/leaflet-torque-layer-view', function () {
       layerViewFactory: new LeafletLayerViewFactory(),
       layerGroupModel: new Backbone.Model()
     });
+    this.mapView.render();
 
     spyOn(L.TorqueLayer.prototype, 'initialize').and.callThrough();
 

--- a/test/spec/geo/map-view.spec.js
+++ b/test/spec/geo/map-view.spec.js
@@ -5,7 +5,6 @@ var Map = require('../../../src/geo/map');
 var MapView = require('../../../src/geo/map-view');
 var TileLayer = require('../../../src/geo/map/tile-layer');
 var CartoDBLayer = require('../../../src/geo/map/cartodb-layer');
-var Infowindow = require('../../../src/geo/ui/infowindow-view');
 var CartoDBLayerGroup = require('../../../src/geo/cartodb-layer-group');
 
 var LayerGroupModel = CartoDBLayerGroup;
@@ -22,7 +21,9 @@ var fakeLayerViewFactory = {
 var MyMapView = MapView.extend({
   _getLayerViewFactory: function () {
     return fakeLayerViewFactory;
-  }
+  },
+  _createNativeMap: function () {},
+  _setAttribution: function () {}
 });
 
 describe('core/geo/map-view', function () {

--- a/test/spec/geo/shared-tests-for-cartodb-layer-group-views.js
+++ b/test/spec/geo/shared-tests-for-cartodb-layer-group-views.js
@@ -1,0 +1,298 @@
+var _ = require('underscore');
+var $ = require('jQuery');
+var CartoDBLayer = require('../../../src/geo/map/cartodb-layer.js');
+var LayersCollection = require('../../../src/geo/map/layers.js');
+var CartoDBLayerGroup = require('../../../src/geo/cartodb-layer-group.js');
+var EMPTY_GIF = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+var FakeWax = require('./fake-wax');
+var fakeWax = FakeWax();
+
+module.exports = function (createLayerGroupView, expectTileURLTemplateToMatch) {
+  describe('shared tests for CartoDBLayerGroupViews', function () {
+    beforeEach(function () {
+      fakeWax.tilejson.calls.reset();
+      fakeWax.map.calls.reset();
+
+      // Disable debounce
+      spyOn(_, 'debounce').and.callFake(function (func) { return function () { func.apply(this, arguments); }; });
+
+      this.container = $('<div id="map">').css('height', '200px');
+      $('body').append(this.container);
+
+      this.cartoDBLayer1 = new CartoDBLayer({}, { vis: { on: function () {} } });
+      this.cartoDBLayer2 = new CartoDBLayer({}, { vis: { on: function () {} } });
+      this.layersCollection = new LayersCollection([
+        this.cartoDBLayer1, this.cartoDBLayer2
+      ]);
+      this.layerGroupModel = new CartoDBLayerGroup({
+        urls: {
+          'tiles': [
+            'http://0.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/{layerIndexes}/{z}/{x}/{y}.png',
+            'http://1.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/{layerIndexes}/{z}/{x}/{y}.png',
+            'http://2.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/{layerIndexes}/{z}/{x}/{y}.png',
+            'http://3.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/{layerIndexes}/{z}/{x}/{y}.png'
+          ],
+          'grids': [
+            [
+              'http://0.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json',
+              'http://1.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json',
+              'http://2.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json',
+              'http://3.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json'
+            ],
+            [
+              'http://0.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1/{z}/{x}/{y}.grid.json',
+              'http://1.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1/{z}/{x}/{y}.grid.json',
+              'http://2.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1/{z}/{x}/{y}.grid.json',
+              'http://3.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1/{z}/{x}/{y}.grid.json'
+            ]
+          ],
+          'attributes': [
+            'http://ashbu.cartocdn.com/documentation/api/v1/map/0123456789/0/attributes',
+            'http://ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1/attributes'
+          ]
+        },
+        indexOfLayersInWindshaft: [1, 2]
+      }, {
+        layersCollection: this.layersCollection
+      });
+
+      this.layerGroupView = createLayerGroupView(this.layerGroupModel, this.container[0]);
+    });
+
+    afterEach(function () {
+      fakeWax.unbindEvents();
+      this.container.remove();
+    });
+
+    it('should fetch tiles', function () {
+      expectTileURLTemplateToMatch(this.layerGroupView, 'http://0.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1,2/{z}/{x}/{y}.png');
+    });
+
+    it('should enable interaction', function () {
+      expect(fakeWax.tilejson.calls.count()).toEqual(2);
+      expect(fakeWax.tilejson.calls.argsFor(0)[0]).toEqual({
+        'tilejson': '2.0.0',
+        'scheme': 'xyz',
+        'grids': [
+          'http://0.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json',
+          'http://1.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json',
+          'http://2.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json',
+          'http://3.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json'
+        ],
+        'tiles': [
+          'http://0.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1,2/{z}/{x}/{y}.png',
+          'http://1.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1,2/{z}/{x}/{y}.png',
+          'http://2.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1,2/{z}/{x}/{y}.png',
+          'http://3.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1,2/{z}/{x}/{y}.png'
+        ],
+        'formatter': jasmine.any(Function)
+      });
+
+      expect(fakeWax.tilejson.calls.argsFor(1)[0]).toEqual({
+        'tilejson': '2.0.0',
+        'scheme': 'xyz',
+        'grids': [
+          'http://0.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1/{z}/{x}/{y}.grid.json',
+          'http://1.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1/{z}/{x}/{y}.grid.json',
+          'http://2.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1/{z}/{x}/{y}.grid.json',
+          'http://3.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1/{z}/{x}/{y}.grid.json'
+        ],
+        'tiles': [
+          'http://0.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1,2/{z}/{x}/{y}.png',
+          'http://1.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1,2/{z}/{x}/{y}.png',
+          'http://2.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1,2/{z}/{x}/{y}.png',
+          'http://3.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1,2/{z}/{x}/{y}.png'
+        ],
+        'formatter': jasmine.any(Function)
+      });
+    });
+
+    describe('when a layer is hidden', function () {
+      beforeEach(function () {
+        fakeWax.tilejson.calls.reset();
+
+        this.cartoDBLayer2.set('visible', false);
+      });
+
+      it('should fetch tiles', function () {
+        expectTileURLTemplateToMatch(this.layerGroupView, 'http://0.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1/{z}/{x}/{y}.png');
+      });
+
+      it('should reload interaction', function () {
+        expect(fakeWax.tilejson.calls.count()).toEqual(1);
+        expect(fakeWax.tilejson.calls.argsFor(0)[0]).toEqual({
+          'tilejson': '2.0.0',
+          'scheme': 'xyz',
+          'grids': [
+            'http://0.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json',
+            'http://1.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json',
+            'http://2.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json',
+            'http://3.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/0/{z}/{x}/{y}.grid.json'
+          ],
+          'tiles': [
+            'http://0.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1/{z}/{x}/{y}.png',
+            'http://1.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1/{z}/{x}/{y}.png',
+            'http://2.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1/{z}/{x}/{y}.png',
+            'http://3.ashbu.cartocdn.com/documentation/api/v1/map/0123456789/1/{z}/{x}/{y}.png'
+          ],
+          'formatter': jasmine.any(Function)
+        });
+      });
+    });
+
+    describe('event binding', function () {
+      beforeEach(function () {
+        this.nativeMap = fakeWax.map.calls.argsFor(0)[0];
+      });
+
+      it('should trigger a "featureOver" event', function () {
+        var callback = jasmine.createSpy('callback');
+        this.layerGroupView.on('featureOver', callback);
+
+        fakeWax.fire('on', {
+          e: {
+            type: 'mousemove',
+            clientX: 10,
+            clientY: 20
+          },
+          data: { cartodb_id: 10 }
+        });
+
+        expect(callback).toHaveBeenCalled();
+      });
+
+      _.each([
+        'click',
+        'touchend',
+        'touchmove',
+        'mspointerup',
+        'pointerup',
+        'pointermove'
+      ], function (eventName) {
+        it('should trigger a "featureClick" event when wax fires a "' + eventName + '" event', function () {
+          var callback = jasmine.createSpy('callback');
+          this.layerGroupView.on('featureClick', callback);
+
+          var waxEvent = {
+            type: eventName,
+            clientX: 10,
+            clientY: 20
+          };
+          fakeWax.fire('on', {
+            e: waxEvent,
+            data: { cartodb_id: 10 }
+          });
+
+          expect(callback).toHaveBeenCalled();
+        });
+      });
+
+      it('should trigger a "featureOut" event', function () {
+        var callback = jasmine.createSpy('callback');
+        this.layerGroupView.on('featureOut', callback);
+
+        fakeWax.fire('off', {
+          e: {}
+        });
+
+        expect(callback).toHaveBeenCalled();
+      });
+    });
+
+    describe('when new urls are set', function () {
+      beforeEach(function () {
+        fakeWax.tilejson.calls.reset();
+
+        this.layerGroupModel.set('urls', {
+          'tiles': [
+            'http://0.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/{layerIndexes}/{z}/{x}/{y}.png',
+            'http://1.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/{layerIndexes}/{z}/{x}/{y}.png',
+            'http://2.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/{layerIndexes}/{z}/{x}/{y}.png',
+            'http://3.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/{layerIndexes}/{z}/{x}/{y}.png'
+          ],
+          'grids': [
+            [
+              'http://0.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/0/{z}/{x}/{y}.grid.json',
+              'http://1.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/0/{z}/{x}/{y}.grid.json',
+              'http://2.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/0/{z}/{x}/{y}.grid.json',
+              'http://3.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/0/{z}/{x}/{y}.grid.json'
+            ],
+            [
+              'http://0.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/1/{z}/{x}/{y}.grid.json',
+              'http://1.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/1/{z}/{x}/{y}.grid.json',
+              'http://2.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/1/{z}/{x}/{y}.grid.json',
+              'http://3.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/1/{z}/{x}/{y}.grid.json'
+            ]
+          ],
+          'attributes': [
+            'http://ashbu.cartocdn.com/documentation/api/v1/map/9876543210/0/attributes',
+            'http://ashbu.cartocdn.com/documentation/api/v1/map/9876543210/1/attributes'
+          ]
+        });
+      });
+
+      it('should set the URL template', function () {
+        expectTileURLTemplateToMatch(this.layerGroupView, 'http://0.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/1,2/{z}/{x}/{y}.png');
+      });
+
+      it('should reload interaction', function () {
+        expect(fakeWax.tilejson.calls.count()).toEqual(2);
+        expect(fakeWax.tilejson.calls.argsFor(0)[0]).toEqual({
+          'tilejson': '2.0.0',
+          'scheme': 'xyz',
+          'grids': [
+            'http://0.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/0/{z}/{x}/{y}.grid.json',
+            'http://1.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/0/{z}/{x}/{y}.grid.json',
+            'http://2.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/0/{z}/{x}/{y}.grid.json',
+            'http://3.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/0/{z}/{x}/{y}.grid.json'
+          ],
+          'tiles': [
+            'http://0.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/1,2/{z}/{x}/{y}.png',
+            'http://1.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/1,2/{z}/{x}/{y}.png',
+            'http://2.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/1,2/{z}/{x}/{y}.png',
+            'http://3.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/1,2/{z}/{x}/{y}.png'
+          ],
+          'formatter': jasmine.any(Function)
+        });
+
+        expect(fakeWax.tilejson.calls.argsFor(1)[0]).toEqual({
+          'tilejson': '2.0.0',
+          'scheme': 'xyz',
+          'grids': [
+            'http://0.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/1/{z}/{x}/{y}.grid.json',
+            'http://1.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/1/{z}/{x}/{y}.grid.json',
+            'http://2.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/1/{z}/{x}/{y}.grid.json',
+            'http://3.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/1/{z}/{x}/{y}.grid.json'
+          ],
+          'tiles': [
+            'http://0.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/1,2/{z}/{x}/{y}.png',
+            'http://1.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/1,2/{z}/{x}/{y}.png',
+            'http://2.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/1,2/{z}/{x}/{y}.png',
+            'http://3.ashbu.cartocdn.com/documentation/api/v1/map/9876543210/1,2/{z}/{x}/{y}.png'
+          ],
+          'formatter': jasmine.any(Function)
+        });
+      });
+    });
+
+    describe("when there aren't tile URLS", function () {
+      beforeEach(function () {
+        fakeWax.tilejson.calls.reset();
+
+        this.layerGroupModel.set('urls', {
+          'tiles': [],
+          'grids': [
+          ],
+          'attributes': [
+            'http://ashbu.cartocdn.com/documentation/api/v1/map/9876543210/0/attributes'
+          ]
+        });
+      });
+
+      it('should fetch empty tiles', function () {
+        expectTileURLTemplateToMatch(this.layerGroupView, EMPTY_GIF);
+      });
+    });
+  });
+};

--- a/test/spec/geo/shared-tests-for-cartodb-layer-group-views.js
+++ b/test/spec/geo/shared-tests-for-cartodb-layer-group-views.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var $ = require('jQuery');
+var $ = require('jquery');
 var CartoDBLayer = require('../../../src/geo/map/cartodb-layer.js');
 var LayersCollection = require('../../../src/geo/map/layers.js');
 var CartoDBLayerGroup = require('../../../src/geo/cartodb-layer-group.js');

--- a/test/spec/geo/ui/search.spec.js
+++ b/test/spec/geo/ui/search.spec.js
@@ -19,6 +19,8 @@ describe('geo/ui/search', function () {
       layerViewFactory: jasmine.createSpyObj('layerViewFactory', ['createLayerView']),
       layerGroupModel: new Backbone.Model()
     });
+    this.mapView.render();
+
     this.view = new Search({
       model: this.map,
       mapView: this.mapView

--- a/test/spec/geo/ui/tooltip.spec.js
+++ b/test/spec/geo/ui/tooltip.spec.js
@@ -16,6 +16,7 @@ describe('geo/ui/tooltip-view', function () {
       layerViewFactory: jasmine.createSpyObj('layerViewFactory', ['createLayerView']),
       layerGroupModel: new Backbone.Model()
     });
+    this.mapView.render();
 
     this.layerView = new Backbone.View();
     this.tooltipModel = new TooltipModel({

--- a/themes/scss/entry.scss
+++ b/themes/scss/entry.scss
@@ -10,6 +10,7 @@
 @import 'infowindow/themes/light';
 @import 'infowindow/cartodb-infowindow-default';
 // Map
+@import 'map/map';
 @import 'map/attributions';
 @import 'map/overlays';
 @import 'map/cartodb-map-light'; // TO BE REVIEWED

--- a/themes/scss/map/map.scss
+++ b/themes/scss/map/map.scss
@@ -1,0 +1,5 @@
+.CDB-Map-wrapper {
+  position: relative;
+  height: 100%;
+  width: 100%;
+}


### PR DESCRIPTION
Part of https://github.com/CartoDB/cartodb.js/issues/1539.

- Map views manage/generate [it's own `div` element](https://github.com/CartoDB/cartodb.js/pull/1541/files#diff-546b824606bbde96318198869eb2de06R7) (`el` was being injected by the `vis-view` before). 
- Instances of CartoDBLayerGroupViewBase (LeafletCartoDBLayerGroupView and GMapsLayerGroupView) automatically [fetch tiles and setup interactivity when they are initialised](https://github.com/CartoDB/cartodb.js/pull/1541/files#diff-394491c3c8e791282436eb57ad5181c6R7) and the layerGroupModel has info (urls) about tiles/grids (eg: when a view is removed and re-rendered).
- Added [a bunch of tests](https://github.com/CartoDB/cartodb.js/pull/1541/files#diff-c1c98c4bc6a55dfe86034033cba4d625) that were missing.

**Acceptance:**

1. Checkout the code and run `grunt dev`.
2. Visit http://localhost:9001/examples/v4/leaflet-layergroup.html.
3. Run the following commands in the console:

```
// 1. remove the map view
mapView.clean();
// 2. you should not see the map any more
// 3. re-add the mapView element to the DOM and render the mapView again:
jQuery('#map').prepend(mapView.el)
mapView.render();
// 4. You should see map again (infowindows and tooltips are not working -> there's an issue for this)
```