### PR TITLE
Improve author information

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "author": {
     "name": "CARTO",
-    "url": "https://carto.com/docs/carto-engine/carto-js"
+    "url": "https://carto.com"
   },
   "contributors": [
     "Javier Álvarez <jmedina@cartodb.com>",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,8 @@
     "url": "git://github.com/CartoDB/cartodb.js.git"
   },
   "author": {
-    "name": "CartoDB",
-    "url": "http://cartodb.com/",
-    "email": "wadus@cartodb.com"
+    "name": "CARTO",
+    "url": "https://carto.com/docs/carto-engine/carto-js"
   },
   "contributors": [
     "Javier Álvarez <jmedina@cartodb.com>",


### PR DESCRIPTION
Fixes #1828

This commit adds our rebranded name and a link to our cartodb.js
docs. It also removes the contact email, since it's not compulsory
and is a 'foo' value.