### PR TITLE
Send bins when own_filter is set

### DIFF
--- a/src/dataviews/histogram-dataview-model.js
+++ b/src/dataviews/histogram-dataview-model.js
@@ -24,6 +24,9 @@ module.exports = DataviewModelBase.extend({
 
     if (_.isNumber(this.get('own_filter'))) {
       params.push('own_filter=' + this.get('own_filter'));
+      if (this.get('column_type') === 'number' && this.get('bins')) {
+        params.push('bins=' + this.get('bins'));
+      }
     } else {
       var offset = this._getCurrentOffset();
 

--- a/test/spec/dataviews/histogram-dataview-model.spec.js
+++ b/test/spec/dataviews/histogram-dataview-model.spec.js
@@ -483,7 +483,7 @@ describe('dataviews/histogram-dataview-model', function () {
 
         this.model.enableFilter();
 
-        expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&own_filter=1');
+        expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&own_filter=1&bins=25');
       });
     });
 


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb/issues/12945

We need to send the bins info when `own_filter` is set for histogram dataviews. If not, a change in bins can be parsed, resulting in an unwanted map instantiation and closing the zoom view in the widget.