### PR TITLE
Support for mustache conditional statements

### DIFF
--- a/src/geo/ui/infowindow-model.js
+++ b/src/geo/ui/infowindow-model.js
@@ -128,7 +128,7 @@ var InfowindowModel = Backbone.Model.extend({
         render_fields.push({
           name: field.name,
           title: field.title ? field.name : null,
-          value: (value !== undefined && value !== null) ? value : 'null',
+          value: (value !== undefined && value !== null) ? value : null,
           index: j
         });
       }

--- a/test/spec/geo/ui/infowindow-model.spec.js
+++ b/test/spec/geo/ui/infowindow-model.spec.js
@@ -34,7 +34,7 @@ describe('geo/ui/infowindow-model', function () {
       var infowindowModel = new InfowindowModel({ fields: [{ name: 'NAME', title: true }, { name: 'SOMETHING', title: true }] });
       infowindowModel.updateContent({ NAME: 'CartoDB' }, { showEmptyFields: true });
 
-      expect(infowindowModel.get('content').fields).toEqual([{ name: 'NAME', title: 'NAME', value: 'CartoDB', index: 0 }, { name: 'SOMETHING', title: 'SOMETHING', value: 'null', index: 1 }]);
+      expect(infowindowModel.get('content').fields).toEqual([{ name: 'NAME', title: 'NAME', value: 'CartoDB', index: 0 }, { name: 'SOMETHING', title: 'SOMETHING', value: null, index: 1 }]);
     });
   });
 
@@ -84,7 +84,7 @@ describe('geo/ui/infowindow-model', function () {
       expect(content.fields[1]).toEqual({
         name: 'field2',
         title: null,
-        value: 'null',
+        value: null,
         index: 1
       });
     });


### PR DESCRIPTION
Sending 'null' instead of `null` makes it hard to use conditional statements if `showEmptyFields` is set to true

Sending `null` literal still renders as 'null' without conditionals, but advanced users are able to parse this in a more granular way.