### PR TITLE
Customisable Mapzen's API Key

### DIFF
--- a/src/api/create-vis.js
+++ b/src/api/create-vis.js
@@ -3,6 +3,7 @@ var VisView = require('../vis/vis-view');
 var VisModel = require('../vis/vis');
 var Loader = require('../core/loader');
 var VizJSON = require('./vizjson');
+var config = require('../cdb.config');
 
 var DEFAULT_OPTIONS = {
   tiles_loader: true,
@@ -47,6 +48,10 @@ var createVis = function (el, vizjson, options) {
     });
   } else {
     loadVizJSON(el, visModel, vizjson, options);
+  }
+
+  if (options.mapzenApiKey) {
+    config.set('mapzenApiKey', options.mapzenApiKey);
   }
 
   return visModel;

--- a/src/geo/geocoder/mapzen-geocoder.js
+++ b/src/geo/geocoder/mapzen-geocoder.js
@@ -1,4 +1,6 @@
 var $ = require('jquery');
+var config = require('../../cdb.config');
+var log = require('cdb.log');
 
 /**
  * geocoders for different services
@@ -8,11 +10,13 @@ var $ = require('jquery');
  * (at least)
  */
 var MAPZEN = {
-  keys: {
-    app_id: 'mapzen-YfBeDWS'
-  },
-
   geocode: function (address, callback) {
+    var mapzenApiKey = config.get('mapzenApiKey');
+    if (!mapzenApiKey) {
+      log.error('[Mapzen Geocoder] API Key is missing');
+      return;
+    }
+
     address = address.toLowerCase()
       .replace(/é/g, 'e')
       .replace(/á/g, 'a')
@@ -25,7 +29,8 @@ var MAPZEN = {
       protocol = 'http:';
     }
 
-    $.getJSON(protocol + '//search.mapzen.com/v1/search?text=' + encodeURIComponent(address) + '&api_key=' + this.keys.app_id, function (data) {
+    var jqxhr = $.getJSON(protocol + '//search.mapzen.com/v1/search?text=' + encodeURIComponent(address) + '&api_key=' + mapzenApiKey);
+    jqxhr.done(function (data) {
       var coordinates = [];
       if (data && data.features && data.features.length > 0) {
         var res = data.features;
@@ -49,7 +54,10 @@ var MAPZEN = {
         callback.call(this, coordinates);
       }
     });
-  }
+    jqxhr.fail(function (jqxhr, error) {
+      log.error('[Mapzen Geocoder] error: ' + error);
+    });
+  },
 };
 
 module.exports = MAPZEN;

--- a/src/geo/geocoder/mapzen-geocoder.js
+++ b/src/geo/geocoder/mapzen-geocoder.js
@@ -25,7 +25,7 @@ var MAPZEN = {
       .replace(/ú/g, 'u');
 
     var protocol = window.location.protocol;
-    if (window.location.protocol.indexOf('http') === -1) {
+    if (protocol.indexOf('http') === -1) {
       protocol = 'http:';
     }
 

--- a/src/geo/geocoder/mapzen-geocoder.js
+++ b/src/geo/geocoder/mapzen-geocoder.js
@@ -24,7 +24,7 @@ var MAPZEN = {
       .replace(/ó/g, 'o')
       .replace(/ú/g, 'u');
 
-    var protocol = '';
+    var protocol = window.location.protocol;
     if (window.location.protocol.indexOf('http') === -1) {
       protocol = 'http:';
     }
@@ -57,7 +57,7 @@ var MAPZEN = {
     jqxhr.fail(function (jqxhr, error) {
       log.error('[Mapzen Geocoder] error: ' + error);
     });
-  },
+  }
 };
 
 module.exports = MAPZEN;

--- a/test/spec/geo/geocoder/mapzen-geocoder.spec.js
+++ b/test/spec/geo/geocoder/mapzen-geocoder.spec.js
@@ -4,41 +4,41 @@ var MAPZEN = require('../../../../src/geo/geocoder/mapzen-geocoder');
 var log = require('cdb.log');
 
 var mapzenResponse = {
-  "geocoding": {},
-  "type": "FeatureCollection",
-  "features": [
+  'geocoding': {},
+  'type': 'FeatureCollection',
+  'features': [
     {
-      "type": "Feature",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
+      'type': 'Feature',
+      'geometry': {
+        'type': 'Point',
+        'coordinates': [
           -3.669245,
           40.429913
         ]
       },
-      "properties": {
-        "id": "101748283",
-        "gid": "whosonfirst:locality:101748283",
-        "layer": "locality",
-        "source": "whosonfirst",
-        "source_id": "101748283",
-        "name": "Madrid",
-        "confidence": 0.951,
-        "accuracy": "centroid",
-        "country": "Spain",
-        "country_gid": "whosonfirst:country:85633129",
-        "country_a": "ESP",
-        "macroregion": "Comunidad De Madrid",
-        "macroregion_gid": "whosonfirst:macroregion:404227387",
-        "region": "Madrid",
-        "region_gid": "whosonfirst:region:85682783",
-        "localadmin": "Madrid",
-        "localadmin_gid": "whosonfirst:localadmin:404338863",
-        "locality": "Madrid",
-        "locality_gid": "whosonfirst:locality:101748283",
-        "label": "Madrid, Spain"
+      'properties': {
+        'id': '101748283',
+        'gid': 'whosonfirst:locality:101748283',
+        'layer': 'locality',
+        'source': 'whosonfirst',
+        'source_id': '101748283',
+        'name': 'Madrid',
+        'confidence': 0.951,
+        'accuracy': 'centroid',
+        'country': 'Spain',
+        'country_gid': 'whosonfirst:country:85633129',
+        'country_a': 'ESP',
+        'macroregion': 'Comunidad De Madrid',
+        'macroregion_gid': 'whosonfirst:macroregion:404227387',
+        'region': 'Madrid',
+        'region_gid': 'whosonfirst:region:85682783',
+        'localadmin': 'Madrid',
+        'localadmin_gid': 'whosonfirst:localadmin:404338863',
+        'locality': 'Madrid',
+        'locality_gid': 'whosonfirst:locality:101748283',
+        'label': 'Madrid, Spain'
       },
-      "bbox": [
+      'bbox': [
         -3.83213999304,
         40.3120207163,
         -3.53212,
@@ -46,7 +46,7 @@ var mapzenResponse = {
       ]
     }
   ],
-  "bbox": [
+  'bbox': [
     -103.878731891,
     4.73245,
     125.93368,
@@ -66,18 +66,18 @@ describe('geo/geocoder/mapzen-geocoder', function () {
     });
 
     it('should trigger a request to the service', function () {
-      MAPZEN.geocode('Madrid', function () { });
-      expect($.ajax.calls.mostRecent().args[0].url).toEqual('//search.mapzen.com/v1/search?text=madrid&api_key=MAPZEN_API_KEY');
+      MAPZEN.geocode('Madrid', function () {});
+      expect($.ajax.calls.mostRecent().args[0].url).toEqual('http://search.mapzen.com/v1/search?text=madrid&api_key=MAPZEN_API_KEY');
     });
 
     it('should remove accents from address', function () {
-      MAPZEN.geocode('áéíóú', function () { });
-      expect($.ajax.calls.mostRecent().args[0].url).toEqual('//search.mapzen.com/v1/search?text=aeiou&api_key=MAPZEN_API_KEY');
+      MAPZEN.geocode('áéíóú', function () {});
+      expect($.ajax.calls.mostRecent().args[0].url).toEqual('http://search.mapzen.com/v1/search?text=aeiou&api_key=MAPZEN_API_KEY');
     });
 
     it('should lowercase the address', function () {
-      MAPZEN.geocode('AEIOU', function () { });
-      expect($.ajax.calls.mostRecent().args[0].url).toEqual('//search.mapzen.com/v1/search?text=aeiou&api_key=MAPZEN_API_KEY');
+      MAPZEN.geocode('AEIOU', function () {});
+      expect($.ajax.calls.mostRecent().args[0].url).toEqual('http://search.mapzen.com/v1/search?text=aeiou&api_key=MAPZEN_API_KEY');
     });
 
     describe('when geocoding succeeds', function () {

--- a/test/spec/geo/geocoder/mapzen-geocoder.spec.js
+++ b/test/spec/geo/geocoder/mapzen-geocoder.spec.js
@@ -1,43 +1,130 @@
+var $ = require('jquery');
+var config = require('../../../../src/cdb.config');
 var MAPZEN = require('../../../../src/geo/geocoder/mapzen-geocoder');
+var log = require('cdb.log');
+
+var mapzenResponse = {
+  "geocoding": {},
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -3.669245,
+          40.429913
+        ]
+      },
+      "properties": {
+        "id": "101748283",
+        "gid": "whosonfirst:locality:101748283",
+        "layer": "locality",
+        "source": "whosonfirst",
+        "source_id": "101748283",
+        "name": "Madrid",
+        "confidence": 0.951,
+        "accuracy": "centroid",
+        "country": "Spain",
+        "country_gid": "whosonfirst:country:85633129",
+        "country_a": "ESP",
+        "macroregion": "Comunidad De Madrid",
+        "macroregion_gid": "whosonfirst:macroregion:404227387",
+        "region": "Madrid",
+        "region_gid": "whosonfirst:region:85682783",
+        "localadmin": "Madrid",
+        "localadmin_gid": "whosonfirst:localadmin:404338863",
+        "locality": "Madrid",
+        "locality_gid": "whosonfirst:locality:101748283",
+        "label": "Madrid, Spain"
+      },
+      "bbox": [
+        -3.83213999304,
+        40.3120207163,
+        -3.53212,
+        40.5334948396
+      ]
+    }
+  ],
+  "bbox": [
+    -103.878731891,
+    4.73245,
+    125.93368,
+    44.847083
+  ]
+};
 
 describe('geo/geocoder/mapzen-geocoder', function () {
-  it("don't remove the spaces in the user-submitted addresses [MAPZEN]", function (done) {
-    var regexp = new RegExp(/http:\/\/search.mapzen.com\/v1\/search\?text\=bn20%208qt/);
-    MAPZEN.geocode('bn20 8qt', function (d) {
-      expect(this.url).toMatch(regexp);
-      done();
+  beforeEach(function () {
+    this.jqxhr = $.Deferred();
+    spyOn($, 'ajax').and.returnValue(this.jqxhr);
+  });
+
+  describe('if a Mapzen API Key has been set up', function () {
+    beforeEach(function () {
+      config.set('mapzenApiKey', 'MAPZEN_API_KEY');
+    });
+
+    it('should trigger a request to the service', function () {
+      MAPZEN.geocode('Madrid', function () { });
+      expect($.ajax.calls.mostRecent().args[0].url).toEqual('//search.mapzen.com/v1/search?text=madrid&api_key=MAPZEN_API_KEY');
+    });
+
+    it('should remove accents from address', function () {
+      MAPZEN.geocode('áéíóú', function () { });
+      expect($.ajax.calls.mostRecent().args[0].url).toEqual('//search.mapzen.com/v1/search?text=aeiou&api_key=MAPZEN_API_KEY');
+    });
+
+    it('should lowercase the address', function () {
+      MAPZEN.geocode('AEIOU', function () { });
+      expect($.ajax.calls.mostRecent().args[0].url).toEqual('//search.mapzen.com/v1/search?text=aeiou&api_key=MAPZEN_API_KEY');
+    });
+
+    describe('when geocoding succeeds', function () {
+      beforeEach(function () {
+        this.callback = jasmine.createSpy('callback');
+        MAPZEN.geocode('Madrid', this.callback);
+        this.jqxhr.resolve(mapzenResponse);
+      });
+
+      it('should invoke the given callback', function () {
+        expect(this.callback).toHaveBeenCalledWith([
+          { lat: 40.429913, lon: -3.669245, type: 'locality', title: 'Madrid, Spain' }
+        ]);
+      });
+    });
+
+    describe('when geocoding fails', function () {
+      beforeEach(function () {
+        spyOn(log, 'error');
+        this.callback = jasmine.createSpy('callback');
+        MAPZEN.geocode('Madrid', this.callback);
+        this.jqxhr.reject(this.jqxhr, 'error');
+      });
+
+      it('should not invoke the given callback', function () {
+        expect(this.callback).not.toHaveBeenCalled();
+      });
+
+      it('should log an error', function () {
+        expect(log.error).toHaveBeenCalledWith('[Mapzen Geocoder] error: error');
+      });
     });
   });
 
-  it('we should get a direction that exists using MAPZEN', function (done) {
-    var data;
-    MAPZEN.geocode('Madrid, Spain', function (d) {
-      data = d;
-      expect(data.length).not.toEqual(0);
-      expect(data[0].lat).not.toEqual(undefined);
-      expect(data[0].lon).not.toEqual(undefined);
-      // expect(data[0].boundingbox).toBeTruthy();
-      done();
-    });
-  });
+  describe('if a Mapzen API Key has NOT been set up', function () {
+    beforeEach(function () {
+      spyOn(log, 'error');
+      this.callback = jasmine.createSpy('callback');
 
-  it('we should get a direction with # character using MAPZEN', function (done) {
-    var data;
-    MAPZEN.geocode('# Mexico', function (d) {
-      data = d;
-      expect(data.length).not.toEqual(0);
-      expect(data[0].lat).not.toEqual(undefined);
-      expect(data[0].lon).not.toEqual(undefined);
-      done();
-    });
-  });
+      config.unset('mapzenApiKey');
 
-  it("we shouldn't get a direction that doesn't exist using MAPZEN", function (done) {
-    var data;
-    MAPZEN.geocode('****', function (d) {
-      data = d;
-      expect(data.length).toEqual(0);
-      done();
+      MAPZEN.geocode('Madrid', this.callback);
+      this.jqxhr.reject('error');
+    });
+
+    it('should log an error', function () {
+      expect(log.error).toHaveBeenCalledWith('[Mapzen Geocoder] API Key is missing');
     });
   });
 });

--- a/test/spec/geo/geocoder/mapzen-geocoder.spec.js
+++ b/test/spec/geo/geocoder/mapzen-geocoder.spec.js
@@ -120,7 +120,6 @@ describe('geo/geocoder/mapzen-geocoder', function () {
       config.unset('mapzenApiKey');
 
       MAPZEN.geocode('Madrid', this.callback);
-      this.jqxhr.reject('error');
     });
 
     it('should log an error', function () {

--- a/test/spec/geo/ui/search.spec.js
+++ b/test/spec/geo/ui/search.spec.js
@@ -65,10 +65,10 @@ describe('geo/ui/search', function () {
 
     it('should change map center when geocoder returns any result', function () {
       var onBoundsChanged = jasmine.createSpy('onBoundsChange');
-      this.map.bind('change:view_bounds_sw', onBoundsChanged, this.view);
+      this.map.bind('change:view_bounds_ne', onBoundsChanged, this.view);
       this.view.$('.js-form').submit();
       expect(onBoundsChanged).toHaveBeenCalled();
-      this.map.unbind('change:view_bounds_sw', onBoundsChanged, this.view);
+      this.map.unbind('change:view_bounds_ne', onBoundsChanged, this.view);
     });
 
     it('should center map to lat,lon when bbox is not defined', function () {


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb.js/issues/1669.

`createVis` now requires the `mapzenApiKey` option for the Search bar to work properly.

Usage example:

```
cartodb.createVis('map', vizjson, {
  mapzenApiKey: 'MAPZEN_API_KEY'
})
```
If Mapzen's API Key is not provided or is no longer valid, the library will log an error in the console and the map will not be panned or zoomed when a user searches though the UI.

cc: @juanignaciosl 