### PR TITLE
Do not try to use subdomains when no CDN templates are present

### DIFF
--- a/src/windshaft/map-base.js
+++ b/src/windshaft/map-base.js
@@ -230,17 +230,13 @@ var WindshaftMap = Backbone.Model.extend({
   },
 
   getSupportedSubdomains: function () {
-    if (!this.get('cdn_url')) return ['0', '1', '2', '3'];
-
-    var templates = this.get('cdn_url').templates;
+    var templates = this.get('cdn_url') && this.get('cdn_url').templates;
     var protocol = this.getProtocol();
     if (templates && templates[protocol]) {
       return templates[protocol].subdomains;
-    } else if (!this._useHTTPS()) {
-      return ['0', '1', '2', '3'];
     }
 
-    return [''];
+    return [];
   },
 
   getLayerMetadata: function (layerIndex) {

--- a/src/windshaft/map-base.js
+++ b/src/windshaft/map-base.js
@@ -175,7 +175,7 @@ var WindshaftMap = Backbone.Model.extend({
     }
 
     if (cdnHost) {
-      return [protocol, '://{s}.', cdnHost, '/', userName].join('');
+      return [protocol, '://', cdnHost, '/', userName].join('');
     }
 
     return urlTemplate.replace('{user}', userName);

--- a/test/spec/windshaft/map-base.spec.js
+++ b/test/spec/windshaft/map-base.spec.js
@@ -478,7 +478,7 @@ describe('windshaft/map-base', function () {
         }
       });
 
-      expect(this.windshaftMap.getBaseURL()).toEqual('http://{s}.cdn.http.example.com/rambo/api/v1/map/0123456789');
+      expect(this.windshaftMap.getBaseURL()).toEqual('http://cdn.http.example.com/rambo/api/v1/map/0123456789');
     });
 
     it('should return the CDN URL for https when CDN info is present', function () {
@@ -492,7 +492,7 @@ describe('windshaft/map-base', function () {
         }
       });
 
-      expect(this.windshaftMap.getBaseURL()).toEqual('https://{s}.cdn.https.example.com/rambo/api/v1/map/0123456789');
+      expect(this.windshaftMap.getBaseURL()).toEqual('https://cdn.https.example.com/rambo/api/v1/map/0123456789');
     });
 
     it('should use the CDN template', function () {


### PR DESCRIPTION
When no CDN templates are present in the response from Maps API we're trying to use the following subdomains:

- `[ '0', '1', '2', '3' ]` for HTTP requests
- `[ '' ]` for HTTPs requests

This was causing some errors because we're replacing the `{s}.` part of the URL that we're generating by and empty string.

This PR basically disables subdomains for those cases.

cc: @rochoa @donflopez 