### PR TITLE
1869 error handling

### DIFF
--- a/examples/v4/_style.css
+++ b/examples/v4/_style.css
@@ -1,0 +1,43 @@
+/* This file contains common styles used by all the v4 examples in order to keep a common look and feel */
+
+html, body {
+    margin: 0;
+    padding: 0;
+}
+
+#map {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+hr {
+    margin: 15px auto;
+}
+
+aside {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    z-index: 999;
+    background: white;
+    padding: 30px;
+    overflow: hidden;
+    max-height: 500px;
+    overflow: scroll;
+}
+
+aside button {
+    padding: 8px 10px;
+    background: none;
+    border: 1px solid #333;
+}
+
+aside pre {
+    position: relative;
+    font-size: 12px;
+    max-height: 200px;
+    overflow: scroll;
+}

--- a/examples/v4/basic.html
+++ b/examples/v4/basic.html
@@ -28,7 +28,6 @@
       // Create the Client
       var client = window.client = new carto.Client({
         apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',
-        serverUrl: 'https://{user}.carto.com:443',
         username: 'cartojs-test'
       });
 

--- a/examples/v4/basic.html
+++ b/examples/v4/basic.html
@@ -12,15 +12,8 @@
   <!-- <link rel="stylesheet" href="../../dist/themes/css/cartodb.css" /> -->
   <!-- Include cartodb.js Library -->
   <script src="../../dist/cartodb.uncompressed.js"></script>
-  <style>
-    #map {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-    }
-  </style>
+  <link rel="stylesheet" href="./_style.css">
+  <style></style>
 </head>
 
 <body>

--- a/examples/v4/bounding-box-filter.html
+++ b/examples/v4/bounding-box-filter.html
@@ -47,7 +47,6 @@
       // Create the Client
       var client = new carto.Client({
         apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',
-        serverUrl: 'https://{user}.carto.com:443',
         username: 'cartojs-test'
       });
 

--- a/examples/v4/bounding-box-filter.html
+++ b/examples/v4/bounding-box-filter.html
@@ -12,14 +12,8 @@
   <link rel="stylesheet" href="../../dist/themes/css/cartodb.css" />
   <!-- Include cartodb.js Library -->
   <script src="../../dist/cartodb.uncompressed.js"></script>
+  <link rel="stylesheet" href="./_style.css">
   <style>
-    #map {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-    }
     #widgetC {
       position: absolute;
       top: 80px;

--- a/examples/v4/category-dataview.html
+++ b/examples/v4/category-dataview.html
@@ -35,15 +35,10 @@
       L.tileLayer('https://cartodb-basemaps-{s}.global.ssl.fastly.net/rastertiles/voyager_nolabels/{z}/{x}/{y}.png').addTo(map);
 
       // Create the Client
-      // var client = new carto.Client({
-      //   apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',
-      //   serverUrl: 'https://{user}.carto.com:443',
-      //   username: 'cartojs-test'
-      // });
 
       var client = new carto.Client({
         apiKey: '4bf183ec5867bd5f9eb59d4d33693fa4fb4283bf',
-        serverUrl: 'http://{user}.localhost.lan:8181',
+        serverUrl: 'http://cdb.localhost.lan:8181',
         username: 'cdb'
       });
 

--- a/examples/v4/category-dataview.html
+++ b/examples/v4/category-dataview.html
@@ -12,14 +12,8 @@
   <link rel="stylesheet" href="../../dist/themes/css/cartodb.css" />
   <!-- Include cartodb.js Library -->
   <script src="../../dist/cartodb.uncompressed.js"></script>
+  <link rel="stylesheet" href="./_style.css">
   <style>
-    #map {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-    }
     #widget {
       position: absolute;
       top: 0;

--- a/examples/v4/errors.html
+++ b/examples/v4/errors.html
@@ -36,7 +36,6 @@
 // Create the Client
 var client = window.client = new carto.Client({
     apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',
-    serverUrl: 'https://cartojs-test.carto.com',
     username: 'cartojs-test'
 });
 
