### PR TITLE
Remove `source` attribute check for "CartoDB" and "Torque" layers

### DIFF
--- a/src/vis/layers-factory.js
+++ b/src/vis/layers-factory.js
@@ -95,8 +95,15 @@ var LAYER_CONSTRUCTORS = {
   },
 
   cartodb: function (attrs, options) {
-    checkProperties(attrs, ['source', 'cartocss']);
-    attrs.source = CartoDBLayer.getLayerSourceFromAttrs(attrs, options.vis.analysis);
+    // TODO: Once https://github.com/CartoDB/cartodb/issues/12885 is merged,
+    // we should make 'source' attribute required again and make sure it's
+    // always populated:
+    // checkProperties(attrs, ['source', 'cartocss']);
+    // attrs.source = CartoDBLayer.getLayerSourceFromAttrs(attrs, options.vis.analysis);
+    checkProperties(attrs, ['cartocss']);
+    if (attrs.source) {
+      attrs.source = CartoDBLayer.getLayerSourceFromAttrs(attrs, options.vis.analysis);
+    }
 
     return new CartoDBLayer(attrs, {
       vis: options.vis
@@ -104,8 +111,15 @@ var LAYER_CONSTRUCTORS = {
   },
 
   torque: function (attrs, options) {
-    checkProperties(attrs, ['source', 'cartocss']);
-    attrs.source = TorqueLayer.getLayerSourceFromAttrs(attrs, options.vis.analysis);
+    // TODO: Once https://github.com/CartoDB/cartodb/issues/12885 is merged,
+    // we should make 'source' attribute required again and make sure it's
+    // populated:
+    // checkProperties(attrs, ['source', 'cartocss']);
+    // attrs.source = CartoDBLayer.getLayerSourceFromAttrs(attrs, options.vis.analysis);
+    checkProperties(attrs, ['cartocss']);
+    if (attrs.source) {
+      attrs.source = CartoDBLayer.getLayerSourceFromAttrs(attrs, options.vis.analysis);
+    }
 
     var windshaftSettings = options.windshaftSettings;
 

--- a/test/spec/vis/layers-factory.spec.js
+++ b/test/spec/vis/layers-factory.spec.js
@@ -41,11 +41,17 @@ describe('vis/layers-factory', function () {
     var testCases = [
       {
         layerType: 'CartoDB',
-        expectedErrorMessage: 'The following attributes are missing: source,cartocss'
+        // TODO: Once https://github.com/CartoDB/cartodb/issues/12885 is merged
+        // source should be required again so we need to add the attribute to this test
+        // expectedErrorMessage: 'The following attributes are missing: source,cartocss'
+        expectedErrorMessage: 'The following attributes are missing: cartocss'
       },
       {
         layerType: 'torque',
-        expectedErrorMessage: 'The following attributes are missing: source,cartocss'
+        // TODO: Once https://github.com/CartoDB/cartodb/issues/12885 is merged
+        // source should be required again so we need to add the attribute to this test
+        // expectedErrorMessage: 'The following attributes are missing: source,cartocss'
+        expectedErrorMessage: 'The following attributes are missing: cartocss'
       },
       {
         layerType: 'Tiled',


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/12881#issuecomment-333042882 until a more definitive fix is implemented (https://github.com/CartoDB/cartodb/issues/12885).

I opened an issue to bring back that check (https://github.com/CartoDB/cartodb.js/issues/1791).
