### PR TITLE
1697 fix feature count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .grunt
 .rvmrc
 .tmp
+.vscode
 *.swp
 bower_components
 cartodb.js-bower/

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -190,7 +190,7 @@ var Map = Model.extend({
     return !this.arePopupsEnabled();
   },
 
- // GEOMETRY MANAGEMENT
+  // GEOMETRY MANAGEMENT
 
   drawPoint: function () {
     return this._drawGeometry(GeometryFactory.createPoint({
@@ -239,8 +239,8 @@ var Map = Model.extend({
       center: latlng,
       zoom: zoom
     }, {
-      silent: true
-    });
+        silent: true
+      });
     this.trigger('set_view');
   },
 
@@ -504,35 +504,37 @@ var Map = Model.extend({
   },
 
   getEstimatedFeatureCount: function () {
-    if (this.hasEstimatedFeatureCount()) {
-      return _.reduce(this.layers.getCartoDBLayers(), function (memo, layerModel) {
-        return memo + layerModel.getEstimatedFeatureCount();
-      }, 0);
+    var acum = 0;
+    var count = 0;
+    var layers = this.layers.getCartoDBLayers();
+    if (!layers) {
+      return;
     }
+    for (var i = 0; i < layers.length; i++) {
+      count = layers[i].getEstimatedFeatureCount();
+      if (count === undefined) {
+        return;
+      }
+      acum += count;
+    }
+    return acum;
   },
-
-  hasEstimatedFeatureCount: function () {
-    return _.every(this.layers.getCartoDBLayers(), function (layerModel) {
-      var estimatedFeatureCount = layerModel.getEstimatedFeatureCount();
-      return estimatedFeatureCount && estimatedFeatureCount >= 0;
-    });
-  }
 }, {
-  PROVIDERS: {
-    GMAPS: 'googlemaps',
-    LEAFLET: 'leaflet'
-  },
+    PROVIDERS: {
+      GMAPS: 'googlemaps',
+      LEAFLET: 'leaflet'
+    },
 
-  latlngToMercator: function (latlng, zoom) {
-    var ll = new L.LatLng(latlng[0], latlng[1]);
-    var pp = L.CRS.EPSG3857.latLngToPoint(ll, zoom);
-    return [pp.x, pp.y];
-  },
+    latlngToMercator: function (latlng, zoom) {
+      var ll = new L.LatLng(latlng[0], latlng[1]);
+      var pp = L.CRS.EPSG3857.latLngToPoint(ll, zoom);
+      return [pp.x, pp.y];
+    },
 
-  mercatorToLatLng: function (point, zoom) {
-    var ll = L.CRS.EPSG3857.pointToLatLng(point, zoom);
-    return [ll.lat, ll.lng];
-  }
-});
+    mercatorToLatLng: function (point, zoom) {
+      var ll = L.CRS.EPSG3857.pointToLatLng(point, zoom);
+      return [ll.lat, ll.lng];
+    }
+  });
 
 module.exports = Map;

