### PR TITLE
Fix Choropleth legend with one bucket

### DIFF
--- a/src/windshaft-integration/legends/rule-to-choropleth-legend-adapter.js
+++ b/src/windshaft-integration/legends/rule-to-choropleth-legend-adapter.js
@@ -12,15 +12,23 @@ var isEveryBucketValid = function (rule) {
 };
 
 var generateColors = function (buckets) {
-  return _.map(buckets, function (bucket, i) {
-    var label = '';
-    if (i === 0) {
-      label = bucket.filter.start;
-    } else if (i === buckets.length - 1) {
-      label = bucket.filter.end;
-    }
-    return { value: bucket.value, label: label.toString() };
-  });
+  if (buckets.length === 1) {
+    var bucket = buckets[0];
+    var labelStart = bucket.filter.start;
+    var labelEnd = bucket.filter.end;
+    return [{ value: bucket.value, label: labelStart.toString() },
+      { value: bucket.value, label: labelEnd.toString() }];
+  } else {
+    return _.map(buckets, function (bucket, i) {
+      var label = '';
+      if (i === 0) {
+        label = bucket.filter.start;
+      } else if (i === buckets.length - 1) {
+        label = bucket.filter.end;
+      }
+      return { value: bucket.value, label: label.toString() };
+    });
+  }
 };
 
 module.exports = {

--- a/src/windshaft-integration/legends/rule-to-choropleth-legend-adapter.js
+++ b/src/windshaft-integration/legends/rule-to-choropleth-legend-adapter.js
@@ -16,19 +16,17 @@ var generateColors = function (buckets) {
     var bucket = buckets[0];
     var labelStart = bucket.filter.start;
     var labelEnd = bucket.filter.end;
-    return [{ value: bucket.value, label: labelStart.toString() },
-      { value: bucket.value, label: labelEnd.toString() }];
-  } else {
-    return _.map(buckets, function (bucket, i) {
-      var label = '';
-      if (i === 0) {
-        label = bucket.filter.start;
-      } else if (i === buckets.length - 1) {
-        label = bucket.filter.end;
-      }
-      return { value: bucket.value, label: label.toString() };
-    });
+    return [{ value: bucket.value, label: labelStart.toString() }, { value: bucket.value, label: labelEnd.toString() }];
   }
+  return _.map(buckets, function (bucket, i) {
+    var label = '';
+    if (i === 0) {
+      label = bucket.filter.start;
+    } else if (i === buckets.length - 1) {
+      label = bucket.filter.end;
+    }
+    return { value: bucket.value, label: label.toString() };
+  });
 };
 
 module.exports = {

--- a/test/spec/windshaft-integration/legends/rule-to-choropleth-legend-adapter.spec.js
+++ b/test/spec/windshaft-integration/legends/rule-to-choropleth-legend-adapter.spec.js
@@ -36,6 +36,24 @@ describe('src/windshaft-integration/legends/rule-to-choropleth-legend-adapter', 
         'filter_avg': 1975
       }
     };
+    this.one_bucket_rule = {
+      'selector': '#layer',
+      'prop': 'polygon-fill',
+      'mapping': '>',
+      'buckets': [
+        {
+          'filter': {
+            'type': 'range',
+            'start': 100,
+            'end': 100
+          },
+          'value': '#AAAAAA'
+        }
+      ],
+      'stats': {
+        'filter_avg': 100
+      }
+    };
   });
 
   describe('.canAdapt', function () {
@@ -61,6 +79,18 @@ describe('src/windshaft-integration/legends/rule-to-choropleth-legend-adapter', 
         avg: 1975,
         max: 3000,
         min: 0
+      });
+    });
+    it('should return two buckets in case we receive just one', function () {
+      var attrs = adapter.adapt([this.one_bucket_rule]);
+      expect(attrs).toEqual({
+        colors: [
+          { label: '100', value: '#AAAAAA' },
+          { label: '100', value: '#AAAAAA' }
+        ],
+        avg: 100,
+        max: 100,
+        min: 100
       });
     });
   });


### PR DESCRIPTION
If we receive just one filter we're not showing the ramp color properly
because the `linear_gradient` css property in the template need two
values so we're going to pass the same value and legend twice