### PR TITLE
Use info instead of error when vector can't render

### DIFF
--- a/src/geo/leaflet/leaflet-layer-view-factory.js
+++ b/src/geo/leaflet/leaflet-layer-view-factory.js
@@ -62,7 +62,7 @@ var canLayerBeRenderedClientSide = function (layerModel) {
   var cartoCSS = layerModel.get('meta').cartocss;
   var result = TC.getSupportedCartoCSSResult(cartoCSS);
   if (!result.supported) {
-    log.error(new Error('[Vector] Unable to render due "' + result.reason + '". Full CartoCSS:\n' + cartoCSS));
+    log.info('[Vector] Unable to render due "' + result.reason + '". Full CartoCSS:\n' + cartoCSS);
   }
   return result.supported;
 };


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb.js/issues/1706