--- a/src/geo/map/cartodb-layer.js
+++ b/src/geo/map/cartodb-layer.js
@@ -117,10 +117,6 @@ var CartoDBLayer = LayerModelBase.extend({
   },
 
   getEstimatedFeatureCount: function () {
-    if (this.isHidden()) {
-      return 0;
-    }
-
     var meta = this.get('meta');
     var stats = meta && meta.stats;
     return stats && stats.estimatedFeatureCount;

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -31,11 +31,7 @@ describe('core/geo/map', function () {
 
   describe('.initialize', function () {
     it('should parse bounds and set attributes', function () {
-      var map = new Map({
-        bounds: [[0, 1], [2, 3]]
-      }, {
-        layersFactory: fakeLayersFactory
-      });
+      var map = new Map({ bounds: [[0, 1], [2, 3]] }, { layersFactory: fakeLayersFactory });
 
       expect(map.get('view_bounds_sw')).toEqual([0, 1]);
       expect(map.get('view_bounds_ne')).toEqual([2, 3]);
@@ -46,9 +42,10 @@ describe('core/geo/map', function () {
       var map = new Map({
         center: [41.40282319070747, 2.3435211181640625],
         zoom: 10
-      }, {
-        layersFactory: fakeLayersFactory
-      });
+      },
+        {
+          layersFactory: fakeLayersFactory
+        });
 
       expect(map.get('center')).toEqual([41.40282319070747, 2.3435211181640625]);
       expect(map.get('original_center')).toEqual([41.40282319070747, 2.3435211181640625]);
@@ -78,7 +75,7 @@ describe('core/geo/map', function () {
     it('should add a layer to the collection', function () {
       var layer = new Backbone.Model();
       map.addLayer(layer);
-      expect(map.layers.models).toEqual([ layer ]);
+      expect(map.layers.models).toEqual([layer]);
     });
   });
 
@@ -98,11 +95,11 @@ describe('core/geo/map', function () {
       map.addLayer(layer1);
       map.addLayer(layer2);
 
-      expect(map.layers.models).toEqual([ layer1, layer2 ]);
+      expect(map.layers.models).toEqual([layer1, layer2]);
 
       map.removeLayerAt(0);
 
-      expect(map.layers.models).toEqual([ layer2 ]);
+      expect(map.layers.models).toEqual([layer2]);
     });
   });
 
@@ -113,11 +110,11 @@ describe('core/geo/map', function () {
       map.addLayer(layer1);
       map.addLayer(layer2);
 
-      expect(map.layers.models).toEqual([ layer1, layer2 ]);
+      expect(map.layers.models).toEqual([layer1, layer2]);
 
       map.removeLayerByCid(layer1.cid);
 
-      expect(map.layers.models).toEqual([ layer2 ]);
+      expect(map.layers.models).toEqual([layer2]);
     });
   });
 
@@ -152,7 +149,7 @@ describe('core/geo/map', function () {
   it('should not change bounds when map size is 0', function () {
     map.set('zoom', 10);
     var bounds = [[43.100982876188546, 35.419921875], [60.23981116999893, 69.345703125]];
-    map.fitBounds(bounds, {x: 0, y: 0});
+    map.fitBounds(bounds, { x: 0, y: 0 });
     expect(map.get('zoom')).toEqual(10);
   });
 
@@ -194,7 +191,7 @@ describe('core/geo/map', function () {
     var layer3 = new CartoDBLayer({ attribution: 'wadus' }, { vis: this.vis });
     var layer4 = new CartoDBLayer({ attribution: '' }, { vis: this.vis });
 
-    map.layers.reset([ layer1, layer2, layer3, layer4 ]);
+    map.layers.reset([layer1, layer2, layer3, layer4]);
 
     // Attributions have been updated removing duplicated and empty attributions
     expect(map.get('attribution')).toEqual([
@@ -496,6 +493,57 @@ describe('core/geo/map', function () {
       this.map.stopEditingGeometry();
 
       expect(callback).toHaveBeenCalled();
+    });
+  });
+
+  describe('.getEstimatedFeatureCount', function () {
+    it('should return the sum of the estimated feature count for each layer (1+2)', function () {
+      map = new Map(null, { layersFactory: fakeLayersFactory });
+      map.layers.getCartoDBLayers = function () {
+        return [{
+          getEstimatedFeatureCount: function () {
+            return 1;
+          }
+        },
+        {
+          getEstimatedFeatureCount: function () {
+            return 2;
+          }
+        }];
+      };
+      expect(map.getEstimatedFeatureCount()).toEqual(3);
+    });
+    it('should return the sum of the estimated feature count for each layer (3+0)', function () {
+      map = new Map(null, { layersFactory: fakeLayersFactory });
+      map.layers.getCartoDBLayers = function () {
+        return [{
+          getEstimatedFeatureCount: function () {
+            return 3;
+          }
+        },
+        {
+          getEstimatedFeatureCount: function () {
+            return 0;
+          }
+        }];
+      };
+      expect(map.getEstimatedFeatureCount()).toEqual(3);
+    });
+    it('should return undefined when some layer has no estimated feature count', function () {
+      map = new Map(null, { layersFactory: fakeLayersFactory });
+      map.layers.getCartoDBLayers = function () {
+        return [{
+          getEstimatedFeatureCount: function () {
+            return undefined;
+          }
+        },
+        {
+          getEstimatedFeatureCount: function () {
+            return 2;
+          }
+        }];
+      };
+      expect(map.getEstimatedFeatureCount()).toBeUndefined();
     });
   });
 });

--- a/test/spec/geo/map/cartodb-layer.spec.js
+++ b/test/spec/geo/map/cartodb-layer.spec.js
@@ -170,7 +170,7 @@ describe('geo/map/cartodb-layer', function () {
         }
       }, { vis: this.vis });
 
-      expect(this.layer.getInteractiveColumnNames()).toEqual([ 'cartodb_id', 'a', 'b', 'c' ]);
+      expect(this.layer.getInteractiveColumnNames()).toEqual(['cartodb_id', 'a', 'b', 'c']);
     });
 
     it("should return the 'cartodb_id' if no fields are present", function () {
@@ -183,7 +183,39 @@ describe('geo/map/cartodb-layer', function () {
         }
       }, { vis: this.vis });
 
-      expect(this.layer.getInteractiveColumnNames()).toEqual([ 'cartodb_id' ]);
+      expect(this.layer.getInteractiveColumnNames()).toEqual(['cartodb_id']);
+    });
+  });
+
+  describe('.getEstimatedFeatureCount', function () {
+    var layer;
+
+    beforeEach(function () {
+      layer = new CartoDBLayer({}, { vis: this.vis });
+    });
+    it('should return undefined when there is no meta information', function () {
+      layer.set('meta', {
+        stats: {}
+      });
+      expect(layer.getEstimatedFeatureCount()).toBeUndefined();
+    });
+    it('should return the number of features extracted from the meta-information when the layer is visible', function () {
+      layer.show();
+      layer.set('meta', {
+        stats: {
+          estimatedFeatureCount: 27,
+        }
+      });
+      expect(layer.getEstimatedFeatureCount()).toEqual(27);
+    });
+    it('should return the number of features extracted from the meta-information when the layer is invisible', function () {
+      layer.hide();
+      layer.set('meta', {
+        stats: {
+          estimatedFeatureCount: 27,
+        }
+      });
+      expect(layer.getEstimatedFeatureCount()).toEqual(27);
     });
   });
 });

