### PR TITLE
Filter GMapsBase layer before to set styles.

### DIFF
--- a/src/windshaft/named-map.js
+++ b/src/windshaft/named-map.js
@@ -1,4 +1,5 @@
 var MapBase = require('./map-base.js');
+var _ = require('underscore');
 
 var NamedMap = MapBase.extend({
   toJSON: function () {
@@ -13,13 +14,18 @@ var NamedMap = MapBase.extend({
     //       "2": "/** torque visualization */\n\nMap { ... }"
     //     }
     //   }
-    //
-    json.styles = this._layersCollection.reduce(function (p, c, i) {
-      var style = c.get('cartocss');
+
+    var layers = this._layersCollection.filter(function (layer) {
+      return layer.get('type') !== 'GMapsBase';
+    });
+
+    json.styles = _.reduce(layers, function (memo, layer, index) {
+      var style = layer.get('cartocss');
       if (style) {
-        p[i] = style;
+        memo[index] = style;
       }
-      return p;
+
+      return memo;
     }, {});
 
     return json;

--- a/src/windshaft/named-map.js
+++ b/src/windshaft/named-map.js
@@ -1,5 +1,6 @@
 var MapBase = require('./map-base.js');
 var _ = require('underscore');
+var LayerTypes = require('../geo/map/layer-types');
 
 var NamedMap = MapBase.extend({
   toJSON: function () {
@@ -16,7 +17,7 @@ var NamedMap = MapBase.extend({
     //   }
 
     var layers = this._layersCollection.filter(function (layer) {
-      return layer.get('type') !== 'GMapsBase';
+      return !LayerTypes.isGoogleMapsBaseLayer(layer);
     });
 
     json.styles = _.reduce(layers, function (memo, layer, index) {

--- a/test/spec/windshaft/named-map.spec.js
+++ b/test/spec/windshaft/named-map.spec.js
@@ -49,7 +49,7 @@ describe('windshaft/named-map', function () {
 
     var isGoogleMapsBaseLayer = function () {
       return false;
-    }
+    };
 
     this.cartoDBLayer1.isGoogleMapsBaseLayer = isGoogleMapsBaseLayer;
     this.cartoDBLayer2.isGoogleMapsBaseLayer = isGoogleMapsBaseLayer;

--- a/test/spec/windshaft/named-map.spec.js
+++ b/test/spec/windshaft/named-map.spec.js
@@ -80,5 +80,15 @@ describe('windshaft/named-map', function () {
         1: 'cartoCSS1', 2: 'cartoCSS2', 3: 'cartoCSS3'
       });
     });
+
+    it('should send styles using the right indexes with Google basemaps', function () {
+      var gmdLayer = new Backbone.Model({ type: 'GMapsBase' });
+
+      this.layersCollection.reset([gmdLayer, this.cartoDBLayer1, this.cartoDBLayer2, this.cartoDBLayer3]);
+
+      expect(this.map.toJSON().styles).toEqual({
+        0: 'cartoCSS1', 1: 'cartoCSS2', 2: 'cartoCSS3'
+      });
+    });
   });
 });

--- a/test/spec/windshaft/named-map.spec.js
+++ b/test/spec/windshaft/named-map.spec.js
@@ -47,6 +47,14 @@ describe('windshaft/named-map', function () {
 
     this.modelUpdater = jasmine.createSpyObj('modelUpdater', ['updateModels']);
 
+    var isGoogleMapsBaseLayer = function () {
+      return false;
+    }
+
+    this.cartoDBLayer1.isGoogleMapsBaseLayer = isGoogleMapsBaseLayer;
+    this.cartoDBLayer2.isGoogleMapsBaseLayer = isGoogleMapsBaseLayer;
+    this.cartoDBLayer3.isGoogleMapsBaseLayer = isGoogleMapsBaseLayer;
+
     this.layersCollection = new Backbone.Collection([this.cartoDBLayer1, this.cartoDBLayer2, this.cartoDBLayer3]);
 
     this.map = new NamedMap({}, {
@@ -73,6 +81,9 @@ describe('windshaft/named-map', function () {
 
     it('should send styles using the right indexes', function () {
       var tiledLayer = new Backbone.Model({ type: 'Tiled' });
+      tiledLayer.isGoogleMapsBaseLayer = function () {
+        return false;
+      };
 
       this.layersCollection.reset([tiledLayer, this.cartoDBLayer1, this.cartoDBLayer2, this.cartoDBLayer3]);
 
@@ -83,6 +94,9 @@ describe('windshaft/named-map', function () {
 
     it('should send styles using the right indexes with Google basemaps', function () {
       var gmdLayer = new Backbone.Model({ type: 'GMapsBase' });
+      gmdLayer.isGoogleMapsBaseLayer = function () {
+        return true;
+      };
 
       this.layersCollection.reset([gmdLayer, this.cartoDBLayer1, this.cartoDBLayer2, this.cartoDBLayer3]);
 


### PR DESCRIPTION
This PR implements https://github.com/CartoDB/cartodb/issues/11838.

We are filtering the google basemap from the layers collection in order to set the json styles. This will work because we are assuming the first layer is always the basemap. See [this comment](https://github.com/CartoDB/support/issues/577#issuecomment-286424774) for more context.