### PR TITLE
Ensure WindshaftClient.prototype.instantiateMap passes a response to …

### DIFF
--- a/src/windshaft/client.js
+++ b/src/windshaft/client.js
@@ -47,11 +47,10 @@ WindshaftClient.prototype.instantiateMap = function (request) {
   if (this._requestTracker.canRequestBePerformed(request)) {
     this._performRequest(request, {
       success: function (response) {
+        this._requestTracker.track(request, response);
         if (response.errors) {
-          this._requestTracker.track(request, response);
           request.options.error && request.options.error(response);
         } else {
-          this._requestTracker.track(request, response);
           request.options.success && request.options.success(response);
         }
       }.bind(this),
@@ -68,7 +67,7 @@ WindshaftClient.prototype.instantiateMap = function (request) {
     });
   } else {
     log.error('Maximum number of subsequent equal requests to the Maps API reached (' + MAP_INSTANTIATION_LIMIT + '):', request.payload, request.params);
-    request.options.error && request.options.error();
+    request.options.error && request.options.error({});
   }
 };
 

--- a/src/windshaft/map-base.js
+++ b/src/windshaft/map-base.js
@@ -55,6 +55,7 @@ var WindshaftMap = Backbone.Model.extend({
       }.bind(this);
 
       options.error = function (response) {
+        response = response || {};
         var windshaftErrors = this._getErrorsFromResponse(response);
         this._modelUpdater.setErrors(windshaftErrors);
 

--- a/test/spec/windshaft/client.spec.js
+++ b/test/spec/windshaft/client.spec.js
@@ -125,20 +125,40 @@ describe('windshaft/client', function () {
       expect(errorCallback).not.toHaveBeenCalled();
     });
 
-    it('should make a request only if the request service allows it', function () {
-      spyOn(this.client._requestTracker, 'canRequestBePerformed').and.returnValue(true);
-      var request = new Request('mapDefinition', {}, {});
-      expect($.ajax).not.toHaveBeenCalled();
-      this.client.instantiateMap(request);
-      expect($.ajax).toHaveBeenCalled();
-    });
+    describe('request tracking', function () {
+      var successCallback;
+      var errorCallback;
+      var request;
 
-    it('should not make a request when the request service does not allow it', function () {
-      spyOn(this.client._requestTracker, 'canRequestBePerformed').and.returnValue(false);
-      var request = new Request('mapDefinition', {}, {});
-      expect($.ajax).not.toHaveBeenCalled();
-      this.client.instantiateMap(request);
-      expect($.ajax).not.toHaveBeenCalled();
+      beforeEach(function () {
+        successCallback = jasmine.createSpy('successCallback');
+        errorCallback = jasmine.createSpy('errorCallback');
+
+        request = new Request('mapDefinition', {}, {
+          success: successCallback,
+          error: errorCallback
+        });
+      });
+
+      it('should make a request only if the request service allows it', function () {
+        expect($.ajax).not.toHaveBeenCalled();
+
+        spyOn(this.client._requestTracker, 'canRequestBePerformed').and.returnValue(true);
+
+        this.client.instantiateMap(request);
+
+        expect($.ajax).toHaveBeenCalled();
+      });
+
+      it('should not make a request when the request service does not allow it', function () {
+        expect($.ajax).not.toHaveBeenCalled();
+
+        spyOn(this.client._requestTracker, 'canRequestBePerformed').and.returnValue(false);
+
+        this.client.instantiateMap(request);
+        expect($.ajax).not.toHaveBeenCalled();
+        expect(errorCallback).toHaveBeenCalledWith({});
+      });
     });
 
     describe('HTTP method:', function () {


### PR DESCRIPTION
Found [a bunch of errors in track.js with the message "Cannot read property 'errors_with_context' of undefined"](https://my.trackjs.com/messages/filtered?hash=4b4d7fe7931c9df0). The problem was that `WindshaftClient.prototype.instantiateMap` was invoking `request.options.error` with no parameters when the request limit was reached, and `WindshaftMap.prototype._getErrorsFromResponse` was expecting a response to be present [here](https://github.com/CartoDB/cartodb.js/blob/79329e251c0068e2828b074f4111793070225ab6/src/windshaft/map-base.js#L236-L248).