@@ -78,7 +77,6 @@ document.querySelector('#addLayerBtn').addEventListener('click', () => {
             // Create the Client
             var client = window.client = new carto.Client({
                 apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',
-                serverUrl: 'https://cartojs-test.carto.com',
                 username: 'cartojs-test'
             });
 

--- a/examples/v4/errors.html
+++ b/examples/v4/errors.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Basic Carto.js example</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet.js"></script>
+    <!--Include carto styles  -->
+    <!-- <link rel="stylesheet" href="../../dist/themes/css/cartodb.css" /> -->
+    <!-- Include cartodb.js Library -->
+    <script src="../../dist/cartodb.uncompressed.js"></script>
+    <style>
+        #map {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="map"></div>
+    <script>
+        (async () => {
+            var i = 0; // Number of reload cycles.
+            var map = window.map = L.map('map').setView([42.431234, -8.643616], 5);
+
+            L.tileLayer('https://cartodb-basemaps-{s}.global.ssl.fastly.net/rastertiles/voyager_nolabels/{z}/{x}/{y}.png').addTo(map);
+
+            // Create the Client
+            var client = window.client = new carto.Client({
+                apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',
+                username: 'cartojs-test'
+            });
+
+            client.on(carto.events.SUCCESS, function () {
+                console.log('Client reloaded', i++);
+            });
+
+            client.on(carto.events.ERROR, function () {
+                console.error('Client Error!', i++);
+            });
+
+            // Create a source
+            var populatedPlacesDataset = new carto.source.Dataset('ne_10m_populated_places_simple');
+
+            // Create a style
+            var populatedPlacesStyle = new carto.style.CartoCSS(`
+                #layer {
+                  marker-width: 10;
+                  marker-fill: #CDCDCD;
+                }`);
+
+
+            var populatedPlaces = new carto.layer.Layer(populatedPlacesDataset, populatedPlacesStyle);
+
+            client.addLayer(populatedPlaces);
+
+            // Add the layer to the map
+            client.getLeafletLayer().addTo(map);
+        })();
+    </script>
+</body>
+
+</html>

--- a/examples/v4/errors.html
+++ b/examples/v4/errors.html
@@ -12,19 +12,62 @@
     <!-- <link rel="stylesheet" href="../../dist/themes/css/cartodb.css" /> -->
     <!-- Include cartodb.js Library -->
     <script src="../../dist/cartodb.uncompressed.js"></script>
-    <style>
-        #map {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-        }
-    </style>
+    <!-- common styles for the examples -->
+    <link rel="stylesheet" href="./_style.css">
+    <!-- Syntax highlighting library -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.8.4/prism.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.8.4/themes/prism.css" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.8.4/components/prism-javascript.js"></script>
+
+
 </head>
 
 <body>
     <div id="map"></div>
+    <aside>
+        <h1>Error handling</h1>
+        <p>This example shows how to handle map related erros.
+            <br> Click the button to add a layer poiting to a inexistent data source and generate a reload-error.
+        </p>
+        <button id="addLayerBtn">Add malformed layer</button>
+        <hr>
+        <p>The following code shows how to handle a .addLayer error.</p>
+        <pre><code class="language-javascript">
+// Create the Client
+var client = window.client = new carto.Client({
+    apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',
+    serverUrl: 'https://cartojs-test.carto.com',
+    username: 'cartojs-test'
+});
+
+// Listen to all client errors
+client.on(carto.events.ERROR, function (clientError) {
+    console.error(clientError.message);
+});
+
+// Create a source pointing to a inexistent dataset.
+var populatedPlacesDataset = new carto.source.SQL('SELECT * FROM inexistent_relation');
+
+// Create a style
+var populatedPlacesStyle = new carto.style.CartoCSS(`
+    #layer {
+        marker-width: 10;
+        marker-fill: red;
+    }`);
+
+// Create the layer
+var populatedPlaces = new carto.layer.Layer(populatedPlacesDataset, populatedPlacesStyle);
+
+// Add the layer to the map
+client.getLeafletLayer().addTo(map);
+
+// When clicking in the button add the populatedPlacesLayer
+document.querySelector('#addLayerBtn').addEventListener('click', () => {
+    client.addLayer(populatedPlaces)
+        .catch(clientError => { alert(clientError.message) });
+});
+        </code></pre>
+    </aside>
     <script>
         (async () => {
             var i = 0; // Number of reload cycles.
@@ -39,34 +82,32 @@
                 username: 'cartojs-test'
             });
 
-            client.on(carto.events.SUCCESS, function () {
-                console.log('Client reloaded', i++);
-            });
-
+            // Listen to all client errors
             client.on(carto.events.ERROR, function (clientError) {
-                console.error('Client Error generico');
+                console.error(clientError.message);
             });
 
-            // Create a source
-            var populatedPlacesDataset = new carto.source.SQL('SELECT FROM ne_10m_populated_places_simple');
+            // Create a source pointing to a inexistent dataset.
+            var populatedPlacesDataset = new carto.source.SQL('SELECT * FROM inexistent_relation');
 
             // Create a style
             var populatedPlacesStyle = new carto.style.CartoCSS(`
                 #layer {
                   marker-width: 10;
-                  marker-fill: #CDCDCD;
+                  marker-fill: red;
                 }`);
 
-
+            // Create the layer
             var populatedPlaces = new carto.layer.Layer(populatedPlacesDataset, populatedPlacesStyle);
-            
-            client.addLayer(populatedPlaces).catch(function(clientError) {
-                console.error(clientError);
-            });
-
 
             // Add the layer to the map
             client.getLeafletLayer().addTo(map);
+
+            // When clicking in the button add the populatedPlacesLayer
+            document.querySelector('#addLayerBtn').addEventListener('click', () => {
+                client.addLayer(populatedPlaces)
+                    .catch(clientError => { alert(clientError.message) });
+            });
         })();
     </script>
 </body>

