### PR TITLE
Filter null values if aggregation is not COUNT for categories dataview.

### DIFF
--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -38,10 +38,15 @@ module.exports = DataviewModelBase.extend({
       authToken: this.get('authToken')
     });
 
-    this._data = new CategoriesCollection();
+    this._data = new CategoriesCollection(null, {
+      aggregationModel: this
+    });
+
     this._searchModel = new SearchModel({
       apiKey: this.get('apiKey'),
       authToken: this.get('authToken')
+    }, {
+      aggregationModel: this
     });
 
     this.on('change:column change:aggregation change:aggregation_column', this._reloadVisAndForceFetch, this);

--- a/src/dataviews/category-dataview/categories-collection.js
+++ b/src/dataviews/category-dataview/categories-collection.js
@@ -10,6 +10,27 @@ var CategoryItemModel = require('./category-item-model');
 module.exports = Backbone.Collection.extend({
   model: CategoryItemModel,
 
+  initialize: function (models, options) {
+    this.aggregationModel = options.aggregationModel;
+    this.aggregation = options.aggregationModel.get('aggregation');
+    this.aggregationModel.on('change:aggregation', function (model, aggregation) {
+      this.aggregation = aggregation;
+      this.filterNull();
+    }, this);
+
+    this.on('reset', this.filterNull, this);
+  },
+
+  filterNull: function () {
+    if (this.aggregation === 'count') return;
+
+    var models = this.filter(function (category) {
+      return category.get('value') != null;
+    });
+
+    this.reset(models, {silent: true});
+  },
+
   comparator: function (a, b) {
     if (a.get('name') === 'Other') {
       return 1;

--- a/src/dataviews/category-dataview/categories-collection.js
+++ b/src/dataviews/category-dataview/categories-collection.js
@@ -1,5 +1,7 @@
 var Backbone = require('backbone');
+var _ = require('underscore');
 var CategoryItemModel = require('./category-item-model');
+var COUNT_AGGREGATION_TYPE = 'count';
 
 /**
  *  Data categories collection
@@ -13,22 +15,17 @@ module.exports = Backbone.Collection.extend({
   initialize: function (models, options) {
     this.aggregationModel = options.aggregationModel;
     this.aggregation = options.aggregationModel.get('aggregation');
-    this.aggregationModel.on('change:aggregation', function (model, aggregation) {
-      this.aggregation = aggregation;
-      this.filterNull();
-    }, this);
-
-    this.on('reset', this.filterNull, this);
   },
 
-  filterNull: function () {
-    if (this.aggregation === 'count') return;
-
-    var models = this.filter(function (category) {
-      return category.get('value') != null;
-    });
-
-    this.reset(models, {silent: true});
+  reset: function (models, options) {
+    if (this.aggregationModel.get('aggregation') !== COUNT_AGGREGATION_TYPE) {
+      models = _.filter(models, function (category) {
+        var isModel = category instanceof Backbone.Model;
+        var value = isModel ? category.get('value') : category.value;
+        return value != null;
+      });
+    }
+    Backbone.Collection.prototype.reset.call(this, models, options);
   },
 
   comparator: function (a, b) {

--- a/src/dataviews/category-dataview/search-model.js
+++ b/src/dataviews/category-dataview/search-model.js
@@ -31,7 +31,9 @@ module.exports = Model.extend({
   },
 
   initialize: function (attrs, opts) {
-    this._data = new CategoriesCollection();
+    this._data = new CategoriesCollection(null, {
+      aggregationModel: opts.aggregationModel
+    });
     this.sync = BackboneAbortSync.bind(this);
   },
 

--- a/test/spec/dataviews/category-dataview-model.spec.js
+++ b/test/spec/dataviews/category-dataview-model.spec.js
@@ -119,7 +119,7 @@ describe('dataviews/category-dataview-model', function () {
         beforeEach(function () {
           spyOn(this.model, 'trigger');
           this.model.filter.accept(['hey']);
-          this.model._searchModel.setData([{ name: 'hey' }, { name: 'vamos' }, { name: 'neno' }]);
+          this.model._searchModel.setData([{ name: 'hey', value: 1 }, { name: 'vamos', value: 2 }, { name: 'neno', value: 3 }]);
         });
 
         it('should check if search results are already selected or not', function () {
@@ -217,7 +217,7 @@ describe('dataviews/category-dataview-model', function () {
 
   describe('filters over data', function () {
     beforeEach(function () {
-      this.model._data.reset([{ name: 'one' }, { name: 'buddy' }, { name: 'neno' }]);
+      this.model._data.reset([{ name: 'one', value: 1 }, { name: 'buddy', value: 2 }, { name: 'neno', value: 3 }]);
     });
 
     describe('.numberOfAcceptedCategories', function () {

--- a/test/spec/dataviews/category-dataview/categories-collection.spec.js
+++ b/test/spec/dataviews/category-dataview/categories-collection.spec.js
@@ -10,9 +10,6 @@ describe('categories-collection', function () {
       aggregation: 'count'
     });
 
-    spyOn(CategoriesCollection.prototype, 'filterNull').and.callThrough();
-    spyOn(CategoriesCollection.prototype, 'reset').and.callThrough();
-
     collection = new CategoriesCollection(null, {
       aggregationModel: aggregationModel
     });
@@ -30,14 +27,24 @@ describe('categories-collection', function () {
       value: null
     }]);
 
-    collection.reset.calls.reset();
-    expect(CategoriesCollection.prototype.filterNull).toHaveBeenCalled();
-    expect(CategoriesCollection.prototype.reset).not.toHaveBeenCalled();
     expect(collection.length).toBe(3);
+    expect(collection.pluck('name').sort()).toEqual([ 'foo', 'bar', 'wadus' ].sort());
+    expect(collection.pluck('value').sort()).toEqual([ 1, 10, null ].sort());
 
     aggregationModel.set({aggregation: 'avg'});
-    expect(CategoriesCollection.prototype.filterNull).toHaveBeenCalled();
-    expect(CategoriesCollection.prototype.reset).toHaveBeenCalled();
+
+    collection.reset([{
+      name: 'foo',
+      value: 1
+    }, {
+      name: 'bar',
+      value: 10
+    }, {
+      name: 'wadus',
+      value: null
+    }]);
     expect(collection.length).toBe(2);
+    expect(collection.pluck('name').sort()).toEqual([ 'foo', 'bar' ].sort());
+    expect(collection.pluck('value').sort()).toEqual([ 1, 10 ].sort());
   });
 });

--- a/test/spec/dataviews/category-dataview/categories-collection.spec.js
+++ b/test/spec/dataviews/category-dataview/categories-collection.spec.js
@@ -1,4 +1,4 @@
-var Backbone = require('Backbone');
+var Backbone = require('backbone');
 var CategoriesCollection = require('../../../../src/dataviews/category-dataview/categories-collection');
 
 describe('categories-collection', function () {

--- a/test/spec/dataviews/category-dataview/categories-collection.spec.js
+++ b/test/spec/dataviews/category-dataview/categories-collection.spec.js
@@ -15,36 +15,39 @@ describe('categories-collection', function () {
     });
   });
 
-  it('reset should filter null when reset', function () {
-    collection.reset([{
-      name: 'foo',
-      value: 1
-    }, {
-      name: 'bar',
-      value: 10
-    }, {
-      name: 'wadus',
-      value: null
-    }]);
+  describe('.reset', function () {
+    it('should NOT filter null values when categories are aggregated by "count"', function () {
+      collection.reset([{
+        name: 'foo',
+        value: 1
+      }, {
+        name: 'bar',
+        value: 10
+      }, {
+        name: 'wadus',
+        value: null
+      }]);
 
-    expect(collection.length).toBe(3);
-    expect(collection.pluck('name').sort()).toEqual([ 'foo', 'bar', 'wadus' ].sort());
-    expect(collection.pluck('value').sort()).toEqual([ 1, 10, null ].sort());
+      expect(collection.length).toBe(3);
+      expect(collection.pluck('name').sort()).toEqual([ 'foo', 'bar', 'wadus' ].sort());
+      expect(collection.pluck('value').sort()).toEqual([ 1, 10, null ].sort());
+    });
 
-    aggregationModel.set({aggregation: 'avg'});
-
-    collection.reset([{
-      name: 'foo',
-      value: 1
-    }, {
-      name: 'bar',
-      value: 10
-    }, {
-      name: 'wadus',
-      value: null
-    }]);
-    expect(collection.length).toBe(2);
-    expect(collection.pluck('name').sort()).toEqual([ 'foo', 'bar' ].sort());
-    expect(collection.pluck('value').sort()).toEqual([ 1, 10 ].sort());
+    it('should filter null values when categories are NOT aggregated by "count"', function () {
+      aggregationModel.set({aggregation: 'avg'});
+      collection.reset([{
+        name: 'foo',
+        value: 1
+      }, {
+        name: 'bar',
+        value: 10
+      }, {
+        name: 'wadus',
+        value: null
+      }]);
+      expect(collection.length).toBe(2);
+      expect(collection.pluck('name').sort()).toEqual([ 'foo', 'bar' ].sort());
+      expect(collection.pluck('value').sort()).toEqual([ 1, 10 ].sort());
+    });
   });
 });

--- a/test/spec/dataviews/category-dataview/categories-collection.spec.js
+++ b/test/spec/dataviews/category-dataview/categories-collection.spec.js
@@ -1,0 +1,43 @@
+var Backbone = require('Backbone');
+var CategoriesCollection = require('../../../../src/dataviews/category-dataview/categories-collection');
+
+describe('categories-collection', function () {
+  var aggregationModel;
+  var collection;
+
+  beforeEach(function () {
+    aggregationModel = new Backbone.Model({
+      aggregation: 'count'
+    });
+
+    spyOn(CategoriesCollection.prototype, 'filterNull').and.callThrough();
+    spyOn(CategoriesCollection.prototype, 'reset').and.callThrough();
+
+    collection = new CategoriesCollection(null, {
+      aggregationModel: aggregationModel
+    });
+  });
+
+  it('reset should filter null when reset', function () {
+    collection.reset([{
+      name: 'foo',
+      value: 1
+    }, {
+      name: 'bar',
+      value: 10
+    }, {
+      name: 'wadus',
+      value: null
+    }]);
+
+    collection.reset.calls.reset();
+    expect(CategoriesCollection.prototype.filterNull).toHaveBeenCalled();
+    expect(CategoriesCollection.prototype.reset).not.toHaveBeenCalled();
+    expect(collection.length).toBe(3);
+
+    aggregationModel.set({aggregation: 'avg'});
+    expect(CategoriesCollection.prototype.filterNull).toHaveBeenCalled();
+    expect(CategoriesCollection.prototype.reset).toHaveBeenCalled();
+    expect(collection.length).toBe(2);
+  });
+});


### PR DESCRIPTION
This PR fixes https://github.com/CartoDB/cartodb/issues/11198

We need to filter the null values if the aggregation is not `COUNT`. We need a reference to the aggregation (through the dataview model). When the aggregation changes, new data is fetched, so when the new data is reset, we filter the models if aggregation meets the condition.

Could you take a look @alonsogarciapablo? Do you see a better approach?