### PR TITLE
Parse histogram dataview timestamps as UTC

### DIFF
--- a/src/dataviews/helpers/histogram-helper.js
+++ b/src/dataviews/helpers/histogram-helper.js
@@ -1,6 +1,8 @@
 var moment = require('moment');
 var _ = require('underscore');
 
+window.moment = moment;
+
 // Preserve the ascendant order!
 var MOMENT_AGGREGATIONS = {
   second: 's',
@@ -42,22 +44,20 @@ helper.isShorterThan = function (limit, aggregation) {
   return limitIndex > -1 && aggregationIndex > -1 && aggregationIndex < limitIndex;
 };
 
-helper.fillTimestampBuckets = function (buckets, start, aggregation, numberOfBins, offset, from, totalBuckets) {
-  var startOffset = helper.isShorterThan('day', aggregation) ? (offset || 0) : 0;
-  var startDate = moment.unix(start + startOffset).utc();
-  var UTCStartDate = moment.unix(start).utc();
+helper.fillTimestampBuckets = function (buckets, start, aggregation, numberOfBins, from, totalBuckets) {
+  var startDate = moment.unix(start).utc();
   var filledBuckets = []; // To catch empty buckets
+  var definedBucket = false;
 
   for (var i = 0; i < numberOfBins; i++) {
-    filledBuckets.push(buckets[i] !== void 0);
+    definedBucket = buckets[i] !== undefined;
+    filledBuckets.push(definedBucket);
 
     buckets[i] = _.extend({
       bin: i,
       start: startDate.clone().add(i, MOMENT_AGGREGATIONS[aggregation]).unix(),
       end: startDate.clone().add(i + 1, MOMENT_AGGREGATIONS[aggregation]).unix() - 1,
       next: startDate.clone().add(i + 1, MOMENT_AGGREGATIONS[aggregation]).unix(),
-      UTCStart: UTCStartDate.clone().add(i, MOMENT_AGGREGATIONS[aggregation]).unix(),
-      UTCEnd: UTCStartDate.clone().add(i + 1, MOMENT_AGGREGATIONS[aggregation]).unix() - 1,
       freq: 0
     }, buckets[i]);
     delete buckets[i].timestamp;

--- a/src/dataviews/helpers/histogram-helper.js
+++ b/src/dataviews/helpers/histogram-helper.js
@@ -1,8 +1,6 @@
 var moment = require('moment');
 var _ = require('underscore');
 
-window.moment = moment;
-
 // Preserve the ascendant order!
 var MOMENT_AGGREGATIONS = {
   second: 's',

--- a/src/dataviews/histogram-dataview-model.js
+++ b/src/dataviews/histogram-dataview-model.js
@@ -28,7 +28,7 @@ module.exports = DataviewModelBase.extend({
         params.push('bins=' + this.get('bins'));
       }
     } else {
-      var offset = this._getCurrentOffset();
+      var offset = this.getCurrentOffset();
 
       if (this.get('column_type') === 'number' && this.get('bins')) {
         params.push('bins=' + this.get('bins'));
@@ -72,7 +72,7 @@ module.exports = DataviewModelBase.extend({
     this._data = new Backbone.Collection(this.get('data'));
 
     if (attrs && (attrs.min || attrs.max)) {
-      this.filter.setRange(this.get('min'), this.get('max'));
+      this.filter && this.filter.setRange(this.get('min'), this.get('max'));
     }
   },
 
@@ -166,7 +166,7 @@ module.exports = DataviewModelBase.extend({
     }, { silent: true });
 
     if (this.get('column_type') === 'date') {
-      parsedData.data = helper.fillTimestampBuckets(parsedData.data, start, aggregation, numberOfBins, this._getCurrentOffset(), 'filtered', this._totals.get('data').length);
+      parsedData.data = helper.fillTimestampBuckets(parsedData.data, start, aggregation, numberOfBins, 'filtered', this._totals.get('data').length);
       numberOfBins = parsedData.data.length;
     } else {
       helper.fillNumericBuckets(parsedData.data, start, width, numberOfBins);
@@ -319,7 +319,7 @@ module.exports = DataviewModelBase.extend({
   },
 
   _onColumnTypeChanged: function () {
-    this.filter.set('column_type', this.get('column_type'));
+    this.filter && this.filter.set('column_type', this.get('column_type'));
   },
 
   _onChangeBinds: function () {
@@ -395,10 +395,10 @@ module.exports = DataviewModelBase.extend({
 
   _resetFilter: function () {
     this.disableFilter();
-    this.filter.unsetRange();
+    this.filter && this.filter.unsetRange();
   },
 
-  _getCurrentOffset: function () {
+  getCurrentOffset: function () {
     return this.get('localTimezone')
       ? this._localOffset
       : this.get('offset');

--- a/src/dataviews/histogram-dataview/histogram-data-model.js
+++ b/src/dataviews/histogram-dataview/histogram-data-model.js
@@ -136,7 +136,7 @@ module.exports = Model.extend({
     }
 
     if (this.get('column_type') === 'date') {
-      parsedData.data = helper.fillTimestampBuckets(parsedData.data, start, aggregation, numberOfBins, this._getCurrentOffset(), 'totals');
+      parsedData.data = helper.fillTimestampBuckets(parsedData.data, start, aggregation, numberOfBins, 'totals');
       numberOfBins = parsedData.data.length;
     } else {
       helper.fillNumericBuckets(parsedData.data, start, width, numberOfBins);
@@ -147,7 +147,7 @@ module.exports = Model.extend({
       parsedData.end = parsedData.data[parsedData.data.length - 1].end;
 
       var limits = helper.calculateLimits(parsedData.data);
-      this._saveStartEnd(this.get('column_type'), parsedData.aggregation, parsedData.start, parsedData.end, limits, data.offset);
+      this._saveStartEnd(this.get('column_type'), parsedData.aggregation, parsedData.start, parsedData.end, limits);
     }
 
     parsedData.bins = numberOfBins;
@@ -190,7 +190,7 @@ module.exports = Model.extend({
     return result;
   },
 
-  _saveStartEnd: function (columnType, aggregation, start, end, limits, offset) {
+  _saveStartEnd: function (columnType, aggregation, start, end, limits) {
     if (this._startEndCache.saved) {
       return;
     }

--- a/test/spec/dataviews/histogram-dataview-model.spec.js
+++ b/test/spec/dataviews/histogram-dataview-model.spec.js
@@ -421,7 +421,7 @@ describe('dataviews/histogram-dataview-model', function () {
 
       var parsedData = this.model.parse(data);
       expect(helper.fillTimestampBuckets).toHaveBeenCalled();
-      expect(JSON.stringify(parsedData)).toBe('{"data":[{"bin":0,"start":1496690940,"end":1496690999,"next":1496691000,"UTCStart":1496690940,"UTCEnd":1496690999,"freq":17,"min":1496690944,"max":1496690999,"avg":1496690971.58824},{"bin":1,"start":1496691000,"end":1496691059,"next":1496691060,"UTCStart":1496691000,"UTCEnd":1496691059,"freq":18,"min":1496691003,"max":1496691059,"avg":1496691031.22222}],"filteredAmount":0,"nulls":0,"totalAmount":35,"bins":2,"hasNulls":true}');
+      expect(JSON.stringify(parsedData)).toBe('{"data":[{"bin":0,"start":1496690940,"end":1496690999,"next":1496691000,"freq":17,"min":1496690944,"max":1496690999,"avg":1496690971.58824},{"bin":1,"start":1496691000,"end":1496691059,"next":1496691060,"freq":18,"min":1496691003,"max":1496691059,"avg":1496691031.22222}],"filteredAmount":0,"nulls":0,"totalAmount":35,"bins":2,"hasNulls":true}');
     });
   });
 
@@ -767,7 +767,7 @@ describe('dataviews/histogram-dataview-model', function () {
     });
   });
 
-  describe('._getCurrentOffset', function () {
+  describe('.getCurrentOffset', function () {
     beforeEach(function () {
       this.model.set('offset', 7200, { silent: true });
       this.model._localOffset = 43200;
@@ -776,7 +776,7 @@ describe('dataviews/histogram-dataview-model', function () {
     it('should return offset if `localTimezone` is not set', function () {
       this.model.set('localTimezone', false, { silent: true });
 
-      var offset = this.model._getCurrentOffset();
+      var offset = this.model.getCurrentOffset();
 
       expect(offset).toBe(7200);
     });
@@ -784,7 +784,7 @@ describe('dataviews/histogram-dataview-model', function () {
     it('should return local offset if `localTimezone` is set', function () {
       this.model.set('localTimezone', true, { silent: true });
 
-      var offset = this.model._getCurrentOffset();
+      var offset = this.model.getCurrentOffset();
 
       expect(offset).toBe(43200);
     });

--- a/test/spec/dataviews/histogram-dataview/histogram-data-model.spec.js
+++ b/test/spec/dataviews/histogram-dataview/histogram-data-model.spec.js
@@ -155,41 +155,4 @@ describe('dataviews/histogram-data-model', function () {
       expect(offset).toBe(43200);
     });
   });
-
-  describe('.parse', function () {
-    beforeEach(function () {
-      this.model.set('column_type', 'date', { silent: true });
-    });
-
-    describe(' aggregated by day', function () {
-      fit(' with offset 0', function () {
-        // 1 event at 2 Jan 1970 - 00:00
-        // 1 event at 2 Jan 1970 - 01:00
-        var payload = {
-          aggregation: 'day',
-          offset: 0,
-          timestamp_start: 86400,
-          bin_width: 3600,
-          bins_count: 1,
-          bins_start: 86400,
-          nulls: 0,
-          bins: [
-            {
-              bin: 0,
-              min: 86400,
-              max: 90000,
-              avg: 88200,
-              freq: 2,
-              timestamp: 86400
-            }
-          ],
-          type: 'histogram'
-        };
-
-        var parsedData = this.model.parse(payload);
-
-        debugger;
-      });
-    });
-  });
 });

--- a/test/spec/dataviews/histogram-dataview/histogram-data-model.spec.js
+++ b/test/spec/dataviews/histogram-dataview/histogram-data-model.spec.js
@@ -155,4 +155,41 @@ describe('dataviews/histogram-data-model', function () {
       expect(offset).toBe(43200);
     });
   });
+
+  describe('.parse', function () {
+    beforeEach(function () {
+      this.model.set('column_type', 'date', { silent: true });
+    });
+
+    describe(' aggregated by day', function () {
+      fit(' with offset 0', function () {
+        // 1 event at 2 Jan 1970 - 00:00
+        // 1 event at 2 Jan 1970 - 01:00
+        var payload = {
+          aggregation: 'day',
+          offset: 0,
+          timestamp_start: 86400,
+          bin_width: 3600,
+          bins_count: 1,
+          bins_start: 86400,
+          nulls: 0,
+          bins: [
+            {
+              bin: 0,
+              min: 86400,
+              max: 90000,
+              avg: 88200,
+              freq: 2,
+              timestamp: 86400
+            }
+          ],
+          type: 'histogram'
+        };
+
+        var parsedData = this.model.parse(payload);
+
+        debugger;
+      });
+    });
+  });
 });


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb/issues/13070
----

This PR removes all code that applied offset to timestamps in histogram dataview. See related issue for more details.