### PR TITLE
It is not necessary to reCenter the map after initialization

### DIFF
--- a/src/geo/leaflet/leaflet-map-view.js
+++ b/src/geo/leaflet/leaflet-map-view.js
@@ -222,14 +222,7 @@ var LeafletMapView = MapView.extend({
   },
 
   invalidateSize: function () {
-    // there is a race condition in leaflet. If size is invalidated
-    // and at the same time the center is set the final center is displaced
-    // so set pan to false so the map is not moved and then force the map
-    // to be at the place it should be
-    this._leafletMap.invalidateSize({ pan: false }); // , animate: false });
-    this._leafletMap.setView(this.map.get('center'), this.map.get('zoom') || 0, {
-      animate: false
-    });
+    this._leafletMap.invalidateSize({ animate: false });
   },
 
   // GEOMETRY

--- a/src/geo/leaflet/leaflet-map-view.js
+++ b/src/geo/leaflet/leaflet-map-view.js
@@ -222,7 +222,10 @@ var LeafletMapView = MapView.extend({
   },
 
   invalidateSize: function () {
-    this._leafletMap.invalidateSize({ animate: false });
+    var center = this.map.get('center');
+    var zoom = this.map.get('zoom');
+    this._leafletMap.invalidateSize({ pan: false, animate: false });
+    this._leafletMap.setView(center, zoom, { pan: false, animate: false });
   },
 
   // GEOMETRY

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -48,9 +48,7 @@ var Map = Model.extend({
     if (attrs.bounds) {
       this.set({
         view_bounds_sw: attrs.bounds[0],
-        view_bounds_ne: attrs.bounds[1],
-        original_view_bounds_sw: attrs.bounds[0],
-        original_view_bounds_ne: attrs.bounds[1]
+        view_bounds_ne: attrs.bounds[1]
       });
       this.unset('bounds');
     } else {

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -412,20 +412,6 @@ var Map = Model.extend({
     this.geometries.remove(geom);
   },
 
-  reCenter: function () {
-    var originalViewBoundsSW = this.get('original_view_bounds_sw');
-    var originalViewBoundsNE = this.get('original_view_bounds_ne');
-    var originalCenter = this.get('original_center');
-    if (originalViewBoundsSW && originalViewBoundsNE) {
-      this.setBounds([
-        originalViewBoundsSW,
-        originalViewBoundsNE
-      ]);
-    } else {
-      this.setCenter(originalCenter);
-    }
-  },
-
   setBounds: function (b) {
     this.attributes.view_bounds_sw = [
       b[0][0],

--- a/src/vis/vis-view.js
+++ b/src/vis/vis-view.js
@@ -111,7 +111,7 @@ var Vis = View.extend({
     // This timeout is necessary due to GMaps needs time
     // to load tiles and recalculate its bounds :S
     setTimeout(function () {
-      self.model.centerMapToOrigin();
+      self.model.invalidateSize();
     }, 150);
   }
 });

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -399,11 +399,6 @@ var VisModel = Backbone.Model.extend({
     this.trigger('invalidateSize');
   },
 
-  centerMapToOrigin: function () {
-    this.invalidateSize();
-    this.map.reCenter();
-  },
-
   _flattenLayers: function (vizjsonLayers) {
     return _.chain(vizjsonLayers)
       .map(function (vizjsonLayer) {

--- a/test/spec/geo/leaflet/leaflet-map-view.spec.js
+++ b/test/spec/geo/leaflet/leaflet-map-view.spec.js
@@ -224,4 +224,18 @@ describe('geo/leaflet/leaflet-map-view', function () {
 
     expect(map.trigger).toHaveBeenCalledWith('moveend', jasmine.any(Object));
   });
+
+  describe('.invalidateSize', function () {
+    it('should invalidate size in Leaflet and "re-center"', function () {
+      spyOn(mapView._leafletMap, 'invalidateSize');
+      spyOn(mapView._leafletMap, 'setView');
+      var center = mapView.map.get('center');
+      var zoom = mapView.map.get('zoom');
+
+      mapView.invalidateSize();
+
+      expect(mapView._leafletMap.setView).toHaveBeenCalledWith(center, zoom, jasmine.any(Object));
+      expect(mapView._leafletMap.invalidateSize).toHaveBeenCalled();
+    });
+  });
 });

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -399,41 +399,6 @@ describe('core/geo/map', function () {
     }, this);
   });
 
-  describe('.reCenter', function () {
-    it('should set the original bounds if present', function () {
-      var map = new Map({
-        bounds: [[1, 2], [3, 4]],
-        center: '[41.40282319070747, 2.3435211181640625]'
-      }, { layersFactory: fakeLayersFactory });
-
-      // Change internal attributes
-      map.set({
-        view_bounds_sw: 'something',
-        view_bounds_ne: 'else',
-        center: 'different'
-      });
-
-      map.reCenter();
-
-      expect(map.get('view_bounds_sw')).toEqual([1, 2]);
-      expect(map.get('view_bounds_ne')).toEqual([3, 4]);
-    });
-
-    it('should set the original center if bounds are not present', function () {
-      var map = new Map({
-        center: [41.40282319070747, 2.3435211181640625]
-      }, { layersFactory: fakeLayersFactory });
-
-      map.set({
-        center: 'different'
-      });
-
-      map.reCenter();
-
-      expect(map.get('center')).toEqual([ 41.40282319070747, 2.3435211181640625 ]);
-    });
-  });
-
   describe('.getLayerById', function () {
     beforeEach(function () {
       var layer1 = new CartoDBLayer({ id: 'xyz-123', attribution: 'attribution1' }, { vis: this.vis });

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -39,8 +39,6 @@ describe('core/geo/map', function () {
 
       expect(map.get('view_bounds_sw')).toEqual([0, 1]);
       expect(map.get('view_bounds_ne')).toEqual([2, 3]);
-      expect(map.get('original_view_bounds_sw')).toEqual([0, 1]);
-      expect(map.get('original_view_bounds_ne')).toEqual([2, 3]);
       expect(map.get('bounds')).toBeUndefined();
     });
 

--- a/test/spec/vis/vis-view.spec.js
+++ b/test/spec/vis/vis-view.spec.js
@@ -105,7 +105,7 @@ describe('vis/vis-view', function () {
 
   it('should bind resize changes when map height is 0', function () {
     jasmine.clock().install();
-    spyOn(this.visModel, 'centerMapToOrigin');
+    spyOn(this.visModel, 'invalidateSize');
 
     var container = $('<div>').css('height', '0');
     var vis = this.createNewVis({ el: container });
@@ -123,7 +123,7 @@ describe('vis/vis-view', function () {
 
     jasmine.clock().tick(160);
 
-    expect(this.visModel.centerMapToOrigin).toHaveBeenCalled();
+    expect(this.visModel.invalidateSize).toHaveBeenCalled();
 
     $(window).trigger('resize');
     expect(vis._onResize).not.toHaveBeenCalled();
@@ -131,7 +131,7 @@ describe('vis/vis-view', function () {
 
   it('should NOT bind resize changes when map height is greater than 0', function () {
     jasmine.clock().install();
-    spyOn(this.visModel, 'centerMapToOrigin');
+    spyOn(this.visModel, 'invalidateSize');
 
     var container = $('<div>').css('height', '200px');
     var vis = this.createNewVis({el: container});
@@ -148,7 +148,7 @@ describe('vis/vis-view', function () {
 
     jasmine.clock().tick(160);
 
-    expect(this.visModel.centerMapToOrigin).not.toHaveBeenCalled();
+    expect(this.visModel.invalidateSize).not.toHaveBeenCalled();
   });
 
   it('should display/hide the loader while loading', function () {

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -1062,22 +1062,6 @@ describe('vis/vis', function () {
       });
     });
 
-    describe('.centerMapToOrigin', function () {
-      it('should invalidate size and re-center the map', function () {
-        var callback = jasmine.createSpy('callback');
-        this.vis.bind('invalidateSize', callback);
-
-        this.vis.load(new VizJSON(fakeVizJSON()));
-
-        spyOn(this.vis.map, 'reCenter');
-
-        this.vis.centerMapToOrigin();
-
-        expect(this.vis.map.reCenter).toHaveBeenCalled();
-        expect(callback).toHaveBeenCalled();
-      });
-    });
-
     describe('.getStaticImageURL', function () {
       beforeEach(function () {
         this.vis.layerGroupModel.set('urls', {


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/support/issues/605

Basically we have noticed that Leaflet 1.0.3 doesn't need to set the center of the map when it is invalidated. It means, for example, when widgets list component appears and map gets stretched.
I'll review the code and make the acceptance with @ivanmalagon.

Then we will need to make changes in deep-insights in order to stop using the `centerMapToOrigin` deprecated function.

cc @alonsogarciapablo @donflopez @ivanmalagon 