### PR TITLE
Allow overriding vizJSON with options in create vis

### DIFF
--- a/src/api/create-vis.js
+++ b/src/api/create-vis.js
@@ -131,6 +131,10 @@ var applyOptionsToVizJSON = function (vizjson, options) {
     vizjson.removeLogoOverlay();
   }
 
+  if (_.has(options, 'vector')) {
+    vizjson.setVector(options.vector);
+  }
+
   // if bounds are present zoom and center will not taken into account
   var zoom = parseInt(options.zoom, 10);
   if (!isNaN(zoom)) {

--- a/src/api/vizjson.js
+++ b/src/api/vizjson.js
@@ -141,4 +141,8 @@ VizJSON.prototype.setBounds = function (bounds) {
   this.bounds = bounds;
 };
 
+VizJSON.prototype.setVector = function (vector) {
+  this.vector = vector;
+};
+
 module.exports = VizJSON;

--- a/test/spec/api/vizjson.spec.js
+++ b/test/spec/api/vizjson.spec.js
@@ -336,4 +336,16 @@ describe('src/vis/vizjson', function () {
       expect(vizjson.bounds).toEqual('new_bounds');
     });
   });
+
+  describe('.setVector', function () {
+    it('should set vector', function () {
+      var vizjson = new VizJSON({
+        vector: true
+      });
+
+      vizjson.setVector(false);
+
+      expect(vizjson.vector).toBeFalsy();
+    });
+  });
 });


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/12513

We're having problems with the vectors in Builder, in the editor view we override the vizJSON in the rails controller to force raster, but in the datasets view we make a call to the API directly, so it doesn't work.

We were using a `vector: false` option in `deep-insights-integration` which we thought forced the raster mode, but debugging I've realised it does nothing, but I liked that approach so I implemented it to use it in the datasets view, and also, when we split the front/back it will work in the editor view too.

Pinging @rochoa since my knowledge about vector/raster is pretty limited