### PR TITLE
Use cdn_url in the server response wrapper

### DIFF
--- a/src/windshaft/response.js
+++ b/src/windshaft/response.js
@@ -13,7 +13,7 @@ function Response (windshaftSettings, serverResponse) {
   this._layers = serverResponse.metadata.layers;
   this._dataviews = serverResponse.metadata.dataviews;
   this._analyses = serverResponse.metadata.analyses;
-  this._cdnUrl = serverResponse.metadata.cdn_url;
+  this._cdnUrl = serverResponse.cdn_url;
 }
 
 /**

--- a/test/spec/engine.spec.js
+++ b/test/spec/engine.spec.js
@@ -198,10 +198,14 @@ describe('Engine', function () {
       engineMock.on(Engine.Events.RELOAD_SUCCESS, function () {
         var urls = engineMock._cartoLayerGroup.attributes.urls;
         // Ensure the modelUpdater has updated the cartoLayerGroup urls
-        expect(urls.attributes[0]).toEqual('http://example.com/api/v1/map/2edba0a73a790c4afb83222183782123:1508164637676/0/attributes');
-        expect(urls.grids[0]).toEqual(['http://example.com/api/v1/map/2edba0a73a790c4afb83222183782123:1508164637676/0/{z}/{x}/{y}.grid.json']);
-        expect(urls.image).toEqual('http://example.com/api/v1/map/static/center/2edba0a73a790c4afb83222183782123:1508164637676/{z}/{lat}/{lng}/{width}/{height}.{format}');
-        expect(urls.tiles).toEqual('http://example.com/api/v1/map/2edba0a73a790c4afb83222183782123:1508164637676/{layerIndexes}/{z}/{x}/{y}.{format}');
+        expect(urls.attributes[0]).toEqual('http://3.ashbu.cartocdn.com/fake-username/api/v1/map/2edba0a73a790c4afb83222183782123:1508164637676/0/attributes');
+        expect(urls.grids[0]).toEqual(
+          ['http://0.ashbu.cartocdn.com/fake-username/api/v1/map/2edba0a73a790c4afb83222183782123:1508164637676/0/{z}/{x}/{y}.grid.json',
+            'http://1.ashbu.cartocdn.com/fake-username/api/v1/map/2edba0a73a790c4afb83222183782123:1508164637676/0/{z}/{x}/{y}.grid.json',
+            'http://2.ashbu.cartocdn.com/fake-username/api/v1/map/2edba0a73a790c4afb83222183782123:1508164637676/0/{z}/{x}/{y}.grid.json',
+            'http://3.ashbu.cartocdn.com/fake-username/api/v1/map/2edba0a73a790c4afb83222183782123:1508164637676/0/{z}/{x}/{y}.grid.json']);
+        expect(urls.image).toEqual('http://{s}.ashbu.cartocdn.com/fake-username/api/v1/map/static/center/2edba0a73a790c4afb83222183782123:1508164637676/{z}/{lat}/{lng}/{width}/{height}.{format}');
+        expect(urls.tiles).toEqual('http://{s}.ashbu.cartocdn.com/fake-username/api/v1/map/2edba0a73a790c4afb83222183782123:1508164637676/{layerIndexes}/{z}/{x}/{y}.{format}');
         done();
       });
 

--- a/test/spec/windshaft/response.spec.js
+++ b/test/spec/windshaft/response.spec.js
@@ -56,12 +56,11 @@ describe('windshaft-response', function () {
       };
       var serverResponse = {
         layergroupid: '0123456789',
-        metadata: {
-          cdn_url: {
-            http: 'cdn.http.example.com',
-            https: 'cdn.https.example.com'
-          }
-        }
+        cdn_url: {
+          http: 'cdn.http.example.com',
+          https: 'cdn.https.example.com'
+        },
+        metadata: {}
       };
       var response = new Response(windshaftSettings, serverResponse);
 
@@ -75,12 +74,11 @@ describe('windshaft-response', function () {
       };
       var serverResponse = {
         layergroupid: '0123456789',
-        metadata: {
-          cdn_url: {
-            http: 'cdn.http.example.com',
-            https: 'cdn.https.example.com'
-          }
-        }
+        cdn_url: {
+          http: 'cdn.http.example.com',
+          https: 'cdn.https.example.com'
+        },
+        metadata: {}
       };
       var response = new Response(windshaftSettings, serverResponse);
 
@@ -94,22 +92,21 @@ describe('windshaft-response', function () {
       };
       var serverResponse = {
         layergroupid: '0123456789',
-        metadata: {
-          cdn_url: {
-            http: 'cdn1.http.example.com',
-            https: 'cdn1.https.example.com',
-            templates: {
-              http: {
-                url: 'http://{s}.cdn2.http.example.com',
-                subdomains: ['0', '1', '2']
-              },
-              https: {
-                url: 'https://{s}.cdn2.https.example.com',
-                subdomains: ['0', '1', '2']
-              }
+        cdn_url: {
+          http: 'cdn1.http.example.com',
+          https: 'cdn1.https.example.com',
+          templates: {
+            http: {
+              url: 'http://{s}.cdn2.http.example.com',
+              subdomains: ['0', '1', '2']
+            },
+            https: {
+              url: 'https://{s}.cdn2.https.example.com',
+              subdomains: ['0', '1', '2']
             }
           }
-        }
+        },
+        metadata: {}
       };
       var response = new Response(windshaftSettings, serverResponse);
 
@@ -152,29 +149,29 @@ describe('windshaft-response', function () {
         userName: 'cartojs-test'
       };
       var serverResponse = {
-        'layergroupid': '0123456789',
-        'metadata': {
-          'layers': [
+        layergroupid: '0123456789',
+        metadata: {
+          layers: [
             {
-              'type': 'mapnik',
-              'meta': {}
+              type: 'mapnik',
+              meta: {}
             },
             {
-              'type': 'torque',
-              'meta': {}
+              type: 'torque',
+              meta: {}
             }
           ],
           dataviews: {
-            'dataviewId': {
-              'url': {
-                'http': 'http://example.com',
-                'https': 'https://example.com'
+            dataviewId: {
+              url: {
+                http: 'http://example.com',
+                https: 'https://example.com'
               }
             },
-            'dataviewId2': {
-              'url': {
-                'http': 'http://example2.com',
-                'https': 'https://example2.com'
+            dataviewId2: {
+              url: {
+                http: 'http://example2.com',
+                https: 'https://example2.com'
               }
             }
           }
@@ -344,20 +341,19 @@ describe('windshaft-response', function () {
       };
       var serverResponse = {
         layergroupid: '0123456789',
-        metadata: {
-          cdn_url: {
-            templates: {
-              http: {
-                url: 'http://cdn.carto.com',
-                subdomains: ['a', 'b']
-              },
-              https: {
-                url: 'http://cdn.carto.com',
-                subdomains: ['c', 'd']
-              }
+        cdn_url: {
+          templates: {
+            http: {
+              url: 'http://cdn.carto.com',
+              subdomains: ['a', 'b']
+            },
+            https: {
+              url: 'http://cdn.carto.com',
+              subdomains: ['c', 'd']
             }
           }
-        }
+        },
+        metadata: {}
       };
       response = new Response(windshaftSettings, serverResponse);
     });


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb-platform/issues/3709
---

The mock server response used in the unit tests was wrong so we couldn't catch this error.

This PR:

- Fixes the unit tests using a mocked server response where cdn_url is not inside the metadata object.
- Fixes the ResponseWrapper to use  `serverResponse.cdn_url` inside `serverResponse.metadata. cdn_url` 