### PR TITLE
1798 fix gmaps tests pr0

### DIFF
--- a/src/geo/gmaps/gmaps-cartodb-layer-group-view.js
+++ b/src/geo/gmaps/gmaps-cartodb-layer-group-view.js
@@ -29,7 +29,7 @@ var GMapsCartoDBLayerGroupView = function (layerModel, gmapsMap) {
   _.bindAll(this, 'featureOut', 'featureOver', 'featureClick');
 
   var opts = _.clone(layerModel.attributes);
-
+  this._gmap = gmapsMap;
   opts.map = gmapsMap;
 
   var _featureOver = opts.featureOver;
@@ -85,7 +85,6 @@ var GMapsCartoDBLayerGroupView = function (layerModel, gmapsMap) {
   // TODO: remove wax.connector here
   _.extend(this.options, opts);
   GMapsLayerView.call(this, layerModel, gmapsMap);
-  this.projector = new Projector(opts.map);
   CartoDBLayerGroupViewBase.call(this, layerModel, gmapsMap);
 };
 
@@ -313,7 +312,8 @@ _.extend(
 
     _manageOnEvents: function (map, o) {
       var point = this._findPos(map, o);
-      var latlng = this.projector.pixelToLatLng(point);
+      console.log(this._gmap.getProjection());
+      var latlng = Projector.pixelToLatLng(this._gmap.getProjection(), point);
       var eventType = o.e.type.toLowerCase();
 
       switch (eventType) {

--- a/src/geo/gmaps/gmaps-cartodb-layer-group-view.js
+++ b/src/geo/gmaps/gmaps-cartodb-layer-group-view.js
@@ -312,7 +312,6 @@ _.extend(
 
     _manageOnEvents: function (map, o) {
       var point = this._findPos(map, o);
-      console.log(this._gmap.getProjection());
       var latlng = Projector.pixelToLatLng(this._gmap.getProjection(), point);
       var eventType = o.e.type.toLowerCase();
 

--- a/src/geo/gmaps/gmaps-map-view.js
+++ b/src/geo/gmaps/gmaps-map-view.js
@@ -80,10 +80,15 @@ var GoogleMapsMapView = MapView.extend({
     MapView.prototype.clean.call(this);
   },
 
-  listenOnce: function (name, callback) {
-    google.maps.event.addListenerOnce(this._gmapsMap, name, function (event) {
-      callback(event);
-    });
+  /**
+   * Pass a function to be executed once the map is ready.
+   */
+  onReady: function (callback) {
+    if (this._isReady) {
+      callback();
+    } else {
+      google.maps.event.addListenerOnce(this._gmapsMap, 'idle', callback);
+    }
   },
 
   _getLayerViewFactory: function () {

--- a/src/geo/gmaps/gmaps-map-view.js
+++ b/src/geo/gmaps/gmaps-map-view.js
@@ -71,8 +71,6 @@ var GoogleMapsMapView = MapView.extend({
     google.maps.event.addListenerOnce(this._gmapsMap, 'idle', function (e) {
       this._isReady = true;
     });
-
-    this.projector = new Projector(this._gmapsMap);
   },
 
   clean: function () {
@@ -155,7 +153,7 @@ var GoogleMapsMapView = MapView.extend({
         [ne.lat(), ne.lng()]
       ];
     }
-    return [ [0, 0], [0, 0] ];
+    return [[0, 0], [0, 0]];
   },
 
   setCursor: function (cursor) {
@@ -194,7 +192,7 @@ var GoogleMapsMapView = MapView.extend({
   },
 
   latLngToContainerPoint: function (latlng) {
-    var point = this.projector.latLngToPixel(new google.maps.LatLng(latlng[0], latlng[1]));
+    var point = Projector.latLngToPixel(this._gmapsMap.getProjection(), new google.maps.LatLng(latlng[0], latlng[1]));
     return {
       x: point.x,
       y: point.y
@@ -202,7 +200,7 @@ var GoogleMapsMapView = MapView.extend({
   },
 
   containerPointToLatLng: function (point) {
-    var latlng = this.projector.pixelToLatLng(new google.maps.Point(point.x, point.y));
+    var latlng = Projector.pixelToLatLng(this._gmapsMap.getProjection(), new google.maps.Point(point.x, point.y));
     return {
       lat: latlng.lat(),
       lng: latlng.lng()

--- a/src/geo/gmaps/projector.js
+++ b/src/geo/gmaps/projector.js
@@ -1,27 +1,20 @@
-/* global google */
-// helper to get pixel position from latlon
-
-function Projector (map) {
-  this.setMap(map);
+/**
+ * Transform a geographic point (lat,lon) into a pixel coordinates (x,y)
+ * using the given [projection](https://developers.google.com/maps/documentation/javascript/3.exp/reference#Projection)
+ */
+function latLngToPixel (projection, latlng) {
+  return projection.fromLatLngToPoint(latlng);
 }
-Projector.prototype = new google.maps.OverlayView();
-Projector.prototype.draw = function () {};
-Projector.prototype.latLngToPixel = function (latlng) {
-  var projection = this.getProjection();
-  if (projection) {
-    return projection.fromLatLngToContainerPixel(latlng);
-  }
-  console.warn('Projector has no projection');
-  return new google.maps.Point(0, 0);
-};
 
-Projector.prototype.pixelToLatLng = function (point) {
-  var projection = this.getProjection();
-  if (projection) {
-    return projection.fromContainerPixelToLatLng(point);
-  }
-  console.warn('Projector has no projection');
-  return new google.maps.LatLng(0, 0);
-};
+/**
+ * Transform pixel coordinates (x,y) into geographic point (lat,lon)
+ * using the given [projection](https://developers.google.com/maps/documentation/javascript/3.exp/reference#Projection)
+ */
+function pixelToLatLng (projection, point) {
+  return projection.fromPointToLatLng(point);
+}
 
-module.exports = Projector;
+module.exports = {
+  latLngToPixel: latLngToPixel,
+  pixelToLatLng: pixelToLatLng
+};

--- a/src/geo/leaflet/leaflet-map-view.js
+++ b/src/geo/leaflet/leaflet-map-view.js
@@ -5,6 +5,11 @@ var MapView = require('../map-view');
 var LeafletLayerViewFactory = require('./leaflet-layer-view-factory');
 
 var LeafletMapView = MapView.extend({
+  initialize: function () {
+    this._isReady = false;
+    MapView.prototype.initialize.apply(this, arguments);
+  },
+
   _createNativeMap: function () {
     var self = this;
     var center = this.map.get('center');
@@ -72,6 +77,10 @@ var LeafletMapView = MapView.extend({
 
     this._leafletMap.on('resize', function () {
       this.map.setMapViewSize(this.getSize());
+    }, this);
+
+    this._leafletMap.on('load', function () {
+      this._isReady = true;
     }, this);
 
     this.map.bind('change:maxZoom', function () {
@@ -194,7 +203,11 @@ var LeafletMapView = MapView.extend({
     }, this);
   },
 
-  listenOnce: function (name, callback) {
+  /**
+   * Pass a function to be executed once the map is ready.
+   */
+  onReady: function (callback) {
+    console.warn('This function should only be used for testing and will be removed');
     callback();
   },
 

--- a/test/spec/geo/geometry-views/shared-tests-for-path-views.js
+++ b/test/spec/geo/geometry-views/shared-tests-for-path-views.js
@@ -162,7 +162,7 @@ module.exports = function (Path, MapView, PathView) {
       });
 
       // Listen for the map to be loaded
-      this.mapView.listenOnce('idle', function () {
+      this.mapView.onReady(function () {
         this.geometryView.render();
 
         // Marker that we'll interact with in the tests

--- a/test/spec/geo/gmaps/gmaps-map-view.spec.js
+++ b/test/spec/geo/gmaps/gmaps-map-view.spec.js
@@ -3,6 +3,7 @@ var $ = require('jquery');
 var Backbone = require('backbone');
 var Map = require('../../../../src/geo/map');
 var GoogleMapsMapView = require('../../../../src/geo/gmaps/gmaps-map-view');
+var Projector = require('../../../../src/geo/gmaps/projector');
 
 describe('geo/gmaps/gmaps-map-view', function () {
   var mapView;
@@ -64,7 +65,7 @@ describe('geo/gmaps/gmaps-map-view', function () {
 
   it('should change center and zoom when bounds are changed', function (done) {
     var spy = jasmine.createSpy('change:center');
-    mapView.getSize = function () { return {x: 200, y: 200}; };
+    mapView.getSize = function () { return { x: 200, y: 200 }; };
     map.bind('change:center', spy);
     spyOn(mapView, '_setCenter');
     mapView._bindModel();
@@ -129,17 +130,24 @@ describe('geo/gmaps/gmaps-map-view', function () {
       expect(map._latLngToPixelConverter).toBeDefined();
     });
 
-    it('should call native methods', function () {
-      spyOn(mapView.projector, 'latLngToPixel').and.callThrough();
-      spyOn(mapView.projector, 'pixelToLatLng').and.callThrough();
+    beforeEach(function () {
+      // TODO: This mocks are due a concurrency error in the tests, the map is not loaded so the Projector receives a undefined projection
+      spyOn(Projector, 'latLngToPixel').and.returnValue(new google.maps.Point(0, 0));
+      spyOn(Projector, 'pixelToLatLng').and.returnValue(new google.maps.LatLng(0, 0));
+    });
 
+    it('should delegate the pixelToLatLng to the native methods', function () {
+      expect(Projector.pixelToLatLng).not.toHaveBeenCalled();
       var pixelToLatLng = map.pixelToLatLng();
-      pixelToLatLng({x: 0, y: 0});
-      expect(mapView.projector.pixelToLatLng).toHaveBeenCalled();
+      pixelToLatLng({ x: 0, y: 0 });
+      expect(Projector.pixelToLatLng).toHaveBeenCalled();
+    });
 
+    it('should delegate the latLngToPixel to the native methods', function () {
+      expect(Projector.latLngToPixel).not.toHaveBeenCalled();
       var latLngToPixel = map.latLngToPixel();
       latLngToPixel([0, 0]);
-      expect(mapView.projector.latLngToPixel).toHaveBeenCalled();
+      expect(Projector.latLngToPixel).toHaveBeenCalled();
     });
   });
 });

--- a/test/spec/geo/shared-tests-for-cartodb-layer-group-views.js
+++ b/test/spec/geo/shared-tests-for-cartodb-layer-group-views.js
@@ -1,9 +1,12 @@
+/* global google */
+
 var _ = require('underscore');
 var $ = require('jquery');
 var CartoDBLayer = require('../../../src/geo/map/cartodb-layer.js');
 var LayersCollection = require('../../../src/geo/map/layers.js');
 var CartoDBLayerGroup = require('../../../src/geo/cartodb-layer-group.js');
 var EMPTY_GIF = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+var Projector = require('../../../src/geo/gmaps/projector');
 
 var FakeWax = require('./fake-wax');
 var fakeWax = FakeWax();
@@ -140,8 +143,10 @@ module.exports = function (createLayerGroupView, expectTileURLTemplateToMatch, f
     describe('event firing', function () {
       beforeEach(function () {
         this.nativeMap = fakeWax.map.calls.argsFor(0)[0];
-
         this.layersCollection.reset([this.cartoDBLayer1]);
+        // TODO: This mocks are due a concurrency error in the tests, the map is not loaded so the Projector receives a undefined projection
+        spyOn(Projector, 'latLngToPixel').and.returnValue(new google.maps.Point(0, 0));
+        spyOn(Projector, 'pixelToLatLng').and.returnValue(new google.maps.LatLng(0, 0));
       });
 
       it('should trigger a "featureOver" event', function () {


### PR DESCRIPTION
Updates #1798
----- 

* Refactor Projector: now just provides two pure functions to translate from points to coords and vice-versa.

* Since there are some concurrency problems, the projector is mocked in some tests.
* Since there are some concurrency problems, we need a .onReady function for the mapViews. This function can be removed once we rewrite those tests.


cc @alonsogarciapablo  @Jesus89 

