### PR TITLE
Update tangram.carto

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "underscore": "1.8.3"
   },
   "devDependencies": {
+    "babel-preset-es2015": "~6.24.1",
+    "babelify": "~7.3.0",
     "browserify": "13.0.0",
     "cartoassets": "CartoDB/CartoAssets#master",
     "findup-sync": "0.1.3",

--- a/src/geo/leaflet/leaflet-cartodb-webgl-layer-group-view.js
+++ b/src/geo/leaflet/leaflet-cartodb-webgl-layer-group-view.js
@@ -1,7 +1,7 @@
 var log = require('cdb.log');
 var _ = require('underscore');
 var L = require('leaflet');
-var TC = require('tangram.cartodb');
+var TC = require('tangram.cartodb').default;
 var LeafletLayerView = require('./leaflet-layer-view');
 var Profiler = require('../../core/profiler');
 


### PR DESCRIPTION
This, in combination with https://github.com/CartoDB/tangram.cartodb/commit/01a39eb85da15dcd06f03b03804e4e4305d80486, allows us to use `tangram.cartodb` without having to rely on `dist/` files.