### PR TITLE
Add getGoogleMapsMapType function

### DIFF
--- a/examples/public/gmaps/single-layer.html
+++ b/examples/public/gmaps/single-layer.html
@@ -49,7 +49,7 @@
 
       // 3.3. Adding the layers to the map
       var mapType = client.getGoogleMapsMapType(map);
-      map.overlayMapTypes.insertAt(0, mapType);
+      map.overlayMapTypes.push(mapType);
 
       // map.overlayMapTypes.setAt(0, mapType)
       // map.overlayMapTypes.insertAt(0, mapType)

--- a/examples/public/gmaps/single-layer.html
+++ b/examples/public/gmaps/single-layer.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8">
     <title>CARTO.js Single layer example</title>
-    <!-- Include Leaflet 1.2.0 Library -->
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet.js"></script>
+    <!-- Include Google Maps Library -->
+    <script src="https://maps.googleapis.com/maps/api/js"></script>
     <!-- Include CARTO.js Library -->
+    <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet.js"></script> <!-- Because of WAX -->
     <script src="../../../dist/public/carto.uncompressed.js"></script>
     <style>
       html, body { margin: 0; padding: 0; }
@@ -16,23 +16,11 @@
   <body>
     <div id="map"></div>
     <script>
-      // 1. Setting up the Leaflet Map
-      // 1.1 Creating the Leaflet Map
-      var map = L.map('map').setView([58.722598828043395, 18.544921875000004], 4);
-
-      // 1.2 Adding basemap and labels layers
-      // Adding Voyager Basemap
-      L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager_nolabels/{z}/{x}/{y}.png', {
-        maxZoom: 18,
-        attribution: carto.ATTRIBUTION
-      }).addTo(map);
-
-      // Adding Voyager Labels
-      L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager_only_labels/{z}/{x}/{y}.png', {
-        maxZoom: 18,
-        zIndex: 100,
-        attribution: carto.ATTRIBUTION
-      }).addTo(map);
+      // 1. Setting up the Google Maps map
+      var map = new google.maps.Map(document.getElementById('map'), {
+        zoom: 4,
+        center: {lat: 58.722598828043395, lng: 18.544921875000004}
+      });
 
       // 2 Defining a carto.Client
       var client = new carto.Client({
@@ -60,8 +48,15 @@
       client.addLayer(europeanCountries);
 
       // 3.3. Adding the layers to the map
-      var leafletLayer = client.getLeafletLayer();
-      leafletLayer.addTo(map);
+      var mapType = client.getGoogleMapsMapType(map);
+      map.overlayMapTypes.insertAt(0, mapType);
+
+      // map.overlayMapTypes.setAt(0, mapType)
+      // map.overlayMapTypes.insertAt(0, mapType)
+      // map.overlayMapTypes.removeAt(0)
+      // map.overlayMapTypes.push(mapType)
+      // map.overlayMapTypes.pop()
+      // map.overlayMapTypes.clear()
     </script>
   </body>
 </html>

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -5,7 +5,8 @@ var Engine = require('../../engine');
 var Events = require('./events');
 var LayerBase = require('./layer/base');
 var Layers = require('./layers');
-var LeafletLayer = require('./leaflet-layer');
+var LeafletLayer = require('./native/leaflet-layer');
+// var GoogleMapsMapType = require('./native/google-maps-map-type');
 var VERSION = require('../../../package.json').version;
 
 /**
@@ -219,6 +220,16 @@ Client.prototype.getDataviews = function () {
 Client.prototype.getLeafletLayer = function () {
   this._leafletLayer = this._leafletLayer || new LeafletLayer(this._layers, this._engine);
   return this._leafletLayer;
+};
+
+/**
+ * [description]
+ * @return {google.maps.ImageMapType} [description]
+ * @api
+ */
+Client.prototype.getGoogleMapsMapType = function () {
+  this._gmapsMapType = this._gmapsMapType || null; // || new GoogleMapsMapType();
+  return this._gmapsMapType;
 };
 
 /**

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -216,6 +216,8 @@ Client.prototype.getDataviews = function () {
  * @api
  */
 Client.prototype.getLeafletLayer = function () {
+  // Check if Leaflet is loaded
+  _isLeafletLoaded();
   if (!this._leafletLayer) {
     var LeafletLayer = require('./native/leaflet-layer');
     this._leafletLayer = new LeafletLayer(this._layers, this._engine);
@@ -236,6 +238,8 @@ Client.prototype.getLeafletLayer = function () {
 Client.prototype.getGoogleMapsMapType = function (map) {
   // NOTE: the map is required here because of wax.g.connector
 
+  // Check if Google Maps is loaded
+  _isGoogleMapsLoaded();
   if (!this._gmapsMapType) {
     var GoogleMapsMapType = require('./native/google-maps-map-type');
     this._gmapsMapType = new GoogleMapsMapType(this._layers, this._engine, map);
@@ -344,6 +348,27 @@ function _checkServerUrl (serverUrl, username) {
   }
   if (serverUrl.indexOf(username) < 0) {
     throw new TypeError('serverUrl doesn\'t match the username.');
+  }
+}
+
+function _isLeafletLoaded () {
+  if (!window.L) {
+    throw new Error('Leaflet is required');
+  }
+  if (window.L.version < '1.0.0') {
+    throw new Error('Leaflet +1.0 is required');
+  }
+}
+
+function _isGoogleMapsLoaded () {
+  if (!window.google) {
+    throw new Error('Google Maps is required');
+  }
+  if (!window.google.maps) {
+    throw new Error('Google Maps is required');
+  }
+  if (window.google.maps.version < '3.0.0') {
+    throw new Error('Google Maps +3.0 is required');
   }
 }
 

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -5,8 +5,6 @@ var Engine = require('../../engine');
 var Events = require('./events');
 var LayerBase = require('./layer/base');
 var Layers = require('./layers');
-var LeafletLayer = require('./native/leaflet-layer');
-// var GoogleMapsMapType = require('./native/google-maps-map-type');
 var VERSION = require('../../../package.json').version;
 
 /**
@@ -218,17 +216,22 @@ Client.prototype.getDataviews = function () {
  * @api
  */
 Client.prototype.getLeafletLayer = function () {
+  var LeafletLayer = require('./native/leaflet-layer');
   this._leafletLayer = this._leafletLayer || new LeafletLayer(this._layers, this._engine);
   return this._leafletLayer;
 };
 
 /**
- * [description]
- * @return {google.maps.ImageMapType} [description]
+ * Return a Google Maps mapType that groups all the layers that have been
+ * added to this client.
+ *
+ * @return {google.maps.MapType} A Google Maps mapType that groups all the layers:
+ * {@link https://developers.google.com/maps/documentation/javascript/maptypes|google.maps.MapType}
  * @api
  */
-Client.prototype.getGoogleMapsMapType = function () {
-  this._gmapsMapType = this._gmapsMapType || null; // || new GoogleMapsMapType();
+Client.prototype.getGoogleMapsMapType = function (map) {
+  var GoogleMapsMapType = require('./native/google-maps-map-type');
+  this._gmapsMapType = this._gmapsMapType || new GoogleMapsMapType(this._layers, this._engine, map);
   return this._gmapsMapType;
 };
 

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -216,8 +216,10 @@ Client.prototype.getDataviews = function () {
  * @api
  */
 Client.prototype.getLeafletLayer = function () {
-  var LeafletLayer = require('./native/leaflet-layer');
-  this._leafletLayer = this._leafletLayer || new LeafletLayer(this._layers, this._engine);
+  if (!this._leafletLayer) {
+    var LeafletLayer = require('./native/leaflet-layer');
+    this._leafletLayer = new LeafletLayer(this._layers, this._engine);
+  }
   return this._leafletLayer;
 };
 
@@ -225,13 +227,19 @@ Client.prototype.getLeafletLayer = function () {
  * Return a Google Maps mapType that groups all the layers that have been
  * added to this client.
  *
+ * @param {google.maps.Map}
+ *
  * @return {google.maps.MapType} A Google Maps mapType that groups all the layers:
  * {@link https://developers.google.com/maps/documentation/javascript/maptypes|google.maps.MapType}
  * @api
  */
 Client.prototype.getGoogleMapsMapType = function (map) {
-  var GoogleMapsMapType = require('./native/google-maps-map-type');
-  this._gmapsMapType = this._gmapsMapType || new GoogleMapsMapType(this._layers, this._engine, map);
+  // NOTE: the map is required here because of wax.g.connector
+
+  if (!this._gmapsMapType) {
+    var GoogleMapsMapType = require('./native/google-maps-map-type');
+    this._gmapsMapType = new GoogleMapsMapType(this._layers, this._engine, map);
+  }
   return this._gmapsMapType;
 };
 

--- a/src/api/v4/index.js
+++ b/src/api/v4/index.js
@@ -17,10 +17,6 @@
  * - **operation** : The operations exposed.
  */
 
-if (window.L && window.L.version < '1.0.0') {
-  throw new Error('Leaflet +1.0 is required');
-}
-
 var Client = require('./client');
 var source = require('./source');
 var style = require('./style');

--- a/src/api/v4/index.js
+++ b/src/api/v4/index.js
@@ -27,7 +27,7 @@ var events = require('./events');
 var constants = require('./constants');
 
 var carto = window.carto = {
-  VERSION: require('../../../package.json').version,
+  version: require('../../../package.json').version,
   ATTRIBUTION: constants.ATTRIBUTION,
   Client: Client,
   source: source,

--- a/src/api/v4/native/google-maps-map-type.js
+++ b/src/api/v4/native/google-maps-map-type.js
@@ -1,0 +1,79 @@
+/* global google */
+var _ = require('underscore');
+var Layer = require('../layer');
+var GMapsCartoDBLayerGroupView = require('../../../geo/gmaps/gmaps-cartodb-layer-group-view');
+
+/**
+ * This object is a custom Google Maps MapType to enable feature interactivity
+ * using an internal GMapsCartoDBLayerGroupView instance.
+ *
+ */
+
+function GoogleMapsMapType (layers, engine, map) {
+  this._layers = layers;
+  this._engine = engine;
+  this._map = map;
+
+  this._hoveredLayers = [];
+
+  this.tileSize = new google.maps.Size(256, 256);
+  this._internalView = new GMapsCartoDBLayerGroupView(this._engine._cartoLayerGroup, {
+    nativeMap: map
+  });
+  this._internalView.on('featureClick', this._onFeatureClick, this);
+  this._internalView.on('featureOver', this._onFeatureOver, this);
+  this._internalView.on('featureOut', this._onFeatureOut, this);
+}
+
+GoogleMapsMapType.prototype.getTile = function (coord, zoom, ownerDocument) {
+  return this._internalView.getTile(coord, zoom, ownerDocument);
+};
+
+GoogleMapsMapType.prototype._onFeatureClick = function (internalEvent) {
+  this._triggerLayerFeatureEvent(Layer.events.FEATURE_CLICKED, internalEvent);
+};
+
+GoogleMapsMapType.prototype._onFeatureOver = function (internalEvent) {
+  var layer = this._layers.findById(internalEvent.layer.id);
+  if (layer.isInteractive()) {
+    this._hoveredLayers[internalEvent.layerIndex] = true;
+    this._map.setOptions({ draggableCursor: 'pointer' });
+  }
+  this._triggerLayerFeatureEvent(Layer.events.FEATURE_OVER, internalEvent);
+};
+
+GoogleMapsMapType.prototype._onFeatureOut = function (internalEvent) {
+  this._hoveredLayers[internalEvent.layerIndex] = false;
+  if (_.any(this._hoveredLayers)) {
+    this._map.setOptions({ draggableCursor: 'pointer' });
+  } else {
+    this._map.setOptions({ draggableCursor: 'auto' });
+  }
+  this._triggerLayerFeatureEvent(Layer.events.FEATURE_OUT, internalEvent);
+};
+
+GoogleMapsMapType.prototype._triggerLayerFeatureEvent = function (eventName, internalEvent) {
+  var layer = this._layers.findById(internalEvent.layer.id);
+  if (layer) {
+    var event = {
+      data: undefined,
+      latLng: undefined
+    };
+    if (internalEvent.feature) {
+      event.data = internalEvent.feature;
+    }
+    if (internalEvent.latlng) {
+      event.latLng = {
+        lat: internalEvent.latlng[0],
+        lng: internalEvent.latlng[1]
+      };
+    }
+    if (internalEvent.position) {
+      event.position = internalEvent.position;
+    }
+
+    layer.trigger(eventName, event);
+  }
+};
+
+module.exports = GoogleMapsMapType;

--- a/src/api/v4/native/google-maps-map-type.js
+++ b/src/api/v4/native/google-maps-map-type.js
@@ -7,6 +7,7 @@ var GMapsCartoDBLayerGroupView = require('../../../geo/gmaps/gmaps-cartodb-layer
  * This object is a custom Google Maps MapType to enable feature interactivity
  * using an internal GMapsCartoDBLayerGroupView instance.
  *
+ * NOTE: It also contains the feature events handlers. That's why it requires the carto layers array.
  */
 
 function GoogleMapsMapType (layers, engine, map) {
@@ -69,7 +70,10 @@ GoogleMapsMapType.prototype._triggerLayerFeatureEvent = function (eventName, int
       };
     }
     if (internalEvent.position) {
-      event.position = internalEvent.position;
+      event.position = {
+        x: internalEvent.position.x,
+        y: internalEvent.position.y
+      };
     }
 
     layer.trigger(eventName, event);

--- a/src/api/v4/native/google-maps-map-type.js
+++ b/src/api/v4/native/google-maps-map-type.js
@@ -1,6 +1,7 @@
 /* global google */
 var _ = require('underscore');
 var Layer = require('../layer');
+var triggerLayerFeatureEvent = require('./trigger-layer-feature-event');
 var GMapsCartoDBLayerGroupView = require('../../../geo/gmaps/gmaps-cartodb-layer-group-view');
 
 /**
@@ -31,7 +32,7 @@ GoogleMapsMapType.prototype.getTile = function (coord, zoom, ownerDocument) {
 };
 
 GoogleMapsMapType.prototype._onFeatureClick = function (internalEvent) {
-  this._triggerLayerFeatureEvent(Layer.events.FEATURE_CLICKED, internalEvent);
+  triggerLayerFeatureEvent(Layer.events.FEATURE_CLICKED, internalEvent, this._layers);
 };
 
 GoogleMapsMapType.prototype._onFeatureOver = function (internalEvent) {
@@ -40,7 +41,7 @@ GoogleMapsMapType.prototype._onFeatureOver = function (internalEvent) {
     this._hoveredLayers[internalEvent.layerIndex] = true;
     this._map.setOptions({ draggableCursor: 'pointer' });
   }
-  this._triggerLayerFeatureEvent(Layer.events.FEATURE_OVER, internalEvent);
+  triggerLayerFeatureEvent(Layer.events.FEATURE_OVER, internalEvent, this._layers);
 };
 
 GoogleMapsMapType.prototype._onFeatureOut = function (internalEvent) {
@@ -50,34 +51,7 @@ GoogleMapsMapType.prototype._onFeatureOut = function (internalEvent) {
   } else {
     this._map.setOptions({ draggableCursor: 'auto' });
   }
-  this._triggerLayerFeatureEvent(Layer.events.FEATURE_OUT, internalEvent);
-};
-
-GoogleMapsMapType.prototype._triggerLayerFeatureEvent = function (eventName, internalEvent) {
-  var layer = this._layers.findById(internalEvent.layer.id);
-  if (layer) {
-    var event = {
-      data: undefined,
-      latLng: undefined
-    };
-    if (internalEvent.feature) {
-      event.data = internalEvent.feature;
-    }
-    if (internalEvent.latlng) {
-      event.latLng = {
-        lat: internalEvent.latlng[0],
-        lng: internalEvent.latlng[1]
-      };
-    }
-    if (internalEvent.position) {
-      event.position = {
-        x: internalEvent.position.x,
-        y: internalEvent.position.y
-      };
-    }
-
-    layer.trigger(eventName, event);
-  }
+  triggerLayerFeatureEvent(Layer.events.FEATURE_OUT, internalEvent, this._layers);
 };
 
 module.exports = GoogleMapsMapType;

--- a/src/api/v4/native/leaflet-layer.js
+++ b/src/api/v4/native/leaflet-layer.js
@@ -8,8 +8,7 @@ var LeafletCartoLayerGroupView = require('../../../geo/leaflet/leaflet-cartodb-l
  * This object is a custom Leaflet layer to enable feature interactivity
  * using an internal LeafletCartoLayerGroupView instance.
  *
- * There are some overwritten functions:
- * - getAttribution: returns always a custom OpenStreetMap / Carto attribution message
+ * There are two overwritten functions:
  * - addTo: when the layer is added to a map it also creates a LeafletCartoLayerGroupView
  *          object called `_internalView` in order to enable the feature events
  * - removeFrom: when the layer is removed from a map it also removes the feature events
@@ -102,6 +101,12 @@ var LeafletLayer = L.TileLayer.extend({
         event.latLng = {
           lat: internalEvent.latlng[0],
           lng: internalEvent.latlng[1]
+        };
+      }
+      if (internalEvent.position) {
+        event.position = {
+          x: internalEvent.position.x,
+          y: internalEvent.position.y
         };
       }
 

--- a/src/api/v4/native/leaflet-layer.js
+++ b/src/api/v4/native/leaflet-layer.js
@@ -1,8 +1,8 @@
 var L = require('leaflet');
 var _ = require('underscore');
-var Layer = require('./layer');
-var constants = require('./constants');
-var LeafletCartoLayerGroupView = require('../../geo/leaflet/leaflet-cartodb-layer-group-view');
+var Layer = require('../layer');
+var constants = require('../constants');
+var LeafletCartoLayerGroupView = require('../../../geo/leaflet/leaflet-cartodb-layer-group-view');
 
 /**
  * This object is a custom Leaflet layer to enable feature interactivity

--- a/src/api/v4/native/leaflet-layer.js
+++ b/src/api/v4/native/leaflet-layer.js
@@ -2,6 +2,7 @@ var L = require('leaflet');
 var _ = require('underscore');
 var Layer = require('../layer');
 var constants = require('../constants');
+var triggerLayerFeatureEvent = require('./trigger-layer-feature-event');
 var LeafletCartoLayerGroupView = require('../../../geo/leaflet/leaflet-cartodb-layer-group-view');
 
 /**
@@ -65,7 +66,7 @@ var LeafletLayer = L.TileLayer.extend({
   },
 
   _onFeatureClick: function (internalEvent) {
-    this._triggerLayerFeatureEvent(Layer.events.FEATURE_CLICKED, internalEvent);
+    triggerLayerFeatureEvent(Layer.events.FEATURE_CLICKED, internalEvent, this._layers);
   },
 
   _onFeatureOver: function (internalEvent) {
@@ -74,7 +75,7 @@ var LeafletLayer = L.TileLayer.extend({
       this._hoveredLayers[internalEvent.layerIndex] = true;
       this._map.getContainer().style.cursor = 'pointer';
     }
-    this._triggerLayerFeatureEvent(Layer.events.FEATURE_OVER, internalEvent);
+    triggerLayerFeatureEvent(Layer.events.FEATURE_OVER, internalEvent, this._layers);
   },
 
   _onFeatureOut: function (internalEvent) {
@@ -84,44 +85,7 @@ var LeafletLayer = L.TileLayer.extend({
     } else {
       this._map.getContainer().style.cursor = 'auto';
     }
-    this._triggerLayerFeatureEvent(Layer.events.FEATURE_OUT, internalEvent);
-  },
-
-  _triggerLayerFeatureEvent: function (eventName, internalEvent) {
-    var layer = this._layers.findById(internalEvent.layer.id);
-    if (layer) {
-      var event = {
-        data: undefined,
-        latLng: undefined
-      };
-      if (internalEvent.feature) {
-        event.data = internalEvent.feature;
-      }
-      if (internalEvent.latlng) {
-        event.latLng = {
-          lat: internalEvent.latlng[0],
-          lng: internalEvent.latlng[1]
-        };
-      }
-      if (internalEvent.position) {
-        event.position = {
-          x: internalEvent.position.x,
-          y: internalEvent.position.y
-        };
-      }
-
-      /**
-       *
-       * Events triggered by {@link carto.layer.Layer} when users interact with a feature.
-       *
-       * @event carto.layer.Layer.FeatureEvent
-       * @property {LatLng} latLng - Object with coordinates where interaction took place
-       * @property {object} data - Object with feature data (one attribute for each specified column)
-       *
-       * @api
-       */
-      layer.trigger(eventName, event);
-    }
+    triggerLayerFeatureEvent(Layer.events.FEATURE_OUT, internalEvent, this._layers);
   }
 });
 

--- a/src/api/v4/native/trigger-layer-feature-event.js
+++ b/src/api/v4/native/trigger-layer-feature-event.js
@@ -1,0 +1,36 @@
+module.exports = function (eventName, internalEvent, layers) {
+  var layer = layers.findById(internalEvent.layer.id);
+  if (layer) {
+    var event = {
+      data: undefined,
+      latLng: undefined
+    };
+    if (internalEvent.feature) {
+      event.data = internalEvent.feature;
+    }
+    if (internalEvent.latlng) {
+      event.latLng = {
+        lat: internalEvent.latlng[0],
+        lng: internalEvent.latlng[1]
+      };
+    }
+    if (internalEvent.position) {
+      event.position = {
+        x: internalEvent.position.x,
+        y: internalEvent.position.y
+      };
+    }
+
+    /**
+     *
+     * Events triggered by {@link carto.layer.Layer} when users interact with a feature.
+     *
+     * @event carto.layer.Layer.FeatureEvent
+     * @property {LatLng} latLng - Object with coordinates where interaction took place
+     * @property {object} data - Object with feature data (one attribute for each specified column)
+     *
+     * @api
+     */
+    layer.trigger(eventName, event);
+  }
+};

--- a/test/spec/api/v4/client.spec.js
+++ b/test/spec/api/v4/client.spec.js
@@ -1,6 +1,6 @@
 var L = require('leaflet');
 var carto = require('../../../../src/api/v4');
-var LeafletLayer = require('../../../../src/api/v4/leaflet-layer');
+var LeafletLayer = require('../../../../src/api/v4/native/leaflet-layer');
 
 describe('api/v4/client', function () {
   var client;

--- a/test/spec/api/v4/client.spec.js
+++ b/test/spec/api/v4/client.spec.js
@@ -1,6 +1,8 @@
+/* global google */
 var L = require('leaflet');
 var carto = require('../../../../src/api/v4');
 var LeafletLayer = require('../../../../src/api/v4/native/leaflet-layer');
+var GoogleMapsMapType = require('../../../../src/api/v4/native/google-maps-map-type');
 
 describe('api/v4/client', function () {
   var client;
@@ -193,7 +195,7 @@ describe('api/v4/client', function () {
       leafletLayer = client.getLeafletLayer();
     });
 
-    it('should return an object', function () {
+    it('should return an instance of LeafletLayer', function () {
       expect(leafletLayer instanceof LeafletLayer).toBe(true);
     });
 
@@ -207,6 +209,33 @@ describe('api/v4/client', function () {
 
     it('should have the OpenStreetMap / Carto attribution', function () {
       expect(leafletLayer.getAttribution()).toBe('&copy;<a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, &copy;<a href="https://carto.com/attribution">CARTO</a>');
+    });
+  });
+
+  describe('.getGoogleMapsMapType', function () {
+    var mapType;
+    var element;
+
+    beforeEach(function () {
+      element = document.createElement('div');
+      mapType = client.getGoogleMapsMapType(new google.maps.Map(element));
+    });
+
+    afterEach(function () {
+      element.remove();
+    });
+
+    it('should return an instance of GoogleMapsMapType', function () {
+      expect(mapType instanceof GoogleMapsMapType).toBe(true);
+    });
+
+    it('should return the same object', function () {
+      expect(mapType === client.getGoogleMapsMapType()).toBe(true);
+    });
+
+    it('should return an object with a MapType interface', function () {
+      expect(mapType.tileSize).toBeDefined();
+      expect(mapType.getTile).toBeDefined();
     });
   });
 });

--- a/test/spec/api/v4/client.spec.js
+++ b/test/spec/api/v4/client.spec.js
@@ -1,5 +1,6 @@
 /* global google */
 var L = require('leaflet');
+var _ = require('underscore');
 var carto = require('../../../../src/api/v4');
 var LeafletLayer = require('../../../../src/api/v4/native/leaflet-layer');
 var GoogleMapsMapType = require('../../../../src/api/v4/native/google-maps-map-type');
@@ -210,11 +211,35 @@ describe('api/v4/client', function () {
     it('should have the OpenStreetMap / Carto attribution', function () {
       expect(leafletLayer.getAttribution()).toBe('&copy;<a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, &copy;<a href="https://carto.com/attribution">CARTO</a>');
     });
+
+    it('should throw an error if Leaflet is not loaded', function () {
+      var L = _.clone(window.L);
+
+      window.L = undefined;
+      expect(function () {
+        client.getLeafletLayer();
+      }).toThrowError('Leaflet is required');
+
+      // Restore window.L
+      window.L = L;
+    });
+
+    it('should throw an error if Leaflet version is <1.0', function () {
+      var L = _.clone(window.L);
+
+      window.L = { version: '0.7' };
+      expect(function () {
+        client.getLeafletLayer();
+      }).toThrowError('Leaflet +1.0 is required');
+
+      // Restore window.L
+      window.L = L;
+    });
   });
 
   describe('.getGoogleMapsMapType', function () {
-    var mapType;
     var element;
+    var mapType;
 
     beforeEach(function () {
       element = document.createElement('div');
@@ -236,6 +261,35 @@ describe('api/v4/client', function () {
     it('should return an object with a MapType interface', function () {
       expect(mapType.tileSize).toBeDefined();
       expect(mapType.getTile).toBeDefined();
+    });
+
+    it('should throw an error if Google Maps is not loaded', function () {
+      var google = _.clone(window.google);
+
+      window.google = undefined;
+      expect(function () {
+        client.getGoogleMapsMapType();
+      }).toThrowError('Google Maps is required');
+
+      window.google = { maps: undefined };
+      expect(function () {
+        client.getGoogleMapsMapType();
+      }).toThrowError('Google Maps is required');
+
+      // Restore window.google
+      window.google = google;
+    });
+
+    it('should throw an error if Google Maps version is <3.0', function () {
+      var google = _.clone(window.google);
+
+      window.google.maps = { version: '2.4' };
+      expect(function () {
+        client.getGoogleMapsMapType();
+      }).toThrowError('Google Maps +3.0 is required');
+
+      // Restore window.google
+      window.google = google;
     });
   });
 });

--- a/test/spec/api/v4/native/leaflet-layer.spec.js
+++ b/test/spec/api/v4/native/leaflet-layer.spec.js
@@ -1,7 +1,7 @@
 var L = require('leaflet');
-var carto = require('../../../../src/api/v4');
+var carto = require('../../../../../src/api/v4');
 
-describe('src/api/v4/leaflet-layer', function () {
+describe('src/api/v4/native/leaflet-layer', function () {
   var client;
   var layer;
   var leafletLayer;


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb.js/issues/1734

**NOTE**

Now you need to pass the map to the get function because of WAX:

```js
var map = new google.maps.Map(document.getElementById('map'), {
  zoom: 10,
  center: {lat: 41.850, lng: -87.650}
});

var mapType = client.getGoogleMapsMapType(map);

map.overlayMapTypes.push(mapType);
```

This could be optimized in the future when WAX is removed.