### PR TITLE
Build & deploy Docs automatically to gh-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.swp
 bower_components
 cartodb.js-bower/
+out
 dist
 Gemfile.lock
 node_modules
@@ -17,4 +18,3 @@ themes/css/all.css
 themes/css/cartodb.ie.css
 themes/css/cartodb.css
 yarn.lock
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,13 @@ install:
 before_script:
   - cp secrets.example.json secrets.json
   - npm install -g grunt-cli
+  - chmod +x ./scripts/deploy-to-gh-pages.sh
 
 script:
   - grunt test
+
+after_success:
+  - ./scripts/deploy-to-gh-pages.sh
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,32 @@
+sudo: false
 cache: false
 language: node_js
 node_js:
-- 6.9.2
+  - 6.9.2
 install:
-- npm install
+  - npm install
 before_script:
-- cp secrets.example.json secrets.json
-- npm install -g grunt-cli
-- chmod +x ./scripts/deploy-to-gh-pages.sh
+  - cp secrets.example.json secrets.json
+  - npm install -g grunt-cli
+  - chmod +x ./scripts/deploy-to-gh-pages.sh
 script:
-- grunt test
+  - grunt test
 after_success:
-- ./scripts/deploy-to-gh-pages.sh
+  - npm run docs
+  - ./scripts/deploy-to-gh-pages.sh
 notifications:
   email:
     on_success: never
     on_failure: change
 env:
   global:
-    secure: qPMF8IgZRx3jG8HQEust5LFpVZuKjPrVVKHwRuilVjREQi14KYpEnuTm0is3YobOsMcG+V9lvulETylekccs/y4LmS+LOCc52tqS4cCq3YbzRt1OmsHNwE71k+Hpqr26QV15yy5bKwX3RZLNESDuC7AgjmS/vn86t5nAB4Rbc3I=
+    secure: D8bXGaTynX3VVPQtwZC03KX95EeBDxzlqhDnq6XskNcWbKwC9PBCzb/c3PF4184ra+XRf5uZZfaQjlZTlGWGfD0xCZwI6TuX0Qj2XfQT/nWhrHrFYm7oL4JeunYSIj2tv0wkIcSJL1/fsc49o+Geqf+v96HGYG1s/Sq6ig60/wQ=
+
+#deploy:
+#  provider: pages
+#  skip_cleanup: true
+#  local_dir: out
+#  on:
+#    branch: jsdoc-ghpages
+#  github-token:
+#    secure: ...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,21 @@
 cache: false
 language: node_js
 node_js:
-  - "6.9.2"
-
+- 6.9.2
 install:
-  - npm install
-
+- npm install
 before_script:
-  - cp secrets.example.json secrets.json
-  - npm install -g grunt-cli
-  - chmod +x ./scripts/deploy-to-gh-pages.sh
-
+- cp secrets.example.json secrets.json
+- npm install -g grunt-cli
+- chmod +x ./scripts/deploy-to-gh-pages.sh
 script:
-  - grunt test
-
+- grunt test
 after_success:
-  - ./scripts/deploy-to-gh-pages.sh
-
+- ./scripts/deploy-to-gh-pages.sh
 notifications:
   email:
     on_success: never
     on_failure: change
+env:
+  global:
+    secure: qPMF8IgZRx3jG8HQEust5LFpVZuKjPrVVKHwRuilVjREQi14KYpEnuTm0is3YobOsMcG+V9lvulETylekccs/y4LmS+LOCc52tqS4cCq3YbzRt1OmsHNwE71k+Hpqr26QV15yy5bKwX3RZLNESDuC7AgjmS/vn86t5nAB4Rbc3I=

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,3 @@ notifications:
 env:
   global:
     secure: D8bXGaTynX3VVPQtwZC03KX95EeBDxzlqhDnq6XskNcWbKwC9PBCzb/c3PF4184ra+XRf5uZZfaQjlZTlGWGfD0xCZwI6TuX0Qj2XfQT/nWhrHrFYm7oL4JeunYSIj2tv0wkIcSJL1/fsc49o+Geqf+v96HGYG1s/Sq6ig60/wQ=
-
-#deploy:
-#  provider: pages
-#  skip_cleanup: true
-#  local_dir: out
-#  on:
-#    branch: jsdoc-ghpages
-#  github-token:
-#    secure: ...

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,10 @@ install:
 before_script:
   - cp secrets.example.json secrets.json
   - npm install -g grunt-cli
-  - chmod +x ./scripts/deploy-to-gh-pages.sh
 script:
   - grunt test
 after_success:
