### PR TITLE
Remove Leaflet's attributionControl by default

### DIFF
--- a/src/geo/gmaps/gmaps-map-view.js
+++ b/src/geo/gmaps/gmaps-map-view.js
@@ -167,12 +167,6 @@ var GoogleMapsMapView = MapView.extend({
     return [ [0, 0], [0, 0] ];
   },
 
-  _setAttribution: function () {
-    // There is no control over Google Maps attribution component, so we can't add
-    // any attribution text there (if Map is already created using createLayer for example)
-    // and there is no CartoDB attribution component.
-  },
-
   setCursor: function (cursor) {
     this._gmapsMap.setOptions({ draggableCursor: cursor });
   },

--- a/src/geo/leaflet/leaflet-map-view.js
+++ b/src/geo/leaflet/leaflet-map-view.js
@@ -2,7 +2,6 @@ var $ = require('jquery');
 var _ = require('underscore');
 var L = require('leaflet');
 var MapView = require('../map-view');
-var Sanitize = require('../../core/sanitize');
 var LeafletLayerViewFactory = require('./leaflet-layer-view-factory');
 
 var LeafletMapView = MapView.extend({
@@ -214,25 +213,6 @@ var LeafletMapView = MapView.extend({
       [sw.lat, sw.lng],
       [ne.lat, ne.lng]
     ];
-  },
-
-  _setAttribution: function (mdl) {
-    var attributionControl = this._leafletMap && this._leafletMap.attributionControl;
-    if (attributionControl) {
-      attributionControl.setPrefix('');
-
-      // If this method comes from an attribution property change
-      if (mdl) {
-        var previousAttributions = mdl.previous('attribution');
-        _.each(previousAttributions, function (text) {
-          attributionControl.removeAttribution(Sanitize.html(text));
-        });
-      }
-      var currentAttributions = this.map.get('attribution');
-      _.each(currentAttributions, function (text) {
-        attributionControl.addAttribution(Sanitize.html(text));
-      });
-    }
   },
 
   getSize: function () {

--- a/src/geo/leaflet/leaflet-map-view.js
+++ b/src/geo/leaflet/leaflet-map-view.js
@@ -25,7 +25,8 @@ var LeafletMapView = MapView.extend({
       dragging: !!this.map.get('drag'),
       doubleClickZoom: !!this.map.get('drag'),
       scrollWheelZoom: !!this.map.get('scrollwheel'),
-      keyboard: !!this.map.get('keyboard')
+      keyboard: !!this.map.get('keyboard'),
+      attributionControl: false
     };
 
     this._leafletMap = new L.Map(this.el, mapConfig);

--- a/src/geo/map-view.js
+++ b/src/geo/map-view.js
@@ -53,7 +53,6 @@ var MapView = View.extend({
 
   render: function () {
     this._createNativeMap();
-    this._setAttribution();
     var bounds = this.map.getViewBounds();
     if (bounds) {
       this._fitBounds(bounds);
@@ -92,7 +91,6 @@ var MapView = View.extend({
     this.map.bind('change:scrollwheel', this._setScrollWheel, this);
     this.map.bind('change:keyboard', this._setKeyboard, this);
     this.map.bind('change:center', this._setCenter, this);
-    this.map.bind('change:attribution', this._setAttribution, this);
   },
 
   /** unbind model properties */
@@ -231,10 +229,6 @@ var MapView = View.extend({
   // returns { lat: 0, lng: 0}
   containerPointToLatLng: function (point) {
     throw new Error('subclasses of MapView must implement containerPointToLatLng');
-  },
-
-  _setAttribution: function () {
-    throw new Error('Subclasses of src/geo/map-view.js must implement _setAttribution');
   },
 
   getNativeMap: function () {

--- a/test/spec/geo/leaflet/leaflet-map-view.spec.js
+++ b/test/spec/geo/leaflet/leaflet-map-view.spec.js
@@ -319,14 +319,7 @@ describe('geo/leaflet/leaflet-map-view', function () {
   describe('attributions', function () {
     it('should not render Leaflet attributions', function () {
       var attributions = mapView.$el.find('.leaflet-control-attribution');
-      expect(attributions.text()).toEqual('© CARTO');
-    });
-
-    it('should update the attribution when map attribution changes', function () {
-      map.set('attribution', [ '© CARTO', 'Another attribution' ]);
-
-      var attributions = mapView.$el.find('.leaflet-control-attribution');
-      expect(attributions.text()).toEqual('© CARTO, Another attribution');
+      expect(attributions.text()).toEqual('');
     });
   });
 

--- a/test/spec/geo/map-view.spec.js
+++ b/test/spec/geo/map-view.spec.js
@@ -22,8 +22,7 @@ var MyMapView = MapView.extend({
   _getLayerViewFactory: function () {
     return fakeLayerViewFactory;
   },
-  _createNativeMap: function () {},
-  _setAttribution: function () {}
+  _createNativeMap: function () {}
 });
 
 describe('core/geo/map-view', function () {


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb.js/issues/1553.

This was removed by mistake here: https://github.com/CartoDB/cartodb.js/commit/4300488a3708e7c77273b1e372f5be5de799d89f#diff-aaf2180ce09425b310a1186ac37bab76L23.

cc: @xavijam 