### PR TITLE
Add .isSourceType() to dataview-model-base

### DIFF
--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -294,6 +294,10 @@ module.exports = Model.extend({
     return this.get('source');
   },
 
+  isSourceType: function () {
+    return this.getSourceType() === 'source';
+  },
+
   isFiltered: function () {
     var isFiltered = false;
     if (this.filter) {

--- a/test/spec/dataviews/dataview-model-base.spec.js
+++ b/test/spec/dataviews/dataview-model-base.spec.js
@@ -499,6 +499,40 @@ describe('dataviews/dataview-model-base', function () {
     });
   });
 
+  describe('isSourceType', function () {
+    it('should return true if the source type is source', function () {
+      var dataview = new DataviewModelBase({
+        source: this.analysisNodes.get('a0')
+      }, {
+        map: this.map,
+        engine: engineMock
+      });
+      dataview.getSourceType = function () {
+        return 'source';
+      };
+
+      expect(dataview.isSourceType()).toBe(true);
+    });
+  });
+
+  describe('when source type is not source', function () {
+    describe('isSourceType', function () {
+      it('should return false', function () {
+        var dataview = new DataviewModelBase({
+          source: this.analysisNodes.get('a0')
+        }, {
+          map: this.map,
+          engine: engineMock
+        });
+        dataview.getSourceType = function () {
+          return 'sampling';
+        };
+
+        expect(dataview.isSourceType()).toBe(false);
+      });
+    });
+  });
+
   describe('getSourceId', function () {
     it('should return the id of the source', function () {
       var dataview = new DataviewModelBase({


### PR DESCRIPTION
We're redesigning how the node info is showed in the widgets and we need to know if the dataview is of type source.