### PR TITLE
Cancellable sql fetch.

### DIFF
--- a/src/api/sql.js
+++ b/src/api/sql.js
@@ -25,7 +25,7 @@ function SQL(options) {
     version: 'v2',
     protocol: loc,
     jsonp: !$.support.cors,
-    cancellable: false
+    abortable: false
   });
 
   if (!this.options.sql_api_template) {
@@ -72,7 +72,7 @@ SQL.prototype.execute = function(sql, vars, options, callback) {
     crossDomain: true
   };
 
-  if (this._xhr && this.options.cancellable === true) {
+  if (this._xhr && this.options.abortable === true) {
     this._xhr.abort();
   }
 

--- a/src/api/sql.js
+++ b/src/api/sql.js
@@ -5,6 +5,9 @@ var Promise = require('./promise');
 
 var NO_BOUNDS_ERROR_MESSAGE = 'No bounds';
 
+//Variable that defines if a query should be using get method or post method
+var MAX_LENGTH_GET_QUERY = 1024;
+
 function SQL(options) {
   if(window.cdb === this || window === this) {
     return new SQL(options);
@@ -21,8 +24,9 @@ function SQL(options) {
   this.options = _.defaults(options, {
     version: 'v2',
     protocol: loc,
-    jsonp: !$.support.cors
-  })
+    jsonp: !$.support.cors,
+    cancellable: false
+  });
 
   if (!this.options.sql_api_template) {
     var opts = this.options;
@@ -51,10 +55,6 @@ SQL.prototype._host = function() {
  * })
  */
 SQL.prototype.execute = function(sql, vars, options, callback) {
-
-  //Variable that defines if a query should be using get method or post method
-  var MAX_LENGTH_GET_QUERY = 1024;
-
   var promise = new Promise();
   if(!sql) {
     throw new TypeError("sql should not be null");
@@ -71,6 +71,10 @@ SQL.prototype.execute = function(sql, vars, options, callback) {
     dataType: 'json',
     crossDomain: true
   };
+
+  if (this._xhr && this.options.cancellable === true) {
+    this._xhr.abort();
+  }
 
   if(options.cache !== undefined) {
     params.cache = options.cache;
@@ -163,9 +167,14 @@ SQL.prototype.execute = function(sql, vars, options, callback) {
     }, 0);
   }
 
+  params.complete = function () {
+    this._xhr = null;
+  }.bind(this);
+
   // call ajax
   delete options.jsonp;
-  $.ajax(_.extend(params, options));
+  this._xhr = $.ajax(_.extend(params, options));
+
   return promise;
 }
 

--- a/test/spec/api/sql.spec.js
+++ b/test/spec/api/sql.spec.js
@@ -11,14 +11,16 @@ describe('api/sql', function() {
   var TEST_DATA = { test: 'good' };
   var NO_BOUNDS = { "rows": [{ "maxx": null }]};
   var throwError;
+  var abort = jasmine.createSpy('abort');
 
   beforeEach(function() {
     jasmine.clock().install();
-    
+
     ajaxParams = null;
     ajax = function(params) {
       ajaxParams = params;
       _.defer(function() {
+        params.complete && params.complete();
         if(!throwError && params.success) params.success(TEST_DATA, 200);
         throwError && params.error && params.error({
           responseText: JSON.stringify({
@@ -26,7 +28,12 @@ describe('api/sql', function() {
           })
         });
       });
+
+      return {
+        abort: abort
+      }
     };
+
     spyOn($, 'ajax').and.callFake(ajax);
 
     sql = new SQL({
@@ -61,6 +68,20 @@ describe('api/sql', function() {
     expect(ajaxParams.type).toEqual('get');
     expect(ajaxParams.dataType).toEqual('json');
     expect(ajaxParams.crossDomain).toEqual(true);
+  });
+
+  it('should be cancellable', function() {
+    sql = new SQL({
+      user: USER,
+      protocol: 'https',
+      cancellable: true
+    });
+
+    sql.execute('select * from table');
+    expect(abort).not.toHaveBeenCalled();
+
+    sql.execute('select * from table limit 10');
+    expect(abort).toHaveBeenCalled();
   });
 
   it("should parse template", function() {
@@ -302,7 +323,7 @@ describe('api/sql', function() {
       // Cleaning
       TEST_DATA = prevTestData;
     });
-    
+
   });
 
 

--- a/test/spec/api/sql.spec.js
+++ b/test/spec/api/sql.spec.js
@@ -70,11 +70,11 @@ describe('api/sql', function() {
     expect(ajaxParams.crossDomain).toEqual(true);
   });
 
-  it('should be cancellable', function() {
+  it('should be abortable', function() {
     sql = new SQL({
       user: USER,
       protocol: 'https',
-      cancellable: true
+      abortable: true
     });
 
     sql.execute('select * from table');


### PR DESCRIPTION
This PR improves the SQL fetch queries to let them be cancellable. The default option is `false`, as the same as it is now.

```
var sql = new SQL({
    cancellable: true
});
```

