### PR TITLE
fix regression for static legends

### DIFF
--- a/src/geo/map/legends/legend-model-base.js
+++ b/src/geo/map/legends/legend-model-base.js
@@ -18,9 +18,11 @@ var LegendModelBase = Backbone.Model.extend({
   initialize: function (attrs, deps) {
     if (!deps.engine) throw new Error('engine is required');
 
-    deps.engine.on(Engine.Events.RELOAD_STARTED, function () {
-      this.set('state', this.constructor.STATE_LOADING);
-    }.bind(this));
+    deps.engine.on(Engine.Events.RELOAD_STARTED, this._onEngineReloadStarted, this);
+  },
+
+  _onEngineReloadStarted: function () {
+    this.set('state', this.constructor.STATE_LOADING);
   },
 
   isLoading: function () {

--- a/src/geo/map/legends/static-legend-model-base.js
+++ b/src/geo/map/legends/static-legend-model-base.js
@@ -8,7 +8,7 @@ var StaticLegendModelBase = LegendModelBase.extend({
     });
   },
 
-  _onVisReloading: function () {},
+  _onEngineReloadStarted: function () {},
 
   isAvailable: function () { return true; }
 });

--- a/test/spec/geo/map/legends/static-legend-model.spec.js
+++ b/test/spec/geo/map/legends/static-legend-model.spec.js
@@ -3,7 +3,7 @@ var MockFactory = require('../../../../helpers/mockFactory');
 var Engine = require('../../../../../src/engine');
 var MyLegendModel = StaticLegendModelBase.extend({ TYPE: 'type' });
 
-fdescribe('src/geo/map/legends/static-legend-model-base', function () {
+describe('src/geo/map/legends/static-legend-model-base', function () {
   var engineMock;
   var legendModel;
   beforeEach(function () {

--- a/test/spec/geo/map/legends/static-legend-model.spec.js
+++ b/test/spec/geo/map/legends/static-legend-model.spec.js
@@ -1,0 +1,20 @@
+var StaticLegendModelBase = require('../../../../../src/geo/map/legends/static-legend-model-base');
+var MockFactory = require('../../../../helpers/mockFactory');
+var Engine = require('../../../../../src/engine');
+var MyLegendModel = StaticLegendModelBase.extend({ TYPE: 'type' });
+
+fdescribe('src/geo/map/legends/static-legend-model-base', function () {
+  var engineMock;
+  var legendModel;
+  beforeEach(function () {
+    engineMock = MockFactory.createEngine();
+    legendModel = new MyLegendModel({}, { engine: engineMock });
+  });
+
+  it('should never change state to "loading" when vis is reloading', function () {
+    legendModel.set('state', 'something');
+    expect(legendModel.isLoading()).toBeFalsy();
+    engineMock._eventEmmitter.trigger(Engine.Events.RELOAD_STARTED);
+    expect(legendModel.isLoading()).toBeFalsy();
+  });
+});


### PR DESCRIPTION
This PR fixes a regression introduced recently that breaks static legends (custom, torque, custom-choropleth...etc)

Static legends never go into 'loading' state, this was prevented before with a base class that overrode the handler for vis:reload. Because there were no tests, it went unnoticed with the recent refactor.

I added a small spec just to be safe in the future 🤞 