### PR TITLE
Remove analysis collection analysis poller pr0

### DIFF
--- a/src/analysis/analysis-service.js
+++ b/src/analysis/analysis-service.js
@@ -94,11 +94,35 @@ AnalysisService.prototype._removeAnalsyisFromIndex = function (analysis) {
 
 /**
  * Return a list with all the analyses contained in the given collections.
+ * 
+ * @example
+ * We have the following analyses:  (a0->a1->a2), (b0->a2)
+ * This method will give us: (a0->a1->a2), (b0->a2)
  */
 AnalysisService.getAnalysisList = function (layersCollection, dataviewsCollection) {
   var layerAnalyses = _getAnalysesFromLayers(layersCollection);
   var dataviewsAnalyses = _getAnalysesFromDataviews(dataviewsCollection);
   return layerAnalyses.concat(dataviewsAnalyses);
+};
+
+/**
+ * Return all the analysis nodes without duplicates.
+ * The analyses are obtained from the layers and dataviews collections.
+ * 
+ * @example
+ * We have the following analyses:  (a0->a1->a2), (b0->a2)
+ * This method will give us: (a0->a1->a1), (a1->a2), (a2), (b0->a2)
+ */
+AnalysisService.getUniqueAnalysesNodes = function (layersCollection, dataviewsCollection) {
+  var uniqueAnalyses = {};
+  var analyses = AnalysisService.getAnalysisList(layersCollection, dataviewsCollection);
+  _.each(analyses, function (analisis) {
+    _.each(analisis.getNodes(), function (analysisNode) {
+      uniqueAnalyses[analysisNode.get('id')] = analysisNode;
+    }, this);
+  }, this);
+
+  return _.map(uniqueAnalyses, function (analisis) { return analisis; }, this);
 };
 
 function _getAnalysesFromLayers (layersCollection) {

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -437,29 +437,8 @@ var VisModel = Backbone.Model.extend({
     return this.get('loading');
   },
 
-  /**
- * Return all the analysis nodes without duplicates.
- * The analyses are obtained from the layers and dataviews collections.
- * 
- * @example
- * We have the following analyses:  (a0->a1->a2), (b0->a2)
- * This method will give us: (a0->a1->a1), (a1->a2), (a2), (b0->a2)
- * 
- * Note that although a2 is included in a1 is also returned.
- * 
- * TOOD: this method is replicated in both model-updater and visModel. 
- * Move it to the analysisService?
- */
   _getUniqueAnalysesNodes: function () {
-    var uniqueAnalyses = {};
-    var analyses = AnalysisService.getAnalysisList(this._layersCollection, this._dataviewsCollection);
-    _.each(analyses, function (analisis) {
-      _.each(analisis.getNodes(), function (analysisNode) {
-        uniqueAnalyses[analysisNode.get('id')] = analysisNode;
-      }, this);
-    }, this);
-
-    return _.map(uniqueAnalyses, function (analisis) { return analisis; }, this);
+    return AnalysisService.getUniqueAnalysesNodes(this._layersCollection, this._dataviewsCollection);
   }
 });
 

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -264,7 +264,7 @@ var VisModel = Backbone.Model.extend({
   },
 
   _getAnalysisNodeModels: function () {
-    return this._analysisCollection.models;
+    return this._getUniqueAnalysesNodes();
   },
 
   /**
@@ -435,6 +435,31 @@ var VisModel = Backbone.Model.extend({
 
   isLoading: function () {
     return this.get('loading');
+  },
+
+  /**
+ * Return all the analysis nodes without duplicates.
+ * The analyses are obtained from the layers and dataviews collections.
+ * 
+ * @example
+ * We have the following analyses:  (a0->a1->a2), (b0->a2)
+ * This method will give us: (a0->a1->a1), (a1->a2), (a2), (b0->a2)
+ * 
+ * Note that although a2 is included in a1 is also returned.
+ * 
+ * TOOD: this method is replicated in both model-updater and visModel. 
+ * Move it to the analysisService?
+ */
+  _getUniqueAnalysesNodes: function () {
+    var uniqueAnalyses = {};
+    var analyses = AnalysisService.getAnalysisList(this._layersCollection, this._dataviewsCollection);
+    _.each(analyses, function (analisis) {
+      _.each(analisis.getNodes(), function (analysisNode) {
+        uniqueAnalyses[analysisNode.get('id')] = analysisNode;
+      }, this);
+    }, this);
+
+    return _.map(uniqueAnalyses, function (analisis) { return analisis; }, this);
   }
 });
 

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -264,7 +264,7 @@ var VisModel = Backbone.Model.extend({
   },
 
   _getAnalysisNodeModels: function () {
-    return this._getUniqueAnalysesNodes();
+    return AnalysisService.getUniqueAnalysesNodes(this._layersCollection, this._dataviewsCollection);
   },
 
   /**
@@ -435,10 +435,6 @@ var VisModel = Backbone.Model.extend({
 
   isLoading: function () {
     return this.get('loading');
-  },
-
-  _getUniqueAnalysesNodes: function () {
-    return AnalysisService.getUniqueAnalysesNodes(this._layersCollection, this._dataviewsCollection);
   }
 });
 

--- a/src/windshaft-integration/model-updater.js
+++ b/src/windshaft-integration/model-updater.js
@@ -269,26 +269,8 @@ ModelUpdater.prototype._getLayerLegends = function (layerModel) {
   ];
 };
 
-/**
- * Return all the analysis nodes without duplicates.
- * The analyses are obtained from the layers and dataviews collections.
- * 
- * @example
- * We have the following analyses:  (a0->a1->a2), (b0->a2)
- * This method will give us: (a0->a1->a1), (a1->a2), (a2), (b0->a2)
- * 
- * Note that although a2 is included in a1 is also returned.
- */
 ModelUpdater.prototype._getUniqueAnalysesNodes = function () {
-  var uniqueAnalyses = {};
-  var analyses = AnalysisService.getAnalysisList(this._layersCollection, this._dataviewsCollection);
-  _.each(analyses, function (analisis) {
-    _.each(analisis.getNodes(), function (analysisNode) {
-      uniqueAnalyses[analysisNode.get('id')] = analysisNode;
-    }, this);
-  }, this);
-
-  return _.map(uniqueAnalyses, function (analisis) { return analisis; }, this);
+  return AnalysisService.getUniqueAnalysesNodes(this._layersCollection, this._dataviewsCollection);
 };
 
 module.exports = ModelUpdater;


### PR DESCRIPTION
* Do not use analysisCollection when reseting models in the analysisPoller (extract sources from layers and dataviews instead).

* Remove code-duplication, move getUniqueNodes to the AnalysisService