### PR TITLE
Fix gmaps tests

### DIFF
--- a/src/geo/gmaps/gmaps-map-view.js
+++ b/src/geo/gmaps/gmaps-map-view.js
@@ -82,6 +82,12 @@ var GoogleMapsMapView = MapView.extend({
     MapView.prototype.clean.call(this);
   },
 
+  listenOnce: function (name, callback) {
+    google.maps.event.addListenerOnce(this._gmapsMap, name, function (event) {
+      callback(event);
+    });
+  },
+
   _getLayerViewFactory: function () {
     this._layerViewFactory = this._layerViewFactory || new GMapsLayerViewFactory();
 

--- a/src/geo/gmaps/gmaps-map-view.js
+++ b/src/geo/gmaps/gmaps-map-view.js
@@ -1,12 +1,10 @@
 /* global google */
-var _ = require('underscore');
 var MapView = require('../map-view');
 var Projector = require('./projector');
 var GMapsLayerViewFactory = require('./gmaps-layer-view-factory');
 
 var GoogleMapsMapView = MapView.extend({
   initialize: function () {
-    _.bindAll(this, '_ready');
     this._isReady = false;
 
     MapView.prototype.initialize.apply(this, arguments);
@@ -70,9 +68,11 @@ var GoogleMapsMapView = MapView.extend({
       self.map.setMapViewSize(self.getSize());
     });
 
-    this.projector = new Projector(this._gmapsMap);
+    google.maps.event.addListenerOnce(this._gmapsMap, 'idle', function (e) {
+      this._isReady = true;
+    });
 
-    this.projector.draw = this._ready;
+    this.projector = new Projector(this._gmapsMap);
   },
 
   clean: function () {
@@ -86,12 +86,6 @@ var GoogleMapsMapView = MapView.extend({
     this._layerViewFactory = this._layerViewFactory || new GMapsLayerViewFactory();
 
     return this._layerViewFactory;
-  },
-
-  _ready: function () {
-    this.projector.draw = function () {};
-    this.trigger('ready');
-    this._isReady = true;
   },
 
   _setKeyboard: function (model, z) {

--- a/src/geo/gmaps/projector.js
+++ b/src/geo/gmaps/projector.js
@@ -5,7 +5,7 @@ function Projector (map) {
   if (!this._projection) {
     google.maps.event.addListenerOnce(map, 'projection_changed', function () {
       this._projection = map.getProjection();
-    });
+    }.bind(this));
   }
 }
 
@@ -13,18 +13,16 @@ Projector.prototype.latLngToPixel = function (latlng) {
   if (this._projection) {
     return this._projection.fromLatLngToPoint(latlng);
   }
-  // FIXME
   console.warn('Projector has no projection');
-  return new google.maps.Point(latlng.lat(), latlng.lng());
+  return new google.maps.Point(0, 0);
 };
 
 Projector.prototype.pixelToLatLng = function (point) {
   if (this._projection) {
     return this._projection.fromPointToLatLng(point);
   }
-  // FIXME
   console.warn('Projector has no projection');
-  return new google.maps.LatLng(point.x, point.y);
+  return new google.maps.LatLng(0, 0);
 };
 
 module.exports = Projector;

--- a/src/geo/gmaps/projector.js
+++ b/src/geo/gmaps/projector.js
@@ -1,22 +1,24 @@
 /* global google */
+// helper to get pixel position from latlon
 
 function Projector (map) {
-  this._map = map;
+  this.setMap(map);
 }
-
+Projector.prototype = new google.maps.OverlayView();
+Projector.prototype.draw = function () {};
 Projector.prototype.latLngToPixel = function (latlng) {
-  var projection = this._map.getProjection();
+  var projection = this.getProjection();
   if (projection) {
-    return projection.fromLatLngToPoint(latlng);
+    return projection.fromLatLngToContainerPixel(latlng);
   }
   console.warn('Projector has no projection');
   return new google.maps.Point(0, 0);
 };
 
 Projector.prototype.pixelToLatLng = function (point) {
-  var projection = this._map.getProjection();
+  var projection = this.getProjection();
   if (projection) {
-    return projection.fromPointToLatLng(point);
+    return projection.fromContainerPixelToLatLng(point);
   }
   console.warn('Projector has no projection');
   return new google.maps.LatLng(0, 0);

--- a/src/geo/gmaps/projector.js
+++ b/src/geo/gmaps/projector.js
@@ -1,25 +1,22 @@
 /* global google */
 
 function Projector (map) {
-  this._projection = map.getProjection();
-  if (!this._projection) {
-    google.maps.event.addListenerOnce(map, 'projection_changed', function () {
-      this._projection = map.getProjection();
-    }.bind(this));
-  }
+  this._map = map;
 }
 
 Projector.prototype.latLngToPixel = function (latlng) {
-  if (this._projection) {
-    return this._projection.fromLatLngToPoint(latlng);
+  var projection = this._map.getProjection();
+  if (projection) {
+    return projection.fromLatLngToPoint(latlng);
   }
   console.warn('Projector has no projection');
   return new google.maps.Point(0, 0);
 };
 
 Projector.prototype.pixelToLatLng = function (point) {
-  if (this._projection) {
-    return this._projection.fromPointToLatLng(point);
+  var projection = this._map.getProjection();
+  if (projection) {
+    return projection.fromPointToLatLng(point);
   }
   console.warn('Projector has no projection');
   return new google.maps.LatLng(0, 0);

--- a/src/geo/gmaps/projector.js
+++ b/src/geo/gmaps/projector.js
@@ -1,21 +1,30 @@
 /* global google */
-// helper to get pixel position from latlon
-var Projector = function (map) { this.setMap(map); };
-Projector.prototype = new google.maps.OverlayView();
-Projector.prototype.draw = function () {};
-Projector.prototype.latLngToPixel = function (point) {
-  var p = this.getProjection();
-  if (p) {
-    return p.fromLatLngToContainerPixel(point);
+
+function Projector (map) {
+  this._projection = map.getProjection();
+  if (!this._projection) {
+    google.maps.event.addListenerOnce(map, 'projection_changed', function () {
+      this._projection = map.getProjection();
+    });
   }
-  return new google.maps.Point(0, 0);
+}
+
+Projector.prototype.latLngToPixel = function (latlng) {
+  if (this._projection) {
+    return this._projection.fromLatLngToPoint(latlng);
+  }
+  // FIXME
+  console.warn('Projector has no projection');
+  return new google.maps.Point(latlng.lat(), latlng.lng());
 };
+
 Projector.prototype.pixelToLatLng = function (point) {
-  var p = this.getProjection();
-  if (p) {
-    return p.fromContainerPixelToLatLng(point);
+  if (this._projection) {
+    return this._projection.fromPointToLatLng(point);
   }
-  return new google.maps.LatLng(0, 0);
+  // FIXME
+  console.warn('Projector has no projection');
+  return new google.maps.LatLng(point.x, point.y);
 };
 
 module.exports = Projector;

--- a/src/geo/leaflet/leaflet-map-view.js
+++ b/src/geo/leaflet/leaflet-map-view.js
@@ -194,6 +194,10 @@ var LeafletMapView = MapView.extend({
     }, this);
   },
 
+  listenOnce: function (name, callback) {
+    callback();
+  },
+
   // return the current bounds of the map view
   getBounds: function () {
     var b = this._leafletMap.getBounds();

--- a/test/spec/geo/geometry-views/shared-tests-for-path-views.js
+++ b/test/spec/geo/geometry-views/shared-tests-for-path-views.js
@@ -143,7 +143,7 @@ module.exports = function (Path, MapView, PathView) {
   });
 
   describe('expandable paths', function () {
-    beforeEach(function () {
+    beforeEach(function (done) {
       this.mapView = createMapView(MapView);
       this.mapView.render();
 
@@ -161,12 +161,17 @@ module.exports = function (Path, MapView, PathView) {
         mapView: this.mapView
       });
 
-      this.geometryView.render();
+      // Listen for the map to be loaded
+      this.mapView.listenOnce('idle', function () {
+        this.geometryView.render();
 
-      // Marker that we'll interact with in the tests
-      this.middlePointMarker = this.mapView.findMarkerByLatLng({ lat: 5, lng: 0 });
-      var markers = this.mapView.getMarkers();
-      this.numberOfMarkersBefore = markers.length;
+        // Marker that we'll interact with in the tests
+        this.middlePointMarker = this.mapView.findMarkerByLatLng({ lat: 5, lng: 0 });
+        var markers = this.mapView.getMarkers();
+        this.numberOfMarkersBefore = markers.length;
+
+        done();
+      }.bind(this));
     });
 
     describe('when the model is removed', function () {


### PR DESCRIPTION
Related to: #1798

The issue is that gmaps projection in the projector is not ready when `latLngToPixel`and `pixelToLatLng`methods are called and they return always (0, 0) failing some tests.

More precisely: in the polygons edition tests (6 tests) the middle points are not added in the coordinates because the `computeMidLatLng` method calls `mapView.latLngToContainerPoint` that returns (0, 0) when the projection is not ready. So no middle points in the coordinates list, no tests passed.

It depends on the platform. In Chrome when all the tests are executed they pass. If you run some tests individually they fail. In Firefox the 6 tests fail when all tests are executed, as in Jenkins.

Changes to solve the issue:
- Refactor of Projector. Remove _ready method trick, use idle event instead
- Added 'Projector has no projection' warning when projection is not loaded
- Wait async for the map to be loaded in the failing tests