### PR TITLE
Format TS example years

### DIFF
--- a/examples/public/time-series-dataview.html
+++ b/examples/public/time-series-dataview.html
@@ -84,6 +84,17 @@
 
       // 4.2 Listening to data changes on the dataview
       timeSeries.on('dataChanged', function (newData) {
+        // Translate EPOCH timestamps to year
+        if (newData && newData.bins.length > 0) {
+          newData.bins.forEach(function (bin) {
+            var newStart = new Date(0);
+            newStart.setUTCSeconds(bin.start);
+            var newEnd = new Date(0);
+            newEnd.setUTCSeconds(bin.end);
+            bin.start = newStart.getFullYear();
+            bin.end = newEnd.getFullYear();
+          });
+        }
         widget && widget.set({ bins: newData.bins })
       });
 


### PR DESCRIPTION
The Timeseries example shows the EPOCH timestamps.

This PR formats them to show the years instead.

![ts](https://user-images.githubusercontent.com/1078228/33069234-246e015a-ceb4-11e7-8480-cb7892a8dc21.gif)
