### PR TITLE
Take account of title in order to update infowindow models.

### DIFF
--- a/src/geo/map/popup-fields.js
+++ b/src/geo/map/popup-fields.js
@@ -2,7 +2,11 @@ var _ = require('underscore');
 var Backbone = require('backbone');
 
 var getFieldNames = function (fields) {
-  return _.map(fields, 'name');
+  return _.map(fields, function (field) {
+    var o = {};
+    o[field.name] = field.title;
+    return o;
+  });
 };
 
 var PopupFields = Backbone.Collection.extend({

--- a/src/geo/ui/tooltip-model.js
+++ b/src/geo/ui/tooltip-model.js
@@ -35,10 +35,9 @@ var TooltipModel = Model.extend({
     // alternamte names
     var names = this.get('alternative_names');
     if (names) {
-      for (var i = 0; i < data.fields.length; ++i) {
-        var f = data.fields[i];
-        f.title = names[f.title] || f.title;
-      }
+      data.fields.forEach(function (field) {
+        field.title = names[field.title] || field.title;
+      });
     }
 
     this.set('content', data);


### PR DESCRIPTION
This PR is related to https://github.com/CartoDB/cartodb/issues/11430.

Until now, we only check for names, but no titles. So when the user
selected a field, and later, changed the title, the model wasn't updated
because we only looked for fields' names.