### PR TITLE
doc updated related to SB12619947

### DIFF
--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -112,7 +112,7 @@ Below, you have an example using a previously instantiated Leaflet map.
 
 ## Creating Visualizations at Runtime
 
-All CARTO services are available through the API, which basically means that you can create a new visualization without doing it before through the CARTO Editor. This is particularly useful when you are modifying the visualization depending on user interactions that change the SQL to get the data or CartoCSS to style it. Although this method requires more programming skills, it provides all the flexibility you might need to create more dynamic visualizations.
+All CARTO services are available through the API, which basically means that you can create a new visualization without doing it before through CARTO Editor. This is particularly useful when you are modifying the visualization depending on user interactions that change the SQL to get the data or CartoCSS to style it. Although this method requires more programming skills, it provides all the flexibility you might need to create more dynamic visualizations.
 
 When you create a visualization using the CARTO website, you automatically get a viz.json URL that defines it. When you want to create the visualization via JavaScript, you don't always have a viz.json. You will need to pass all the required parameters to the library so that it can create the visualization at runtime and display it on your map. It is pretty simple.
 

--- a/doc/static_maps.md
+++ b/doc/static_maps.md
@@ -30,7 +30,7 @@ cartodb.Image(vizjson_url)
 
 Name |Description
 --- | ---
-layerSource | can be either a `viz.json` object or a [layer source object](/carto-engine/carto-js/api-methods/#standard-layer-source-object-type-cartodb)
+layerSource | can be either a `viz.json` object or a [MapConfig object](https://carto.com/docs/carto-engine/maps-api/mapconfig#mapnik-layer-options).<br/><br/>**Note:** If defining an image through the MapConfig layer definition, you must set the `tiler_domain`, `tiler_port`, and `tiler_protocol`, as displayed in this [example](https://github.com/CartoDB/cartodb.js/blob/4ba5148638091fd2c194f48b2fa3ed6ac4ecdb23/examples/layer_definition.html). Otherwise the Static Image API tries to use your localhost to source the tiles and an error appears.
 
 options | 
 --- | ---


### PR DESCRIPTION
@oriolbx , related to [Docs issue#1212](https://github.com/CartoDB/docs/issues/1212) (via reported SB issue).

- Okay, first things first. I confirmed that there was a broken hyperlink. I edited the description of `layerSource`, under the `cartodb.Image(layerSource[, options])` section; to include all the details reported by the user. I also linked to the correct doc location and the example he found on Github.

- The bigger issue is how to handle all the existing examples that appear in the Static Maps API doc (in regards to `cartodb.image`).  Do we need to update all the examples and add missing configurations?  For now, let me know if this update is correct, then I'll loop in a developer to figure out how to move forward with the rest of the examples.
