### PR TITLE
InfowindowManager wasn't getting a visModel

### DIFF
--- a/src/vis/vis-view.js
+++ b/src/vis/vis-view.js
@@ -59,7 +59,7 @@ var Vis = View.extend({
     this.$el.append(infowindowView.el);
 
     new InfowindowManager({ // eslint-disable-line
-      visModel: this,
+      visModel: this.model,
       mapModel: this.model.map,
       mapView: this.mapView,
       tooltipModel: tooltipModel,


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/11264.

Bug was introduced here: https://github.com/CartoDB/cartodb.js/commit/def83a2bee7174b2c9a9c63739d8b1c504f5def0#diff-e825eba49cff0944452ad6d39e2ae16dL66

cc: @xavijam would you mind taking a look please?