### PR TITLE
Time series context menu

### DIFF
--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -1,6 +1,6 @@
 var _ = require('underscore');
 var Model = require('../core/model');
-var BackboneCancelSync = require('../util/backbone-abort-sync');
+var BackboneAbortSync = require('../util/backbone-abort-sync');
 var WindshaftFiltersBoundingBoxFilter = require('../windshaft/filters/bounding-box');
 var BOUNDING_BOX_FILTER_WAIT = 500;
 
@@ -86,7 +86,7 @@ module.exports = Model.extend({
     this._vis = opts.vis;
     this._analysisCollection = opts.analysisCollection;
 
-    this.sync = BackboneCancelSync.bind(this);
+    this.sync = BackboneAbortSync.bind(this);
 
     // filter is optional, so have to guard before using it
     this.filter = opts.filter;

--- a/src/dataviews/histogram-dataview/histogram-data-model.js
+++ b/src/dataviews/histogram-dataview/histogram-data-model.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var BackboneCancelSync = require('../../util/backbone-abort-sync');
+var BackboneAbortSync = require('../../util/backbone-abort-sync');
 var Model = require('../../core/model');
 
 /**
@@ -33,7 +33,7 @@ module.exports = Model.extend({
   },
 
   initialize: function () {
-    this.sync = BackboneCancelSync.bind(this);
+    this.sync = BackboneAbortSync.bind(this);
     this.bind('change:url change:bins', function () {
       this.fetch();
     }, this);

--- a/src/dataviews/histogram-dataview/histogram-data-model.js
+++ b/src/dataviews/histogram-dataview/histogram-data-model.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var BackboneCancelSync = require('../../util/backbone-abort-sync');
 var Model = require('../../core/model');
 
 /**
@@ -32,6 +33,7 @@ module.exports = Model.extend({
   },
 
   initialize: function () {
+    this.sync = BackboneCancelSync.bind(this);
     this.bind('change:url change:bins', function () {
       this.fetch();
     }, this);


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb/issues/12177

There was a 'race condition' when changing the number of bins in a timeseries widget. If a change response delays and then we request another number of bins, the datamodel enters a spiral of request the data for those two numbers till infinity.

This fix is independent of the original issue cited but has appeared while developing it.

Related PR:
- cartodb: https://github.com/CartoDB/cartodb/pull/12246
- cartodb.js: https://github.com/CartoDB/cartodb.js/pull/1665
- deep-insights.js: https://github.com/CartoDB/deep-insights.js/pull/547