### PR TITLE
Overflow wrap.

### DIFF
--- a/themes/scss/infowindow/_cartodb-infowindow-default.scss
+++ b/themes/scss/infowindow/_cartodb-infowindow-default.scss
@@ -5,10 +5,7 @@
   position: absolute;
   z-index: 1; // makes infowindows visible with Google Maps
   word-wrap: break-word;
-  word-break: break-all;
-  -ms-hyphens: auto;
-  -webkit-hyphens: auto;
-  hyphens: auto;
+  overflow-wrap: break-word;
 }
 .CDB-infowindow {
   position: relative;

--- a/themes/scss/tooltip/_cartodb-tooltip-default.scss
+++ b/themes/scss/tooltip/_cartodb-tooltip-default.scss
@@ -10,10 +10,7 @@
   border-radius: 4px;
   overflow: hidden;
   word-wrap: break-word;
-  word-break: break-all;
-  -ms-hyphens: auto;
-  -webkit-hyphens: auto;
-  hyphens: auto;
+  overflow-wrap: break-word;
   &.CDB-Tooltip-wrapper--topLeft {
     border-top-left-radius: 0;
   }


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb/pull/12833
The next solution is using word-wrap (overflow-wrap), another property to specify whether or not the browser may break lines within words.