### PR TITLE
Clean up subdomains

### DIFF
--- a/src/geo/cartodb-layer-group.js
+++ b/src/geo/cartodb-layer-group.js
@@ -48,16 +48,20 @@ var CartoDBLayerGroup = Backbone.Model.extend({
   },
 
   getSubdomains: function () {
-    return (this.get('urls') && this.get('urls').subdomains) || ['0'];
+    return (this.get('urls') && this.get('urls').subdomains) || [];
   },
 
   getTileURLTemplatesWithSubdomains: function () {
-    var urls = this.get('urls');
     var urlTemplate = this.getTileURLTemplate();
+    var subdomains = this.getSubdomains();
 
-    return _.map(urls.subdomains, function (subdomain) {
-      return urlTemplate.replace('{s}', subdomain);
-    });
+    if (subdomains && subdomains.length) {
+      return _.map(subdomains, function (subdomain) {
+        return urlTemplate.replace('{s}', subdomain);
+      });
+    }
+
+    return [ urlTemplate ];
   },
 
   getTileURLTemplate: function (type) {

--- a/src/windshaft-integration/model-updater.js
+++ b/src/windshaft-integration/model-updater.js
@@ -48,7 +48,7 @@ ModelUpdater.prototype.updateModels = function (windshaftMap, sourceId, forceFet
 ModelUpdater.prototype._updateLayerGroupModel = function (windshaftMap) {
   var urls = {
     tiles: this._generateTileURLTemplate(windshaftMap),
-    subdomains: this._getTileSubdomains(windshaftMap),
+    subdomains: windshaftMap.getSupportedSubdomains(),
     grids: this._calculateGridURLTemplatesForCartoDBLayers(windshaftMap),
     attributes: this._calculateAttributesBaseURLsForCartoDBLayers(windshaftMap),
     image: this._calculateStaticMapURL(windshaftMap)
@@ -67,21 +67,8 @@ ModelUpdater.prototype._calculateStaticMapURL = function (windshaftMap) {
   ].join('/');
 };
 
-ModelUpdater.prototype._calculateTileURLTemplatesForCartoDBLayers = function (windshaftMap) {
-  var urlTemplates = [];
-  _.each(windshaftMap.getSupportedSubdomains(), function (subdomain) {
-    urlTemplates.push(this._generateTileURLTemplate(windshaftMap, subdomain));
-  }, this);
-
-  return urlTemplates;
-};
-
 ModelUpdater.prototype._generateTileURLTemplate = function (windshaftMap) {
   return windshaftMap.getBaseURL() + '/{layerIndexes}/{z}/{x}/{y}.{format}';
-};
-
-ModelUpdater.prototype._getTileSubdomains = function (windshafMap) {
-  return windshafMap.getSupportedSubdomains();
 };
 
 ModelUpdater.prototype._calculateGridURLTemplatesForCartoDBLayers = function (windshaftMap) {
@@ -90,18 +77,24 @@ ModelUpdater.prototype._calculateGridURLTemplatesForCartoDBLayers = function (wi
   if (indexesOfMapnikLayers.length > 0) {
     _.each(indexesOfMapnikLayers, function (index) {
       var layerUrlTemplates = [];
-      _.each(windshaftMap.getSupportedSubdomains(), function (subdomain) {
-        layerUrlTemplates.push(this._generateGridURLTemplate(windshaftMap, subdomain, index));
-      }, this);
+      var gridURLTemplate = this._generateGridURLTemplate(windshaftMap, index);
+      var subdomains = windshaftMap.getSupportedSubdomains();
+      if (subdomains.length) {
+        _.each(subdomains, function (subdomain) {
+          layerUrlTemplates.push(gridURLTemplate.replace('{s}', subdomain));
+        });
+      } else {
+        layerUrlTemplates.push(gridURLTemplate);
+      }
+
       urlTemplates.push(layerUrlTemplates);
     }, this);
   }
   return urlTemplates;
 };
 
-ModelUpdater.prototype._generateGridURLTemplate = function (windshaftMap, subdomain, index) {
-  var baseURL = windshaftMap.getBaseURL() + '/' + index + '/{z}/{x}/{y}.grid.json';
-  return baseURL.replace('{s}', subdomain);
+ModelUpdater.prototype._generateGridURLTemplate = function (windshaftMap, index) {
+  return windshaftMap.getBaseURL() + '/' + index + '/{z}/{x}/{y}.grid.json';
 };
 
 ModelUpdater.prototype._calculateAttributesBaseURLsForCartoDBLayers = function (windshaftMap) {

--- a/src/windshaft/client.js
+++ b/src/windshaft/client.js
@@ -53,7 +53,6 @@ WindshaftClient.prototype.instantiateMap = function (options) {
       if (data.errors) {
         errorCallback(data);
       } else {
-        delete data.cdn_url.templates;
         successCallback(data);
       }
     },

--- a/src/windshaft/client.js
+++ b/src/windshaft/client.js
@@ -53,6 +53,7 @@ WindshaftClient.prototype.instantiateMap = function (options) {
       if (data.errors) {
         errorCallback(data);
       } else {
+        delete data.cdn_url.templates;
         successCallback(data);
       }
     },

--- a/src/windshaft/map-base.js
+++ b/src/windshaft/map-base.js
@@ -230,17 +230,13 @@ var WindshaftMap = Backbone.Model.extend({
   },
 
   getSupportedSubdomains: function () {
-    if (!this.get('cdn_url')) return ['0', '1', '2', '3'];
-
-    var templates = this.get('cdn_url').templates;
+    var templates = this.get('cdn_url') && this.get('cdn_url').templates;
     var protocol = this.getProtocol();
     if (templates && templates[protocol]) {
       return templates[protocol].subdomains;
-    } else if (!this._useHTTPS()) {
-      return ['0', '1', '2', '3'];
     }
 
-    return [''];
+    return [];
   },
 
   getLayerMetadata: function (layerIndex) {

--- a/test/spec/geo/cartodb-layer-group.spec.js
+++ b/test/spec/geo/cartodb-layer-group.spec.js
@@ -183,6 +183,46 @@ describe('geo/cartodb-layer-group', function () {
     });
   });
 
+  describe('.getTileURLTemplatesWithSubdomains', function () {
+    beforeEach(function () {
+      this.cartoDBLayerGroup = new CartoDBLayerGroup({
+        indexOfLayersInWindshaft: [1, 2],
+        urls: {
+          tiles: 'http://carto.com/{layerIndexes}/{z}/{x}/{y}.{format}'
+        }
+      }, {
+        layersCollection: this.layersCollection
+      });
+
+      var otherLayer = new Backbone.Model();
+      this.cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });
+      this.cartoDBLayer2 = new CartoDBLayer({}, { vis: this.vis });
+      this.layersCollection.reset([
+        otherLayer,
+        this.cartoDBLayer1,
+        this.cartoDBLayer2
+      ]);
+    });
+
+    it('should return one URL when there are NO subdomains', function () {
+      expect(this.cartoDBLayerGroup.getTileURLTemplatesWithSubdomains()).toEqual([ 'http://carto.com/1,2/{z}/{x}/{y}.png' ]);
+    });
+
+    it('should include URLs for different subdomains', function () {
+      this.cartoDBLayerGroup.set('urls', {
+        tiles: 'http://{s}.carto.com/{layerIndexes}/{z}/{x}/{y}.{format}',
+        subdomains: [ '0', '1', '2', '3' ]
+      });
+
+      expect(this.cartoDBLayerGroup.getTileURLTemplatesWithSubdomains()).toEqual([
+        'http://0.carto.com/1,2/{z}/{x}/{y}.png',
+        'http://1.carto.com/1,2/{z}/{x}/{y}.png',
+        'http://2.carto.com/1,2/{z}/{x}/{y}.png',
+        'http://3.carto.com/1,2/{z}/{x}/{y}.png'
+      ]);
+    });
+  });
+
   describe('.hasTileURLTemplates', function () {
     beforeEach(function () {
       this.cartoDBLayer1 = new CartoDBLayer({}, { vis: this.vis });


### PR DESCRIPTION
This is a follow up on https://github.com/CartoDB/cartodb.js/pull/1607 (I had to revert one cleanup commit which broke some stuff). Since Maps API is now returning info about subdomains that should be used for tiles, grids, and attributes, we should just use those. If this info is not available, no subdomains will be used.

cc: @rochoa @donflopez 

