### PR TITLE
Layers serializer ignores layers not supported by Maps API

### DIFF
--- a/src/windshaft/map-serializer/anonymous-map-serializer/layers-serializer.js
+++ b/src/windshaft/map-serializer/anonymous-map-serializer/layers-serializer.js
@@ -12,7 +12,10 @@ var TORQUE_LAYER_TYPE = 'torque';
  * Generate a json payload from a layer collection of a map
  */
 function serialize (layersCollection) {
-  return layersCollection.map(_calculateLayerJSON);
+  return layersCollection.chain()
+    .map(_calculateLayerJSON)
+    .compact()
+    .value();
 }
 
 function _calculateLayerJSON (layerModel) {
@@ -27,8 +30,6 @@ function _calculateLayerJSON (layerModel) {
   } else if (LayerTypes.isTorqueLayer(layerModel)) {
     return optionsForTorqueLayer(layerModel);
   }
-
-  throw new Error('Layer of type "' + layerModel.get('type') + '" are not supported');
 }
 
 function optionsForHTTPLayer (layerModel) {

--- a/test/spec/windshaft/map-serializer/anonymous-map-serializer/layers-serializer.spec.js
+++ b/test/spec/windshaft/map-serializer/anonymous-map-serializer/layers-serializer.spec.js
@@ -3,6 +3,7 @@ var CartoDBLayer = require('../../../../../src/geo/map/cartodb-layer');
 var PlainLayer = require('../../../../../src/geo/map/plain-layer');
 var TileLayer = require('../../../../../src/geo/map/tile-layer');
 var TorqueLayer = require('../../../../../src/geo/map/torque-layer');
+var GMapsBaseLayer = require('../../../../../src/geo/map/gmaps-base-layer');
 var VisModel = require('../../../../../src/vis/vis');
 var LayersSerializer = require('../../../../../src/windshaft/map-serializer/anonymous-map-serializer/layers-serializer');
 
@@ -107,6 +108,18 @@ describe('layers-serializer', function () {
           'tms': false
         }
       }];
+      expect(actual).toEqual(expected);
+    });
+
+    it('should not serialize GMapsBase layers', function () {
+      var gmapsBaseLayer = new GMapsBaseLayer({
+        id: 'l4',
+        baseType: 'roadmap'
+      }, { vis: {} });
+      layersCollection.reset([gmapsBaseLayer]);
+
+      var actual = LayersSerializer.serialize(layersCollection);
+      var expected = [];
       expect(actual).toEqual(expected);
     });
   });


### PR DESCRIPTION
`layers-serializer` should ignore layers that are not supported by Maps API (eg: layers of type `GMapsBase` instead of throwing an error that breaks the map.

**Acceptance Criteria**

1. Checkout this branch and run `grunt dev`.
2. Visit http://localhost:9001/examples/gmaps-geometry-editor.html.
3. Map should load and you shouldn't see any errors in the console.

cc: @IagoLast @Jesus89 