### PR TITLE
[Vector] Use tangram.cartodb method to validate CartoCSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,11 @@
     "camshaft-reference": "<2.0",
     "carto": "cartodb/carto#master",
     "d3": "3.5.17",
-    "tangram.cartodb": "cartodb/tangram.cartodb#master",
     "jquery": "2.1.4",
     "leaflet": "1.0.3",
     "mustache": "1.1.0",
     "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#master",
-    "tangram-cartocss": "cartodb/tangram-carto#master",
+    "tangram.cartodb": "cartodb/tangram.cartodb#master",
     "torque.js": "CartoDB/torque#master",
     "underscore": "1.8.3"
   },

--- a/src/geo/leaflet/leaflet-cartodb-webgl-layer-group-view.js
+++ b/src/geo/leaflet/leaflet-cartodb-webgl-layer-group-view.js
@@ -1,7 +1,7 @@
 var log = require('cdb.log');
 var _ = require('underscore');
 var L = require('leaflet');
-var TC = require('tangram.cartodb').default;
+var TC = require('tangram.cartodb');
 var LeafletLayerView = require('./leaflet-layer-view');
 var Profiler = require('../../core/profiler');
 

--- a/src/geo/leaflet/leaflet-layer-view-factory.js
+++ b/src/geo/leaflet/leaflet-layer-view-factory.js
@@ -6,7 +6,7 @@ var LeafletPlainLayerView = require('./leaflet-plain-layer-view');
 var LeafletCartoDBLayerGroupView = require('./leaflet-cartodb-layer-group-view');
 var LeafletTorqueLayerView = require('./leaflet-torque-layer-view');
 var LeafletCartoDBWebglLayerGroupView = require('./leaflet-cartodb-webgl-layer-group-view');
-var TangramCartoCSS = require('tangram-cartocss');
+var TC = require('tangram.cartodb');
 var RenderModes = require('../../geo/render-modes');
 var util = require('../../core/util');
 
@@ -60,16 +60,11 @@ function getRenderModeResult (mapModel) {
 
 var canLayerBeRenderedClientSide = function (layerModel) {
   var cartoCSS = layerModel.get('meta').cartocss;
-
-  try {
-    TangramCartoCSS.carto2Draw(cartoCSS);
-  } catch (e) {
-    e.message = '[Tangram] Unable to render layer with the following cartoCSS:\n' + cartoCSS + '\nError: ' + e.message;
-    log.error(e);
-    return false;
+  var result = TC.getSupportedCartoCSSResult(cartoCSS);
+  if (!result.supported) {
+    log.error(new Error('[Vector] Unable to render due "' + result.reason + '". Full CartoCSS:\n' + cartoCSS));
   }
-
-  return true;
+  return result.supported;
 };
 
 var LeafletLayerViewFactory = function () {};


### PR DESCRIPTION
This removes the dependency on tangram-cartocss, but more important,
the validation will happen against the same parser version the rendering
component is using, so no need to keep the versions updated in two different
libraries. Win-win.