### PR TITLE
Filter log, to avoid treating "Unsupported CartoCSS" as errors

### DIFF
--- a/src/geo/leaflet/leaflet-layer-view-factory.js
+++ b/src/geo/leaflet/leaflet-layer-view-factory.js
@@ -62,9 +62,9 @@ var canLayerBeRenderedClientSide = function (layerModel) {
   var cartoCSS = layerModel.get('meta').cartocss;
   var result = TC.getSupportedCartoCSSResult(cartoCSS);
   if (!result.supported) {
-    if (result.reason.indexOf('Unsupported CartoCSS')==0){
+    if (result.reason.indexOf('Unsupported CartoCSS') === 0) {
       log.info('[Vector] Unable to render due "' + result.reason + '". Full CartoCSS:\n' + cartoCSS);
-    }else{
+    } else {
       log.error(new Error('[Vector] Unable to render due "' + result.reason + '". Full CartoCSS:\n' + cartoCSS));
     }
   }

--- a/src/geo/leaflet/leaflet-layer-view-factory.js
+++ b/src/geo/leaflet/leaflet-layer-view-factory.js
@@ -62,7 +62,11 @@ var canLayerBeRenderedClientSide = function (layerModel) {
   var cartoCSS = layerModel.get('meta').cartocss;
   var result = TC.getSupportedCartoCSSResult(cartoCSS);
   if (!result.supported) {
-    log.error(new Error('[Vector] Unable to render due "' + result.reason + '". Full CartoCSS:\n' + cartoCSS));
+    if (result.reason.indexOf('Unsupported CartoCSS')==0){
+      log.info('[Vector] Unable to render due "' + result.reason + '". Full CartoCSS:\n' + cartoCSS);
+    }else{
+      log.error(new Error('[Vector] Unable to render due "' + result.reason + '". Full CartoCSS:\n' + cartoCSS));
+    }
   }
   return result.supported;
 };

--- a/src/geo/leaflet/leaflet-layer-view-factory.js
+++ b/src/geo/leaflet/leaflet-layer-view-factory.js
@@ -62,19 +62,14 @@ var canLayerBeRenderedClientSide = function (layerModel) {
   var cartoCSS = layerModel.get('meta').cartocss;
   var result = TC.getSupportedCartoCSSResult(cartoCSS);
   if (!result.supported) {
-    _logErrors(result, cartoCSS);
+    if (result.reason.indexOf('Unsupported CartoCSS') === 0) {
+      log.info('[Vector] Unable to render due "' + result.reason + '". Full CartoCSS:\n' + cartoCSS);
+    } else {
+      log.error(new Error('[Vector] Unable to render due "' + result.reason + '". Full CartoCSS:\n' + cartoCSS));
+    }
   }
   return result.supported;
 };
-
-/**
- * Log an info message when the layer cannot be rendered because cartoCSS is not supported
- * or an error when is not rendered for another reasons.
- */
-function _logErrors (result, cartoCSS) {
-  var logFn = (result.reason.indexOf('Unsupported CartoCSS') === 0) ? log.info : log.error;
-  logFn('[Vector] Unable to render due "' + result.reason + '". Full CartoCSS:\n' + cartoCSS);
-}
 
 var LeafletLayerViewFactory = function () {};
 

--- a/src/geo/leaflet/leaflet-layer-view-factory.js
+++ b/src/geo/leaflet/leaflet-layer-view-factory.js
@@ -62,14 +62,19 @@ var canLayerBeRenderedClientSide = function (layerModel) {
   var cartoCSS = layerModel.get('meta').cartocss;
   var result = TC.getSupportedCartoCSSResult(cartoCSS);
   if (!result.supported) {
-    if (result.reason.indexOf('Unsupported CartoCSS') === 0) {
-      log.info('[Vector] Unable to render due "' + result.reason + '". Full CartoCSS:\n' + cartoCSS);
-    } else {
-      log.error(new Error('[Vector] Unable to render due "' + result.reason + '". Full CartoCSS:\n' + cartoCSS));
-    }
+    _logErrors(result, cartoCSS);
   }
   return result.supported;
 };
+
+/**
+ * Log an info message when the layer cannot be rendered because cartoCSS is not supported
+ * or an error when is not rendered for another reasons.
+ */
+function _logErrors (result, cartoCSS) {
+  var logFn = (result.reason.indexOf('Unsupported CartoCSS') === 0) ? log.info : log.error;
+  logFn('[Vector] Unable to render due "' + result.reason + '". Full CartoCSS:\n' + cartoCSS);
+}
 
 var LeafletLayerViewFactory = function () {};
 


### PR DESCRIPTION
We want to avoid logging "Unsupported CartoCSS" errors, since they are not really errors.