--- a/examples/v4/errors.html
+++ b/examples/v4/errors.html
@@ -35,6 +35,7 @@
             // Create the Client
             var client = window.client = new carto.Client({
                 apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',
+                serverUrl: 'https://cartojs-test.carto.com',
                 username: 'cartojs-test'
             });
 
@@ -42,12 +43,12 @@
                 console.log('Client reloaded', i++);
             });
 
-            client.on(carto.events.ERROR, function () {
-                console.error('Client Error!', i++);
+            client.on(carto.events.ERROR, function (clientError) {
+                console.error('Client Error generico');
             });
 
             // Create a source
-            var populatedPlacesDataset = new carto.source.Dataset('ne_10m_populated_places_simple');
+            var populatedPlacesDataset = new carto.source.SQL('SELECT FROM ne_10m_populated_places_simple');
 
             // Create a style
             var populatedPlacesStyle = new carto.style.CartoCSS(`
@@ -58,8 +59,11 @@
 
 
             var populatedPlaces = new carto.layer.Layer(populatedPlacesDataset, populatedPlacesStyle);
+            
+            client.addLayer(populatedPlaces).catch(function(clientError) {
+                console.error(clientError);
+            });
 
-            client.addLayer(populatedPlaces);
 
             // Add the layer to the map
             client.getLeafletLayer().addTo(map);

--- a/examples/v4/formula-dataview.html
+++ b/examples/v4/formula-dataview.html
@@ -12,14 +12,8 @@
   <link rel="stylesheet" href="../../dist/themes/css/cartodb.css" />
   <!-- Include cartodb.js Library -->
   <script src="../../dist/cartodb.uncompressed.js"></script>
+  <link rel="stylesheet" href="./_style.css">
   <style>
-    #map {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-    }
     #widget {
       position: absolute;
       top: 0;

--- a/examples/v4/formula-dataview.html
+++ b/examples/v4/formula-dataview.html
@@ -37,7 +37,6 @@
       // Create the Client
       var client = new carto.Client({
         apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',
-        serverUrl: 'https://{user}.carto.com:443',
         username: 'cartojs-test'
       });
 

--- a/examples/v4/interactivity.html
+++ b/examples/v4/interactivity.html
@@ -12,15 +12,7 @@
   <!-- <link rel="stylesheet" href="../../dist/themes/css/cartodb.css" /> -->
   <!-- Include cartodb.js Library -->
   <script src="../../dist/cartodb.uncompressed.js"></script>
-  <style>
-    #map {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-    }
-  </style>
+  <link rel="stylesheet" href="./_style.css">
 </head>
 
 <body>

--- a/examples/v4/interactivity.html
+++ b/examples/v4/interactivity.html
@@ -29,7 +29,6 @@
       // Create the Client
       var client = window.client = new carto.Client({
         apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',
-        serverUrl: 'https://{user}.carto.com:443',
         username: 'cartojs-test'
       });
 

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var Events = require('./events');
 var Engine = require('../../engine');
 var Layers = require('./layers');
@@ -24,12 +25,13 @@ var LayerBase = require('./layer/base');
  * @fires carto.events.ERROR
  */
 function Client (settings) {
+  _checkSettings(settings);
   this._layers = new Layers();
   this._dataviews = [];
   this._engine = new Engine({
     apiKey: settings.apiKey,
     username: settings.username,
-    serverUrl: settings.serverUrl,
+    serverUrl: settings.serverUrl || 'https://{user}.carto.com'.replace(/{user}/, settings.username),
     statTag: 'carto.js-v' + VERSION
   });
 }
@@ -226,6 +228,42 @@ Client.prototype._addDataview = function (dataview, engine) {
 function _checkLayer (object) {
   if (!(object instanceof LayerBase)) {
     throw new TypeError('The given object is not a layer');
+  }
+}
+
+function _checkSettings (settings) {
+  _checkApiKey(settings.apiKey);
+  _checkUsername(settings.username);
+  if (settings.serverUrl) {
+    _checkServerUrl(settings.serverUrl, settings.username);
+  }
+}
+
+function _checkApiKey (apiKey) {
+  if (!apiKey) {
+    throw new TypeError('apiKey property is required.');
+  }
+  if (!_.isString(apiKey)) {
+    throw new TypeError('apiKey property must be a string.');
+  }
+}
+
+function _checkUsername (username) {
+  if (!username) {
+    throw new TypeError('username property is required.');
+  }
+  if (!_.isString(username)) {
+    throw new TypeError('username property must be a string.');
+  }
+}
+
+function _checkServerUrl (serverUrl, username) {
+  var urlregex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/;
+  if (!serverUrl.match(urlregex)) {
+    throw new TypeError('serverUrl is not a valid URL.');
+  }
+  if (serverUrl.indexOf(username) < 0) {
+    throw new TypeError('serverUrl doesn\'t match the username.');
   }
 }
 

--- a/src/api/v4/error.js
+++ b/src/api/v4/error.js
@@ -1,0 +1,59 @@
+/**
+ * Build a cartoError from a generic error
+ * @constructor
+ * 
+ * @return {CartoError} A well formed object representing the error.
+ */
+function CartoError (error) {
+  if (!error) {
+    this.message = 'unexpected error';
+    return this;
+  }
+  if (_isWindshaftError(error)) {
+    this.message = error.errors[0];
+    return this;
+  }
+  if (error.message) {
+    this.message = error.message;
+    return this;
+  }
+  this.message = 'unexpected error';
+}
+
+function _isWindshaftError (error) {
+  return error && error.errors_with_context;
+}
+
+module.exports = CartoError;
+
+/**
+ * 
+ * Represents an error in the carto library.
+ * 
+ * Some actions like adding a layer to a map will trigger a **reload cycle**
+ * if some error happens during this reload cycle will be captured and transformed into a 
+ * `CartoError`.
+ * 
+ * The cartoErrors can be obtained listening to the client {@link carto.events|error events} `client.on(carto.events.ERROR, callback);` 
+ * or through the promise returned by each async action.
+ * 
+ * @example
+ * // Listen when a layer has been added or there has been an error.
+ * client.addLayer(layerWithErrors)
+ *  .then(()=> console.log('Layer added succesfully'))
+ *  .catch(cartoError => console.error(cartoError.message))
+ * 
+ * @example 
+ * // Events also will be registered here when the map changes.
+ * client.on(carto.events.SUCCESS, function () {
+ *  console.log('Client reloaded');
+ * });
+ * 
+ * client.on(carto.events.ERROR, function (clientError) {
+ *  console.error(clientError.message);
+ * });
+ * 
+ * @typedef CartoError
+ * @property {string} message - A short error description.
+ * @api
+ */

--- a/src/api/v4/error.js
+++ b/src/api/v4/error.js
@@ -5,15 +5,11 @@
  * @return {CartoError} A well formed object representing the error.
  */
 function CartoError (error) {
-  if (!error) {
-    this.message = 'unexpected error';
-    return this;
-  }
   if (_isWindshaftError(error)) {
     this.message = error.errors[0];
     return this;
   }
-  if (error.message) {
+  if (error && error.message) {
     this.message = error.message;
     return this;
   }

--- a/src/api/v4/events.js
+++ b/src/api/v4/events.js
@@ -1,25 +1,28 @@
 /**
- * Enum for event names.
- *
- * @enum {string} carto.events
- * @readonly
- * @memberof carto
+ * @namespace carto.events
  * @api
  */
-var events = {
-  /**
-   * Reload started event, fired every time the reload process is completed succesfully.
-   *
-   * @api
-   */
-  SUCCESS: 'success',
 
-  /**
-   * Reload started event, fired every time the reload process has some error.
-   *
-   * @api
-   */
-  ERROR: 'error'
+/**
+  * @constant {string} SUCCESS
+  * @description
+  * Reload started event, fired every time the reload process is completed succesfully.
+  * @memberof carto.events
+  * @api
+  */
+var SUCCESS = 'success';
+
+/**
+ * @constant {string} ERROR
+ * @description 
+ * Reload started event, fired every time the reload process has some error.
+ * 
+ * @memberof carto.events
+ * @api
+ */
+var ERROR = 'error';
+
+module.exports = {
+  SUCCESS: SUCCESS,
+  ERROR: ERROR
 };
-
-module.exports = events;

--- a/src/api/v4/source/dataset.js
+++ b/src/api/v4/source/dataset.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var Base = require('./base');
 var AnalysisModel = require('../../../analysis/analysis-model');
 var CamshaftReference = require('../../../analysis/camshaft-reference');
@@ -18,6 +19,7 @@ var CamshaftReference = require('../../../analysis/camshaft-reference');
  *
  */
 function Dataset (dataset) {
+  _checkDataset(dataset);
   this._dataset = dataset;
   Base.apply(this, arguments);
 }
@@ -40,5 +42,15 @@ Dataset.prototype._createInternalModel = function (engine) {
     engine: engine
   });
 };
+
+function _checkDataset (dataset) {
+  if (!dataset) {
+    throw new TypeError('dataset is required.');
+  }
+
+  if (!_.isString(dataset)) {
+    throw new Error('dataset must be a string.');
+  }
+}
 
 module.exports = Dataset;

--- a/src/api/v4/source/sql.js
+++ b/src/api/v4/source/sql.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var Base = require('./base');
 var AnalysisModel = require('../../../analysis/analysis-model');
 var CamshaftReference = require('../../../analysis/camshaft-reference');
@@ -18,6 +19,7 @@ var CamshaftReference = require('../../../analysis/camshaft-reference');
  *
  */
 function SQL (query) {
+  _checkQuery(query);
   this._query = query;
   Base.apply(this, arguments);
 }
@@ -30,6 +32,7 @@ SQL.prototype = Object.create(Base.prototype);
  * @param {string} query - The sql query that will be the source of the data. 
  */
 SQL.prototype.setQuery = function (query) {
+  _checkQuery(query);
   this._query = query;
   if (this._internalModel) {
     this._internalModel.set('query', query);
@@ -61,4 +64,13 @@ SQL.prototype._createInternalModel = function (engine) {
   });
 };
 
+function _checkQuery (query) {
+  if (!query) {
+    throw new TypeError('query is required.');
+  }
+
+  if (!_.isString(query)) {
+    throw new Error('query must be a string.');
+  }
+}
 module.exports = SQL;

--- a/src/api/v4/style/cartocss.js
+++ b/src/api/v4/style/cartocss.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var Base = require('./base');
 
 /**
@@ -18,14 +19,25 @@ var Base = require('./base');
  * @api
  *
  */
-function CartoCSS (cartocss) {
-  this.cartocss = cartocss;
+function CartoCSS (cartoCSS) {
+  _checkCartoCSS(cartoCSS);
+  this._cartoCSS = cartoCSS;
 }
 
 CartoCSS.prototype = Object.create(Base.prototype);
 
 CartoCSS.prototype.toCartoCSS = function () {
-  return this.cartocss;
+  return this._cartoCSS;
 };
+
+function _checkCartoCSS (cartoCSS) {
+  if (!cartoCSS) {
+    throw new TypeError('cartoCSS is required.');
+  }
+
+  if (!_.isString(cartoCSS)) {
+    throw new Error('cartoCSS must be a string.');
+  }
+}
 
 module.exports = CartoCSS;

--- a/test/spec/api/v4/client.spec.js
+++ b/test/spec/api/v4/client.spec.js
@@ -123,7 +123,7 @@ fdescribe('api/v4/client', function () {
       spyOn(client._engine, 'reload').and.returnValue(Promise.reject(errorMock));
 
       client.addLayer(layer).catch(function (error) {
-        expect(error).toEqual(errorMock);
+        expect(error.message).toEqual(errorMock.message);
         done();
       });
     });

--- a/test/spec/api/v4/client.spec.js
+++ b/test/spec/api/v4/client.spec.js
@@ -1,7 +1,7 @@
 var carto = require('../../../../src/api/v4');
 var LeafletLayerGroup = require('../../../../src/api/v4/leaflet/layer-group');
 
-fdescribe('api/v4/client', function () {
+describe('api/v4/client', function () {
   var client;
 
   beforeEach(function () {

--- a/test/spec/api/v4/client.spec.js
+++ b/test/spec/api/v4/client.spec.js
@@ -1,13 +1,13 @@
 var carto = require('../../../../src/api/v4');
 var LeafletLayerGroup = require('../../../../src/api/v4/leaflet/layer-group');
 
-describe('api/v4/client', function () {
+fdescribe('api/v4/client', function () {
   var client;
 
   beforeEach(function () {
     client = new carto.Client({
       apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',
-      serverUrl: 'https://{user}.carto.com:443',
+      serverUrl: 'https://cartojs-test.carto.com',
       username: 'cartojs-test'
     });
   });
@@ -16,6 +16,69 @@ describe('api/v4/client', function () {
     it('should build a new client', function () {
       expect(client).toBeDefined();
       expect(client.getLayers()).toEqual([]);
+    });
+
+    it('should autogenerate the carto url when is not given', function () {
+      client = new carto.Client({
+        apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',
+        username: 'cartojs-test'
+      });
+
+      expect(client._engine._windshaftSettings.urlTemplate).toEqual('https://cartojs-test.carto.com');
+    });
+
+    describe('error handling', function () {
+      describe('apiKey', function () {
+        it('should throw a descriptive error when apikey is not given', function () {
+          expect(function () {
+            new carto.Client({ username: 'cartojs-test' }); // eslint-disable-line
+          }).toThrowError('apiKey property is required.');
+        });
+
+        it('should throw a descriptive error when apikey is not a string', function () {
+          expect(function () {
+            new carto.Client({ apiKey: 1234, username: 'cartojs-test' }); // eslint-disable-line
+          }).toThrowError('apiKey property must be a string.');
+        });
+
+        it('should throw a descriptive error when apikey is not a string', function () {
+          expect(function () {
+            new carto.Client({ apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18' }); // eslint-disable-line
+          }).toThrowError('username property is required.');
+        });
+      });
+
+      describe('username', function () {
+        it('should throw a descriptive error when username is not a string', function () {
+          expect(function () {
+            new carto.Client({ apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18', username: 1234 }); // eslint-disable-line
+          }).toThrowError('username property must be a string.');
+        });
+      });
+
+      describe('serverUrl', function () {
+        it('should throw a descriptive error when serverUrl is given and is not valid', function () {
+          expect(function () {
+            // eslint-disable-next-line
+            new carto.Client({
+              apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',
+              username: 'cartojs-test',
+              serverUrl: 'invalid-url'
+            });
+          }).toThrowError('serverUrl is not a valid URL.');
+        });
+
+        it('should throw a descriptive error when serverUrl doesn\'t match the username', function () {
+          expect(function () {
+            // eslint-disable-next-line
+            new carto.Client({
+              apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',
+              username: 'cartojs-test',
+              serverUrl: 'https://invald-username.carto.com'
+            });
+          }).toThrowError('serverUrl doesn\'t match the username.');
+        });
+      });
     });
   });
 

--- a/test/spec/api/v4/dataview/category.spec.js
+++ b/test/spec/api/v4/dataview/category.spec.js
@@ -34,7 +34,7 @@ function createInternalModelMock () {
 }
 
 function createSourceMock () {
-  return new carto.source.Dataset();
+  return new carto.source.Dataset('foo');
 }
 
 function createEngineMock () {

--- a/test/spec/api/v4/dataview/formula.spec.js
+++ b/test/spec/api/v4/dataview/formula.spec.js
@@ -22,7 +22,7 @@ function createInternalModelMock () {
 }
 
 function createSourceMock () {
-  return new carto.source.Dataset();
+  return new carto.source.Dataset('foo');
 }
 
 function createEngineMock () {

--- a/test/spec/api/v4/layer/layer.spec.js
+++ b/test/spec/api/v4/layer/layer.spec.js
@@ -77,7 +77,6 @@ describe('api/v4/layer', function () {
     it('should set the internal model style', function (done) {
       var client = new carto.Client({
         apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',
-        serverUrl: 'https://{user}.carto.com:443',
         username: 'cartojs-test'
       });
 

--- a/test/spec/api/v4/leaflet/layer-group.spec.js
+++ b/test/spec/api/v4/leaflet/layer-group.spec.js
@@ -15,7 +15,6 @@ describe('src/api/v4/leaflet/layer-group', function () {
 
     client = new carto.Client({
       apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',
-      serverUrl: 'https://{user}.carto.com:443',
       username: 'cartojs-test'
     });
     map = L.map('map').setView([42.431234, -8.643616], 5);

--- a/test/spec/api/v4/source/dataset.spec.js
+++ b/test/spec/api/v4/source/dataset.spec.js
@@ -11,6 +11,24 @@ describe('api/v4/source/dataset', function () {
       var populatedPlacesDataset = new carto.source.Dataset('ne_10m_populated_places_simple');
       expect(populatedPlacesDataset.getId()).toMatch(/S\d+/);
     });
+
+    it('should throw an error if dataset is not provided', function () {
+      expect(function () {
+        new carto.source.Dataset(); // eslint-disable-line
+      }).toThrowError('dataset is required.');
+    });
+
+    it('should throw an error if dataset is empty', function () {
+      expect(function () {
+        new carto.source.Dataset(''); // eslint-disable-line
+      }).toThrowError('dataset is required.');
+    });
+
+    it('should throw an error if dataset is not a valid string', function () {
+      expect(function () {
+        new carto.source.Dataset(3333); // eslint-disable-line
+      }).toThrowError('dataset must be a string.');
+    });
   });
 
   describe('$setEngine', function () {

--- a/test/spec/api/v4/source/sql.spec.js
+++ b/test/spec/api/v4/source/sql.spec.js
@@ -1,26 +1,65 @@
 var carto = require('../../../../../src/api/v4');
 
 describe('api/v4/source/sql', function () {
+  var sqlQuery;
+
+  beforeEach(function () {
+    sqlQuery = new carto.source.SQL('SELECT * FROM ne_10m_populated_places_simple WHERE adm0name = \'Spain\'');
+  });
+
   describe('constructor', function () {
     it('should return a new Dataset object', function () {
-      var sqlDataset = new carto.source.SQL('SELECT * FROM ne_10m_populated_places_simple WHERE adm0name = \'Spain\'');
-      expect(sqlDataset).toBeDefined();
+      expect(sqlQuery).toBeDefined();
     });
 
-    it('should autogenerate an id when no ID is given', function () {
-      var sqlDataset = new carto.source.SQL('SELECT * FROM ne_10m_populated_places_simple WHERE adm0name = \'Spain\'');
-      expect(sqlDataset.getId()).toMatch(/S\d+/);
+    it('should autogenerate an id', function () {
+      expect(sqlQuery.getId()).toMatch(/S\d+/);
+    });
+
+    it('should throw an error if query is not provided', function () {
+      expect(function () {
+        new carto.source.SQL(); // eslint-disable-line
+      }).toThrowError('query is required.');
+    });
+
+    it('should throw an error if query is empty', function () {
+      expect(function () {
+        new carto.source.SQL(''); // eslint-disable-line
+      }).toThrowError('query is required.');
+    });
+
+    it('should throw an error if query is not a valid string', function () {
+      expect(function () {
+        new carto.source.SQL(3333); // eslint-disable-line
+      }).toThrowError('query must be a string.');
+    });
+  });
+
+  describe('.setQuery', function () {
+    it('should set the query', function () {
+      sqlQuery.setQuery('SELECT foo FROM bar');
+      expect(sqlQuery.getQuery()).toEqual('SELECT foo FROM bar');
+    });
+
+    it('should throw an error if query is empty', function () {
+      expect(function () {
+        sqlQuery.setQuery('');
+      }).toThrowError('query is required.');
+    });
+
+    it('should throw an error if query is not a valid string', function () {
+      expect(function () {
+        sqlQuery.setQuery(333);
+      }).toThrowError('query must be a string.');
     });
   });
 
   describe('$setEngine', function () {
     it('should create an internal model with the dataset attrs and the engine', function () {
-      var sqlDataset = new carto.source.SQL('SELECT * FROM ne_10m_populated_places_simple WHERE adm0name = \'Spain\'', { id: 'sql0' });
+      sqlQuery.$setEngine('fakeEngine');
 
-      sqlDataset.$setEngine('fakeEngine');
-
-      var internalModel = sqlDataset.$getInternalModel();
-      expect(internalModel.get('id')).toEqual(sqlDataset.getId());
+      var internalModel = sqlQuery.$getInternalModel();
+      expect(internalModel.get('id')).toEqual(sqlQuery.getId());
       expect(internalModel.get('query')).toEqual('SELECT * FROM ne_10m_populated_places_simple WHERE adm0name = \'Spain\'');
       expect(internalModel._engine).toEqual('fakeEngine');
     });

--- a/test/spec/api/v4/style/cartocss.spec.js
+++ b/test/spec/api/v4/style/cartocss.spec.js
@@ -1,0 +1,33 @@
+var carto = require('../../../../../src/api/v4');
+
+describe('api/v4/style/cartocss', function () {
+  var cartoCSS;
+
+  beforeEach(function () {
+    cartoCSS = new carto.style.CartoCSS('#layer { marker-with:10; }');
+  });
+
+  describe('constructor', function () {
+    it('should return an object', function () {
+      expect(cartoCSS).toBeDefined();
+    });
+
+    it('should throw an error if cartoCSS is not provided', function () {
+      expect(function () {
+        new carto.style.CartoCSS(); // eslint-disable-line
+      }).toThrowError('cartoCSS is required.');
+    });
+
+    it('should throw an error if cartoCSS is empty', function () {
+      expect(function () {
+        new carto.style.CartoCSS(''); // eslint-disable-line
+      }).toThrowError('cartoCSS is required.');
+    });
+
+    it('should throw an error if cartoCSS is not a valid string', function () {
+      expect(function () {
+        new carto.style.CartoCSS(3333); // eslint-disable-line
+      }).toThrowError('cartoCSS must be a string.');
+    });
+  });
+});


### PR DESCRIPTION
#1869
----

- Client throws cartoErrors wrapped from engine errors.
- `.addLayer` and `.addDataview` return a promise, if those promises are rejected the parameter is a CartoError
- Add an error example with a code snippet and description.
- Update carto.events doc, use a custom namespace with constants instead enum

[![https://gyazo.com/cb4c6c96d4c9f31c7e1dc87e6f2ff5dd](https://i.gyazo.com/cb4c6c96d4c9f31c7e1dc87e6f2ff5dd.gif)](https://gyazo.com/cb4c6c96d4c9f31c7e1dc87e6f2ff5dd)