### PR TITLE
Source cannot be updated via [CartoDB|Torque].prototype.update

### DIFF
--- a/src/geo/map/cartodb-layer.js
+++ b/src/geo/map/cartodb-layer.js
@@ -136,7 +136,7 @@ var CartoDBLayer = LayerModelBase.extend({
     if (attrs.source) {
       throw new Error('Use ".setSource" to update a layer\'s source instead of the update method');
     }
-    LayerModelBase.prototype.update.call(this, attrs, { silent: onlySourceChanged });
+    LayerModelBase.prototype.update.call(this, attrs);
   },
 
   remove: function () {

--- a/src/geo/map/cartodb-layer.js
+++ b/src/geo/map/cartodb-layer.js
@@ -133,15 +133,9 @@ var CartoDBLayer = LayerModelBase.extend({
   },
 
   update: function (attrs) {
-    var onlySourceChanged = attrs.source && _.keys(attrs).length === 1;
-
     if (attrs.source) {
-      console.warn('Deprecated: Use ".setSource" to update a layer\'s source instead of the update method');
-      var source = CartoDBLayer.getLayerSourceFromAttrs(attrs, this._vis.analysis);
-      this.setSource(source, { silent: !onlySourceChanged });
-      delete attrs.source;
+      throw new Error('Use ".setSource" to update a layer\'s source instead of the update method');
     }
-
     LayerModelBase.prototype.update.call(this, attrs, { silent: onlySourceChanged });
   },
 

--- a/src/geo/map/torque-layer.js
+++ b/src/geo/map/torque-layer.js
@@ -191,13 +191,8 @@ var TorqueLayer = LayerModelBase.extend({
   },
 
   update: function (attrs) {
-    var onlySourceChanged = attrs.source && _.keys(attrs).length === 1;
-
     if (attrs.source) {
-      console.warn('Deprecated: Use ".setSource" to update a layer\'s source instead the update method');
-      var source = TorqueLayer.getLayerSourceFromAttrs(attrs, this._vis.analysis);
-      this.setSource(source, { silent: !onlySourceChanged });
-      delete attrs.source;
+      throw new Error('Use ".setSource" to update a layer\'s source instead of the update method');
     }
     LayerModelBase.prototype.update.apply(this, arguments);
   },

--- a/test/spec/geo/map/shared-for-interactive-layers.js
+++ b/test/spec/geo/map/shared-for-interactive-layers.js
@@ -44,26 +44,6 @@ module.exports = function (LayerModel) {
     expect(layer.legends.custom.get('title')).toEqual('My Custom Legend');
   });
 
-  describe('.update', function () {
-    it('should allow a string as parameter (deprecated: keep this only for prevent breaking changes in the api)', function () {
-      var newSource = fakeFactory.createAnalysisModel({ id: 'a1' });
-      vis.analysis = {
-        findNodeById: function (nodeId) {
-          if (nodeId === source.id) {
-            return source;
-          }
-          if (nodeId === newSource.id) {
-            return newSource;
-          }
-        }
-      };
-
-      layer.update({ source: 'a1' });
-
-      expect(layer.getSource()).toBe(newSource);
-    });
-  });
-
   describe('source references', function () {
     describe('when layer is initialized', function () {
       it('should mark source as referenced', function () {
@@ -79,7 +59,7 @@ module.exports = function (LayerModel) {
         expect(oldSource.isSourceOf(layer)).toBe(true);
         expect(newSource.isSourceOf(layer)).toBe(false);
 
-        layer.update({ source: newSource });
+        layer.setSource(newSource);
 
         expect(oldSource.isSourceOf(layer)).toBe(false);
         expect(newSource.isSourceOf(layer)).toBe(true);


### PR DESCRIPTION
[CartoDB|Torque].prototype.update will raise an error when given a `source` attr.

cc: @IagoLast @Jesus89 