### PR TITLE
Change histogram data URL properly with column changes

### DIFF
--- a/src/dataviews/histogram-dataview-model.js
+++ b/src/dataviews/histogram-dataview-model.js
@@ -56,7 +56,7 @@ module.exports = DataviewModelBase.extend({
       this._onChangeBinds();
     }, this);
 
-    this.once('change:url', function () {
+    this.on('change:url', function () {
       this._unfilteredData.setUrl(this.get('url'));
     }, this);
 


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb/issues/11536

While doing acceptance we found this bug: when changing the column used in a histogram widget, there is no notification to the original data model. This way, when showing totals there were no changes at all.

Furthermore, in the cartodb associated PR, after a validation error in the column type, it prevented to fetch the right data when choosing a proper column.

We dug in `git blame` to find a reason for `once` to be there but it doesn't make any sense. The dataview model is changing its URL, so it's backing data model must change it as well.