### PR TITLE
Create geometries unexpected behaviour in IE

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "semver": "~4.1.0",
     "source-map-support": "CartoDB/node-source-map-support#0.4.6-cdb1",
     "time-grunt": "~0.3.1",
+    "url": "0.11.0",
     "watchify": "3.4.0"
   },
   "browserify": {

--- a/src/windshaft/client.js
+++ b/src/windshaft/client.js
@@ -13,6 +13,15 @@ var validatePresenceOfOptions = function (options, requiredOptions) {
   }
 };
 
+var getInstantiationParams = function (params) {
+  var source = params || {};
+  var destination = util.browser.ie
+    ? { nocache: Date.now() }
+    : {};
+
+  return _.extend(destination, source);
+};
+
 var MAX_URL_LENGTH = 2033;
 var COMPRESSION_LEVEL = 3;
 
@@ -44,7 +53,7 @@ WindshaftClient.prototype.instantiateMap = function (options) {
   }
 
   var mapDefinition = options.mapDefinition;
-  var params = options.params || {};
+  var params = getInstantiationParams(options.params);
   var successCallback = options.success;
   var errorCallback = options.error;
 

--- a/test/spec/windshaft/client.spec.js
+++ b/test/spec/windshaft/client.spec.js
@@ -1,6 +1,7 @@
 var $ = require('jquery');
 var _ = require('underscore');
 var util = require('cdb.core.util');
+var urlParser = require('url');
 var WindshaftClient = require('../../../src/windshaft/client');
 var LZMA = require('lzma');
 
@@ -26,13 +27,28 @@ describe('windshaft/client', function () {
         mapDefinition: { some: 'json that must be encoded' }
       });
 
-      var url = this.ajaxParams.url.split('?')[0];
+      var parsedUrl = urlParser.parse(this.ajaxParams.url);
 
-      expect(url).toEqual('https://rambo.example.com:443/api/v1/map');
+      expect(parsedUrl.protocol).toEqual('https:');
+      expect(parsedUrl.host).toEqual('rambo.example.com:443');
+      expect(parsedUrl.pathname).toEqual('/api/v1/map');
+      expect(parsedUrl.query).not.toContain('nocache=');
       expect(this.ajaxParams.method).toEqual('GET');
       expect(this.ajaxParams.dataType).toEqual('jsonp');
       expect(this.ajaxParams.jsonpCallback).toMatch('_cdbc_callbackName');
       expect(this.ajaxParams.cache).toEqual(true);
+    });
+
+    it('should trigger a GET request to instantiate a map with nocache param in IE', function () {
+      util.browser.ie = 'ie';
+      this.client.instantiateMap({
+        mapDefinition: { some: 'json that must be encoded' }
+      });
+
+      var parsedUrl = urlParser.parse(this.ajaxParams.url);
+
+      expect(parsedUrl.query).toContain('nocache=');
+      util.browser.ie = null;
     });
 
     it('should use the endpoint for named maps', function () {


### PR DESCRIPTION
Fixes one of the problems related to https://github.com/CartoDB/support/issues/915

IE caches Ajax GET requests and the state of the map and its current visualization are different.

Added a `nocache` param to the request URL to avoid caching.