### PR TITLE
Adding moveCartoDBLayer function

### DIFF
--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -91,8 +91,10 @@ var Map = Model.extend({
   // PUBLIC API METHODS
 
   moveCartoDBLayer: function (from, to) {
-    this.layers.moveCartoDBLayer(from, to);
-    this.trigger('cartodbLayerMoved', {}, this);
+    var layerMoved = this.layers.moveCartoDBLayer(from, to);
+    if (layerMoved) {
+      this.trigger('cartodbLayerMoved', {}, this);
+    }
   },
 
   createCartoDBLayer: function (attrs, options) {

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -90,6 +90,11 @@ var Map = Model.extend({
 
   // PUBLIC API METHODS
 
+  moveCartoDBLayer: function (from, to) {
+    this.layers.moveCartoDBLayer(from, to);
+    this.trigger('cartodbLayerMoved', {}, this);
+  },
+
   createCartoDBLayer: function (attrs, options) {
     this._checkProperties(attrs, ['sql|source', 'cartocss']);
     return this._addNewLayerModel('cartodb', attrs, options);

--- a/src/geo/map/layers.js
+++ b/src/geo/map/layers.js
@@ -78,7 +78,7 @@ var Layers = Backbone.Collection.extend({
     if (from === to) {
       return this;
     }
-    
+
     var tempLayerModel = this.at(from);
 
     if (tempLayerModel.get('type') !== CARTODB_LAYER_TYPE) {

--- a/src/geo/map/layers.js
+++ b/src/geo/map/layers.js
@@ -76,7 +76,7 @@ var Layers = Backbone.Collection.extend({
 
   moveCartoDBLayer: function (from, to) {
     if (from === to) {
-      return this;
+      return false;
     }
 
     var tempLayerModel = this.at(from);

--- a/src/geo/map/layers.js
+++ b/src/geo/map/layers.js
@@ -79,19 +79,19 @@ var Layers = Backbone.Collection.extend({
       return false;
     }
 
-    var tempLayerModel = this.at(from);
+    var movingLayer = this.at(from);
 
-    if (tempLayerModel.get('type') !== CARTODB_LAYER_TYPE) {
+    if (!movingLayer || movingLayer.get('type') !== CARTODB_LAYER_TYPE) {
       return false;
     }
 
-    this.remove(tempLayerModel, { silent: true });
-    this.add(tempLayerModel, {
+    this.remove(movingLayer, { silent: true });
+    this.add(movingLayer, {
       at: to,
       silent: true
     });
 
-    return tempLayerModel;
+    return movingLayer;
   }
 });
 

--- a/src/geo/map/layers.js
+++ b/src/geo/map/layers.js
@@ -72,6 +72,24 @@ var Layers = Backbone.Collection.extend({
     return this.select(function (layerModel) {
       return !!layerModel.legends;
     });
+  },
+
+  moveCartoDBLayer: function (from, to) {
+    if (from === to) {
+      return this;
+    }
+    
+    var tempLayerModel = this.at(from);
+
+    if (tempLayerModel.get('type') !== CARTODB_LAYER_TYPE) {
+      return false;
+    }
+
+    this.remove(tempLayerModel, { silent: true });
+    this.add(tempLayerModel, {
+      at: to,
+      silent: true
+    });
   }
 });
 

--- a/src/geo/map/layers.js
+++ b/src/geo/map/layers.js
@@ -90,6 +90,8 @@ var Layers = Backbone.Collection.extend({
       at: to,
       silent: true
     });
+
+    return tempLayerModel;
   }
 });
 

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -171,6 +171,8 @@ var VisModel = Backbone.Model.extend({
       layersFactory: layersFactory
     });
 
+    this.listenTo(this.map, 'cartodbLayerMoved', this.reload);
+
     // Reset the collection of overlays
     this.overlaysCollection.reset(vizjson.overlays);
 
@@ -401,7 +403,12 @@ var VisModel = Backbone.Model.extend({
     overlayView.type = 'custom';
     this.overlaysCollection.add(overlayView);
     return overlayView;
-  }
+  },
+
+  moveCartoDBLayer: function (from, to) {
+    this.layers.moveCartoDBLayer(from, to);
+    this.refres
+  },
 });
 
 module.exports = VisModel;

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -403,12 +403,7 @@ var VisModel = Backbone.Model.extend({
     overlayView.type = 'custom';
     this.overlaysCollection.add(overlayView);
     return overlayView;
-  },
-
-  moveCartoDBLayer: function (from, to) {
-    this.layers.moveCartoDBLayer(from, to);
-    this.refres
-  },
+  }
 });
 
 module.exports = VisModel;

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -191,6 +191,21 @@ describe('core/geo/map', function () {
     ]);
   });
 
+  describe('Layer action methods', function () {
+    describe('.moveCartoDBLayer', function () {
+      it('should provide a way to move CartoDB layers', function () {
+        expect(this.map.moveCartoDBLayer).toBeDefined();
+      });
+
+      it('should trigger an event in order to notify other elements', function () {
+        spyOn(this.map, 'trigger');
+        spyOn(this.map.layers, 'moveCartoDBLayer').and.returnValue(new Backbone.Model());
+        this.map.moveCartoDBLayer(1, 2);
+        expect(this.map.trigger).toHaveBeenCalledWith('cartodbLayerMoved', {}, this.map);
+      });
+    });
+  });
+
   describe('Layer creation methods', function () {
     var testCases = [
       {

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -192,16 +192,21 @@ describe('core/geo/map', function () {
   });
 
   describe('Layer action methods', function () {
+    beforeEach(function () {
+      this.map.layers.add(new CartoDBLayer({}, { vis: this.vis }));
+      this.map.layers.add(new PlainLayer({}));
+    });
+
     describe('.moveCartoDBLayer', function () {
       it('should provide a way to move CartoDB layers', function () {
         expect(this.map.moveCartoDBLayer).toBeDefined();
       });
 
       it('should trigger an event in order to notify other elements', function () {
-        spyOn(this.map, 'trigger');
-        spyOn(this.map.layers, 'moveCartoDBLayer').and.returnValue(new Backbone.Model());
-        this.map.moveCartoDBLayer(1, 2);
-        expect(this.map.trigger).toHaveBeenCalledWith('cartodbLayerMoved', {}, this.map);
+        var moveCartoDBLayer = jasmine.createSpy('moveCartoDBLayer', {});
+        this.map.on('cartodbLayerMoved', moveCartoDBLayer);
+        this.map.moveCartoDBLayer(0, 1);
+        expect(moveCartoDBLayer).toHaveBeenCalled();
       });
     });
   });

--- a/test/spec/geo/map/layers.spec.js
+++ b/test/spec/geo/map/layers.spec.js
@@ -148,4 +148,34 @@ describe('geo/map/layers', function () {
     expect(layer2.get('order')).toEqual(1);
     expect(layers.pluck('order')).toEqual([ 0, 1 ]);
   });
+
+  describe('.moveCartoDBLayer', function () {
+    beforeEach(function () {
+      layers.add(new PlainLayer({ name: 'Positron' }));
+      layers.add(new CartoDBLayer({ title: 'CARTO' }, { vis: this.vis }));
+    });
+
+    it('should move a layer from one position to other', function () {
+      var movedLayer = layers.moveCartoDBLayer(1, 0);
+      expect(layers.indexOf(movedLayer)).toBe(0);
+      expect(movedLayer.get('title')).toBe('CARTO');
+
+      layers.add(new CartoDBLayer({ title: 'CARTO 2' }, { vis: this.vis }));
+      movedLayer = layers.moveCartoDBLayer(2, 1);
+      expect(layers.indexOf(movedLayer)).toBe(1);
+      expect(movedLayer.get('title')).toBe('CARTO 2');
+    });
+
+    it('should not move anything if the position is the same', function () {
+      var movedLayer = layers.moveCartoDBLayer(1, 1);
+      expect(movedLayer).toBeFalsy();
+      expect(layers.at(1).get('title')).toBe('CARTO');
+    });
+
+    it('should not move the layer if it is not a CartoDB type', function () {
+      var movedLayer = layers.moveCartoDBLayer(0, 1);
+      expect(movedLayer).toBeFalsy();
+      expect(layers.at(1).get('title')).toBe('CARTO');
+    });
+  });
 });


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/11137.

In BUILDER, when a layer was moved, we used to remove the layer and add it again in the proper position instead of doing that operation in CARTO.js. Why? I don't know, but let's do it properly!

Also, when a CartoDB layer is moved, we have to refresh the map, of course, thanks reload.