### PR TITLE
add image support for custom legends beyond svg

### DIFF
--- a/examples/v4/leaflet-layergroup-legends.html
+++ b/examples/v4/leaflet-layergroup-legends.html
@@ -146,6 +146,10 @@
                         "title": "Item 3",
                         "color": "#cc607d",
                         "icon": "https://s3.amazonaws.com/com.cartodb.users-assets.production/maki-icons/circle-stroked-18.svg"
+                      },
+                      {
+                        "title": "Item 4",
+                        "icon": "https://s3.amazonaws.com/com.cartodb.users-assets.staging/development/matatageom/assets/20170112145621a18f902726b8fdc0.png"
                       }
                     ]
                   },

--- a/src/geo/ui/legends/base/img-loader-view.js
+++ b/src/geo/ui/legends/base/img-loader-view.js
@@ -30,7 +30,7 @@ module.exports = Backbone.View.extend({
         var svg = content.cloneNode(true);
         var $svg = $(svg);
         $svg = $svg.removeAttr('xmlns:a');
-        $svg.attr('class', self._imageClass + ' is-svg js-image');
+        $svg.attr('class', self._imageClass + ' js-image');
 
         self.$el.empty().append($svg);
 

--- a/src/geo/ui/legends/base/img-loader-view.js
+++ b/src/geo/ui/legends/base/img-loader-view.js
@@ -30,7 +30,7 @@ module.exports = Backbone.View.extend({
         var svg = content.cloneNode(true);
         var $svg = $(svg);
         $svg = $svg.removeAttr('xmlns:a');
-        $svg.attr('class', self._imageClass + ' js-image');
+        $svg.attr('class', self._imageClass + ' is-svg js-image');
 
         self.$el.empty().append($svg);
 

--- a/src/geo/ui/legends/custom/legend-template.tpl
+++ b/src/geo/ui/legends/custom/legend-template.tpl
@@ -3,7 +3,7 @@
     <li class="Legend-categoryListItem u-flex u-justifySpace u-alignCenter">
       <p class="Legend-categoryTitle CDB-Text CDB-Size-small u-upperCase u-ellipsis" title="<%= items[i].title %>"><%= items[i].title %></p>
       <% if (items[i].icon) { %>
-        <span class="Legend-categoryIcon"><div class="js-image-container" data-icon="<%= items[i].icon %>" data-color="<%= items[i].color %>"></div></span>
+        <span class="Legend-categoryIcon js-image-container" data-icon="<%= items[i].icon %>" data-color="<%= items[i].color %>"></span>
       <% } else if (items[i].color) { %>
         <span class="Legend-categoryCircle" style="opacity:1; background: <%= items[i].color %>;"></span>
       <% } %>

--- a/themes/scss/map/overlays.scss
+++ b/themes/scss/map/overlays.scss
@@ -483,6 +483,10 @@ $maxLegendContainerHeight: 300px;
 .Legend-placeholderInner {
   padding: 12px 24px 0;
 }
+.Legend-fillImageAsset.is-svg {
+  width: 18px;
+  height: 18px;
+}
 
 @media (max-width: 600px) {
   .CDB-Legends-canvas {

--- a/themes/scss/map/overlays.scss
+++ b/themes/scss/map/overlays.scss
@@ -462,8 +462,8 @@ $maxLegendContainerHeight: 300px;
   content: '';
 }
 .Legend-categoryIcon {
-  position: relative;
   display: block;
+  position: relative;
   width: 10px;
   height: 10px;
 }
@@ -487,10 +487,10 @@ $maxLegendContainerHeight: 300px;
   position: absolute;
   top: 0;
   right: 0;
-  height: 18px;
   width: 18px;
-  vertical-align: bottom;
+  height: 18px;
   transform: translateX(4px) translateY(-4px) scale(0.55556); // scale original 18px SVG image => 10px
+  vertical-align: bottom;
 }
 
 @media (max-width: 600px) {

--- a/themes/scss/map/overlays.scss
+++ b/themes/scss/map/overlays.scss
@@ -462,10 +462,10 @@ $maxLegendContainerHeight: 300px;
   content: '';
 }
 .Legend-categoryIcon {
+  position: relative;
   display: block;
   width: 10px;
   height: 10px;
-  transform: translateX(-1px) translateY(-2px) scale(0.55556); // scale original 18px SVG image => 10px
 }
 .Legend-categoryTitle {
   max-width: 90%;
@@ -483,9 +483,14 @@ $maxLegendContainerHeight: 300px;
 .Legend-placeholderInner {
   padding: 12px 24px 0;
 }
-.Legend-fillImageAsset.is-svg {
-  width: 18px;
+.Legend-fillImageAsset {
+  position: absolute;
+  top: 0;
+  right: 0;
   height: 18px;
+  width: 18px;
+  vertical-align: bottom;
+  transform: translateX(4px) translateY(-4px) scale(0.55556); // scale original 18px SVG image => 10px
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
prepare custom legends with images, it wasn't working properly before as it was only supported for svg

**custom legend with images (svg, and png), and circles**

before
![screen shot 2017-01-30 at 10 14 52](https://cloud.githubusercontent.com/assets/36676/22417617/730a20cc-e6d5-11e6-95dc-8353f39035fc.png)

after
<img width="240" alt="screen shot 2017-01-30 at 10 07 52" src="https://cloud.githubusercontent.com/assets/36676/22417613/7114a864-e6d5-11e6-8d19-be7e0f81779e.png">