--- a/test/spec/geo/map/cartodb-layer.spec.js
+++ b/test/spec/geo/map/cartodb-layer.spec.js
@@ -203,7 +203,7 @@ describe('geo/map/cartodb-layer', function () {
       layer.show();
       layer.set('meta', {
         stats: {
-          estimatedFeatureCount: 27,
+          estimatedFeatureCount: 27
         }
       });
       expect(layer.getEstimatedFeatureCount()).toEqual(27);
@@ -212,7 +212,7 @@ describe('geo/map/cartodb-layer', function () {
       layer.hide();
       layer.set('meta', {
         stats: {
-          estimatedFeatureCount: 27,
+          estimatedFeatureCount: 27
         }
       });
       expect(layer.getEstimatedFeatureCount()).toEqual(27);


### PR DESCRIPTION
Regarding to #1697.

https://team.carto.com/u/javi/builder/74bb971d-5554-459a-b67d-92834dec63a0/embed?state=%7B%22map%22%3A%7B%22ne%22%3A%5B50.31653121149523%2C6.892890930175782%5D%2C%22sw%22%3A%5B50.395825267023824%2C7.019577026367188%5D%2C%22center%22%3A%5B50.35619479483569%2C6.956233978271485%5D%2C%22zoom%22%3A13%7D%7D 

This map was rendered in . `raster mode`  because `"estimatedfeaturecount=not-available"`
this was strange because the estimatedFeatureCount was included for every layer.

After doing some research we found that the `hasEstimatedFeatureCount` function in the map object has a bug when the `layerModel.getEstimatedFeatureCount()` returns 0. (For example when the layer is hidden)

This PR changes the `layerModel.getEstimatedFeatureCount()`. (This function is now ignoring the layer's visibility) and updates the `getEstimatedFeatureCount` function in the map object to perform a single pass.

With those changes, the map is now rendered with webGL:

```
MAP RENDER MODE
{
  mode: "vector",
  reason: "webgl=yes,cartocss=supported,valid-estimated-features=9807"}
}
log.js?72c3:40 Rendered Geometries Count:  59440
```