-  - npm run docs
-  - ./scripts/deploy-to-gh-pages.sh
+  - bash scripts/deploy-to-gh-pages.sh
 notifications:
   email:
     on_success: never

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-CartoDB.js (v3.15)
+CARTO.js [v4](http://cartodb.github.io/cartodb.js/)
 ===========
 
-This library allows to embed visualizations created with CartoDB in your map or website in a simple way.
+This library allows to embed visualizations created with CARTO in your map or website in a simple way.
 
+# TODO:
 
-## Quick start
+## ~Quick start
 
   1. Add cartodb.js and css to your site:
 
@@ -43,10 +44,10 @@ You can install **cartodb.js** with [bower](http://bower.io/) by running
 bower install cartodb.js
 ```
 
-## Documentation
+## ~Documentation
 You can find the documentation online [here](http://docs.carto.com/cartodb-platform/cartodb-js.html) and the [source](https://github.com/CartoDB/cartodb.js/blob/develop/doc/API.md) inside this repository.
 
-## Examples
+## ~Examples
 
 - [Load a layer with google maps](http://cartodb.github.com/cartodb.js/examples/gmaps_force_basemap.html)
 - [Load a layer with Leaflet](http://cartodb.github.com/cartodb.js/examples/leaflet.html)
@@ -56,7 +57,7 @@ You can find the documentation online [here](http://docs.carto.com/cartodb-platf
 - [The Hobbit filming location paths](http://cartodb.github.com/cartodb.js/examples/TheHobbitLocations/) a full example with some widgets
 
 
-## How to build
+## ~How to build
 Build CartoDB.js library:
 
 - Install [node.js](http://nodejs.org/download/), from 0.10 version
@@ -68,6 +69,6 @@ Build CartoDB.js library:
 - Start the server: `grunt build`
 - Happy mapping!
 
-## Submitting Contributions
+## ~Submitting Contributions
 
 You will need to sign a Contributor License Agreement (CLA) before making a submission. [Learn more here.](https://carto.com/contributing)

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,26 @@
+{
+  "tags": {
+    "allowUnknownTags": true,
+    "dictionaries": [
+      "jsdoc",
+      "closure"
+    ]
+  },
+  "source": {
+    "include": [ "src" ],
+    "includePattern": ".+\\.js(doc|x)?$",
+    "excludePattern": "(^|\\/|\\\\)_"
+  },
+  "plugins": [],
+  "templates": {
+    "cleverLinks": false,
+    "monospaceLinks": false,
+    "default": {
+      "outputSourceFiles": false
+    }
+  },
+  "opts": {
+    "destination": "./out/",
+    "recurse": true
+  }
+}

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -20,7 +20,7 @@
     }
   },
   "opts": {
-    "destination": "./out/",
+    "destination": "./out/v4",
     "recurse": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -138,6 +138,6 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "docs": "rm -rf doc; jsdoc --configure jsdoc.json"
+    "docs": "rm -rf out; jsdoc --configure jsdoc.json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "gulp-install": "0.2.0",
     "gulp-sketch": "0.0.7",
     "jasmine-ajax": "git://github.com/nobuti/jasmine-ajax.git#master",
+    "jsdoc": "~3.5.5",
     "jshint-stylish": "~0.1.3",
     "jstify": "0.12.0",
     "load-grunt-tasks": "~0.6.0",
@@ -136,6 +137,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "docs": "rm -rf doc; jsdoc --configure jsdoc.json"
   }
 }

--- a/scripts/deploy-to-gh-pages.sh
+++ b/scripts/deploy-to-gh-pages.sh
@@ -1,38 +1,39 @@
 #!/bin/bash
-if [[ "$TRAVIS_BRANCH" != "jsdoc-ghpages" ]]; then
+
+# Pull requests and commits to other branches shouldn't try to deploy
+if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_BRANCH" != "jsdoc-ghpages" ]; then
   exit 0
 fi
 
 echo "Starting deployment"
 echo "Target: gh-pages branch"
 
-DIST_DIRECTORY="out/"
+SOURCE_DIR="out/v4"
+TARGET_DIR="v4"
 CURRENT_COMMIT=`git rev-parse HEAD`
 ORIGIN_URL=`git config --get remote.origin.url`
-ORIGIN_URL_WITH_CREDENTIALS=${ORIGIN_URL/\/\/github.com/\/\/$GITHUB_TOKEN@github.com}
+ORIGIN_URL_WITH_CREDENTIALS="https://$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG"
 
-cp .gitignore $DIST_DIRECTORY || exit 1
+echo "Fetching gh-pages branch"
+git fetch origin gh-pages:refs/remotes/origin/gh-pages || exit 1
 
 echo "Checking out gh-pages branch"
-git checkout -B gh-pages || exit 1
+git checkout -b gh-pages origin/gh-pages || exit 1
 
-echo "Removing old static content"
-git rm -rf . || exit 1
-
-echo "Copying dist content to root"
-cp -r $DIST_DIRECTORY/* . || exit 1
-cp $DIST_DIRECTORY/.gitignore . || exit 1
+echo "Copying source content to root"
+rm -rf $TARGET_DIR || exit 1
+cp -r $SOURCE_DIR $TARGET_DIR || exit 1
 
 echo "Pushing new content to $ORIGIN_URL"
-git config user.name "Carto CI" || exit 1
+git config user.name "CartoBot" || exit 1
 git config user.email "frontend@carto.com" || exit 1
 
-git add -A . || exit 1
-git commit --allow-empty -m "Regenerated static content for $CURRENT_COMMIT" || exit 1
-git push --force --quiet "$ORIGIN_URL_WITH_CREDENTIALS" gh-pages > /dev/null 2>&1
+git add $TARGET_DIR || exit 1
+git commit --allow-empty -m "Update docs for $CURRENT_COMMIT" || exit 1
+git push --force --quiet "$ORIGIN_URL_WITH_CREDENTIALS" gh-pages
 
 echo "Cleaning up temp files"
-rm -Rf $DIST_DIRECTORY
+rm -rf $TARGET_DIR
 
 echo "Deployed successfully."
 exit 0

--- a/scripts/deploy-to-gh-pages.sh
+++ b/scripts/deploy-to-gh-pages.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+if [[ "$TRAVIS_BRANCH" != "jsdoc-ghpages" ]]; then
+  exit 0
+fi
+
+echo "Starting deployment"
+echo "Target: gh-pages branch"
+
+DIST_DIRECTORY="out/"
+CURRENT_COMMIT=`git rev-parse HEAD`
+ORIGIN_URL=`git config --get remote.origin.url`
+ORIGIN_URL_WITH_CREDENTIALS=${ORIGIN_URL/\/\/github.com/\/\/$GITHUB_TOKEN@github.com}
+
+cp .gitignore $DIST_DIRECTORY || exit 1
+
+echo "Checking out gh-pages branch"
+git checkout -B gh-pages || exit 1
+
+echo "Removing old static content"
+git rm -rf . || exit 1
+
+echo "Copying dist content to root"
+cp -r $DIST_DIRECTORY/* . || exit 1
+cp $DIST_DIRECTORY/.gitignore . || exit 1
+
+echo "Pushing new content to $ORIGIN_URL"
+git config user.name "Carto CI" || exit 1
+git config user.email "frontend@carto.com" || exit 1
+
+git add -A . || exit 1
+git commit --allow-empty -m "Regenerated static content for $CURRENT_COMMIT" || exit 1
+git push --force --quiet "$ORIGIN_URL_WITH_CREDENTIALS" gh-pages > /dev/null 2>&1
+
+echo "Cleaning up temp files"
+rm -Rf $DIST_DIRECTORY
+
+echo "Deployed successfully."
+exit 0

--- a/scripts/deploy-to-gh-pages.sh
+++ b/scripts/deploy-to-gh-pages.sh
@@ -14,6 +14,9 @@ CURRENT_COMMIT=`git rev-parse HEAD`
 ORIGIN_URL=`git config --get remote.origin.url`
 ORIGIN_URL_WITH_CREDENTIALS="https://$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG"
 
+echo "Generating documentation"
+npm run docs
+
 echo "Fetching gh-pages branch"
 git fetch origin gh-pages:refs/remotes/origin/gh-pages || exit 1
 
@@ -30,7 +33,7 @@ git config user.email "frontend@carto.com" || exit 1
 
 git add $TARGET_DIR || exit 1
 git commit --allow-empty -m "Update docs for $CURRENT_COMMIT" || exit 1
-git push --force --quiet "$ORIGIN_URL_WITH_CREDENTIALS" gh-pages
+git push --force --quiet "$ORIGIN_URL_WITH_CREDENTIALS" gh-pages > /dev/null 2>&1
 
 echo "Cleaning up temp files"
 rm -rf $TARGET_DIR

--- a/scripts/deploy-to-gh-pages.sh
+++ b/scripts/deploy-to-gh-pages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Pull requests and commits to other branches shouldn't try to deploy
-if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_BRANCH" != "jsdoc-ghpages" ]; then
+if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_BRANCH" != "v4" ]; then
   exit 0
 fi
 

--- a/src/core/sanitize.js
+++ b/src/core/sanitize.js
@@ -3,7 +3,7 @@ var htmlCssSanitizer = require('html-css-sanitizer');
 /**
  * Sanitize inputHtml of unsafe HTML tags & attributes
  * @param {String} inputHtml
- * @param {Function,false,null,undefined} optionalSanitizer By default undefined, for which the default sanitizer will be used.
+ * @param {Function} optionalSanitizer By default undefined, for which the default sanitizer will be used.
  *   Pass a function (that takes inputHtml) to sanitize yourself, or false/null to skip sanitize call.
  */
 htmlCssSanitizer.html = function (inputHtml, optionalSanitizer) {

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -62,7 +62,7 @@ module.exports = Model.extend({
   /**
    * Subclasses might override this method to define extra params that will be appended
    * to the dataview's URL.
-   * @return {[Array]} An array of strings in the form of "key=value".
+   * @return {Array} An array of strings in the form of "key=value".
    */
   _getDataviewSpecificURLParams: function () {
     return [];


### PR DESCRIPTION
Related to: #1741

With each v4 commit, the API documentation is built with [JSDoc](http://usejsdoc.org/) and commited to [gh-pages branch](https://github.com/CartoDB/cartodb.js/commits/gh-pages). No generated docs in v4 branch!

This is the main page: http://cartodb.github.io/cartodb.js/