### PR TITLE
Leap year

### DIFF
--- a/src/dataviews/histogram-dataview/histogram-data-model.js
+++ b/src/dataviews/histogram-dataview/histogram-data-model.js
@@ -3,7 +3,7 @@ var BackboneAbortSync = require('../../util/backbone-abort-sync');
 var Model = require('../../core/model');
 var helper = require('../helpers/histogram-helper');
 
-var DEFAULT_MAX_BUCKETS = 366;
+var DEFAULT_MAX_BUCKETS = 367;
 
 /**
  *  This model is used for getting the total amount of data


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb/issues/12778

There are some datasets with data between the same dates of consecutive years in a leap year. `2015-01-01` and `2016-01-01` In this case, the API returns 367 buckets (366 + the one of the next year).

We thought that this case would comprehend from `2015-01-01` to `2015-12-31` but it seems that the example above is also common.

This PR only increase the constant in one day to allow this case.