### PR TITLE
Append legends view if js-embed-legends is found

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb.js",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-beta.13",
   "description": "CARTO javascript library",
   "repository": {
     "type": "git",

--- a/src/geo/ui/legends/bubble/legend-template.tpl
+++ b/src/geo/ui/legends/bubble/legend-template.tpl
@@ -1,34 +1,37 @@
 <div class="Bubble-container">
-  <ul class="Bubble-numbers">
-    <% if (hasCustomLabels) { %>
-      <li class="Bubble-numbersItem CDB-Text CDB-Size-small" style="bottom: 0%"><%- labels[1] %></li>
-      <li class="Bubble-numbersItem CDB-Text CDB-Size-small" style="bottom: 100%"><%- labels[0] %></li>
-    <% } else { %>
-      <% for (var i = 0; i<labels.length; i++) { %>
-        <li class="Bubble-numbersItem CDB-Text CDB-Size-small" style="bottom: <%- labelPositions[i] %>%">
-          <%= formatter.formatNumber(labels[i]) %>
-        </li>
-      <% } %>
+  <ul class="Bubble-list<% if (hasCustomLabels && labels[1] === '') { %> Bubble-list--custom<% } %>">
+    <% for (var i in bubbleSizes) { %>
+      <%
+        var customCssClass = '';
+        var index = +i;
+        if (hasCustomLabels) {
+          customCssClass = (labels[0] !== '' && index === 0) ? '' : 'Bubble-item--custom';
+        }
+      %>
+      <li class="js-bubbleItem Bubble-item <%- customCssClass %>">
+        <% if (!hasCustomLabels || (hasCustomLabels && index === 0)) {%>
+          <div class="Bubble-label CDB-Text CDB-Size-small" style="height: <%- bubbleSizes[i] %>%;">
+            <div class="Bubble-numbersItem CDB-Text CDB-Size-small"><%= formatter.formatNumber(labels[i]) %></div>
+          </div>
+        <% } %>
+        <div class="Bubble-circle">
+          <span class="Bubble-itemCircle" style="height: <%- bubbleSizes[i] %>%; width: <%- bubbleSizes[i] %>%; <%- fillColor ? 'opacity:1; background-color:' + fillColor + ';': ''%>" ></span>
+        </div>
+      </li>
+    <% } %>
+
+    <% if (labels[labels.length - 1]) { %>
+      <li class="js-bubbleItem Bubble-item">
+        <div class="Bubble-label CDB-Text CDB-Size-small" style="height: 0%;">
+          <div class="Bubble-numbersItem CDB-Text CDB-Size-small"><%= formatter.formatNumber(labels[labels.length - 1]) %></div>
+        </div>
+      </li>
     <% } %>
   </ul>
 
-  <div class="Bubble-inner">
-    <ul class="Bubble-list<% if (hasCustomLabels && labels[1] === '') { %> Bubble-list--custom<% } %>">
-      <% for (var i in bubbleSizes) { %>
-        <%
-          var customCssClass = '';
-          var index = +i;
-          if (hasCustomLabels) {
-            customCssClass = (labels[0] !== '' && index === 0) ? '' : 'Bubble-item--custom';
-          }
-        %>
-        <li class="js-bubbleItem Bubble-item <%- customCssClass %>" style="height: <%- bubbleSizes[i] %>%; width: <%- bubbleSizes[i] %>%">
-          <span class="Bubble-itemCircle" style=" <%- fillColor ? 'opacity:1; background-color:' + fillColor + ';': ''%>" ></span>
-        </li>
-      <% } %>
-    </ul>
+  <% if (!hasCustomLabels) { %>
     <p class="Bubble-average CDB-Text CDB-Size-small u-altTextColor <% if (hasCustomLabels) { %>Bubble-average--custom<% } %>" style="bottom: <%- avgSize %>%;">
-      <% if (!hasCustomLabels) { %> AVG: <%= formatter.formatNumber(avgLabel) %> <% } %>
+      AVG: <%= formatter.formatNumber(avgLabel) %>
     </p>
-  </div>
+  <% } %>
 </div>

--- a/src/geo/ui/legends/bubble/legend-template.tpl
+++ b/src/geo/ui/legends/bubble/legend-template.tpl
@@ -1,23 +1,19 @@
-<div class="Bubble-container u-flex u-justifySpace">
-  <ul class="Bubble-numbers u-flex u-justifySpace">
+<div class="Bubble-container">
+  <ul class="Bubble-numbers">
     <% if (hasCustomLabels) { %>
-      <li class="Bubble-numbersItem CDB-Text CDB-Size-small" style="bottom: 0%">
-        <span class="Bubble-numbersItem-value"><%- labels[1] %></span>
-      </li>
-      <li class="Bubble-numbersItem CDB-Text CDB-Size-small" style="bottom: 100%">
-        <span class="Bubble-numbersItem-value"><%- labels[0] %></span>
-      </li>
+      <li class="Bubble-numbersItem CDB-Text CDB-Size-small" style="bottom: 0%"><%- labels[1] %></li>
+      <li class="Bubble-numbersItem CDB-Text CDB-Size-small" style="bottom: 100%"><%- labels[0] %></li>
     <% } else { %>
       <% for (var i = 0; i<labels.length; i++) { %>
         <li class="Bubble-numbersItem CDB-Text CDB-Size-small" style="bottom: <%- labelPositions[i] %>%">
-          <span class="Bubble-numbersItem-value"><%= formatter.formatNumber(labels[i]) %></span>
+          <%= formatter.formatNumber(labels[i]) %>
         </li>
       <% } %>
     <% } %>
   </ul>
 
   <div class="Bubble-inner">
-    <ul class="Bubble-list <% if (hasCustomLabels && labels[1] === '') { %>Bubble-list--custom<% } %>">
+    <ul class="Bubble-list<% if (hasCustomLabels && labels[1] === '') { %> Bubble-list--custom<% } %>">
       <% for (var i in bubbleSizes) { %>
         <%
           var customCssClass = '';

--- a/src/geo/ui/legends/bubble/legend-template.tpl
+++ b/src/geo/ui/legends/bubble/legend-template.tpl
@@ -1,11 +1,17 @@
 <div class="Bubble-container u-flex u-justifySpace">
   <ul class="Bubble-numbers u-flex u-justifySpace">
     <% if (hasCustomLabels) { %>
-      <li class="Bubble-numbersItem CDB-Text CDB-Size-small" style="bottom: 0%"><%- labels[1] %></li>
-      <li class="Bubble-numbersItem CDB-Text CDB-Size-small" style="bottom: 100%"><%- labels[0] %></li>
+      <li class="Bubble-numbersItem CDB-Text CDB-Size-small" style="bottom: 0%">
+        <span class="Bubble-numbersItem-value"><%- labels[1] %></span>
+      </li>
+      <li class="Bubble-numbersItem CDB-Text CDB-Size-small" style="bottom: 100%">
+        <span class="Bubble-numbersItem-value"><%- labels[0] %></span>
+      </li>
     <% } else { %>
       <% for (var i = 0; i<labels.length; i++) { %>
-        <li class="Bubble-numbersItem CDB-Text CDB-Size-small" style="bottom: <%- labelPositions[i] %>%"><%= formatter.formatNumber(labels[i]) %></li>
+        <li class="Bubble-numbersItem CDB-Text CDB-Size-small" style="bottom: <%- labelPositions[i] %>%">
+          <span class="Bubble-numbersItem-value"><%= formatter.formatNumber(labels[i]) %></span>
+        </li>
       <% } %>
     <% } %>
   </ul>

--- a/src/vis/vis-view.js
+++ b/src/vis/vis-view.js
@@ -66,6 +66,17 @@ var Vis = View.extend({
     });
 
     this.$el.append(this._legendsView.render().$el);
+
+    var embedLegends = $('.js-embed-legends');
+
+    if (embedLegends.length) {
+      this._embedLegendsView = new LegendsView({
+        layersCollection: this.model.map.layers,
+        settingsModel: this.settingsModel
+      });
+
+      embedLegends.append(this._embedLegendsView.render().$el);
+    }
   },
 
   _cleanLegendsView: function () {

--- a/src/vis/vis-view.js
+++ b/src/vis/vis-view.js
@@ -66,6 +66,7 @@ var Vis = View.extend({
     });
 
     this.$el.append(this._legendsView.render().$el);
+    this.addView(this._legendsView);
 
     var embedLegends = $('.js-embed-legends');
 
@@ -76,6 +77,7 @@ var Vis = View.extend({
       });
 
       embedLegends.append(this._embedLegendsView.render().$el);
+      this.addView(this._embedLegendsView);
     }
   },
 

--- a/test/spec/geo/ui/legends/bubble/legend-view.spec.js
+++ b/test/spec/geo/ui/legends/bubble/legend-view.spec.js
@@ -77,9 +77,9 @@ describe('geo/ui/legends/bubbles/legend-view.js', function () {
 
     it('should render custom labels properly', function () {
       this.model.set('topLabel', 'foo');
-      expect(this.legendView.$('.Bubble-numbersItem').length).toBe(2);
-      expect(this.legendView.$('.Bubble-numbersItem').eq(0).text()).toBe('');
-      expect(this.legendView.$('.Bubble-numbersItem').eq(1).text()).toBe('foo');
+      expect(this.legendView.$('.Bubble-numbersItem-value').length).toBe(2);
+      expect(this.legendView.$('.Bubble-numbersItem-value').eq(0).text()).toBe('');
+      expect(this.legendView.$('.Bubble-numbersItem-value').eq(1).text()).toBe('foo');
       expect(this.legendView.$('.Bubble-average').text()).toMatch(/^\s+$/);
     });
   });

--- a/test/spec/geo/ui/legends/bubble/legend-view.spec.js
+++ b/test/spec/geo/ui/legends/bubble/legend-view.spec.js
@@ -39,7 +39,7 @@ describe('geo/ui/legends/bubbles/legend-view.js', function () {
     });
 
     it('should render bubbles', function () {
-      expect(this.legendView.$('.js-bubbleItem').length).toBe(3);
+      expect(this.legendView.$('.js-bubbleItem').length).toBe(4);
       expect(this.legendView._calculateBubbleSizes()).toEqual([100, 50, 25]);
     });
 
@@ -77,10 +77,9 @@ describe('geo/ui/legends/bubbles/legend-view.js', function () {
 
     it('should render custom labels properly', function () {
       this.model.set('topLabel', 'foo');
-      expect(this.legendView.$('.Bubble-numbersItem-value').length).toBe(2);
-      expect(this.legendView.$('.Bubble-numbersItem-value').eq(0).text()).toBe('');
-      expect(this.legendView.$('.Bubble-numbersItem-value').eq(1).text()).toBe('foo');
-      expect(this.legendView.$('.Bubble-average').text()).toMatch(/^\s+$/);
+      expect(this.legendView.$('.Bubble-numbersItem').length).toBe(1);
+      expect(this.legendView.$('.Bubble-numbersItem').eq(0).text()).toBe('foo');
+      expect(this.legendView.$('.Bubble-average').length).toBe(0);
     });
   });
 });

--- a/themes/scss/map/_attributions.scss
+++ b/themes/scss/map/_attributions.scss
@@ -14,10 +14,12 @@ $size: 20px;
   font-family: 'Open Sans';
   line-height: $size;
   z-index: 10;
+
+  &.is-active {
+    width: auto;
+  }
 }
-.CDB-Attribution.is-active {
-  width: auto;
-}
+
 .CDB-Attribution.is-active .CDB-Attribution-text {
   @include flex(1);
   width: auto;
@@ -37,10 +39,16 @@ $size: 20px;
   line-height: 32px;
   vertical-align: middle;
   z-index: 1;
+
+  &.is-disabled {
+    opacity: 0.24;
+  }
+
+  &:hover {
+    background: rgba($cBlue, 0.08);
+  }
 }
-.CDB-Attribution-button.is-disabled {
-  opacity: 0.24;
-}
+
 .CDB-Attribution-text {
   @include transition(opacity, 150ms);
   width: 0;
@@ -53,6 +61,7 @@ $size: 20px;
   line-height: 16px;
   overflow: hidden;
 }
+
 .CDB-Attribution .CDB-Attribution-text a {
   color: #139BFC;
   text-decoration: underline;

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -353,16 +353,16 @@ $maxLegendContainerHeight: 300px;
   position: relative;
   margin-bottom: 5px;
 
-  &:before {
+  &::before {
     position: absolute;
     top: 7px;
     left: 0;
-    height: 1px;
     width: calc(100% - 74px);
+    height: 1px;
+    transform: translate3d(24px, 0, 0);
     background: rgba(0, 0, 0, 0.08);
     content: ' ';
     z-index: 0;
-    transform: translate3d(24px, 0, 0);
   }
 
   &:last-of-type {

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -369,7 +369,7 @@ $maxLegendContainerHeight: 300px;
     left: 0;
     width: 100%;
     height: 1px;
-    background: rgba(0, 0, 0, 0.08);
+    background: rgba(#000, 0.08);
     content: '';
     z-index: -1;
   }
@@ -384,7 +384,7 @@ $maxLegendContainerHeight: 300px;
   display: inline-block;
   padding-right: 5px;
   transform: translate3d(0, -50%, 0);
-  background: rgba(255, 255, 255, 0.8);
+  background: rgba(#FFF, 0.8);
 }
 
 .Bubble-average {

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -13,7 +13,7 @@ $buttonColor: #636D72;
   z-index: 11;
   pointer-events: none;
 
-  & > * {
+  > * {
     pointer-events: all;
   }
 }

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -364,13 +364,13 @@ $maxLegendContainerHeight: 300px;
   width: calc(100% - 50px);
 
   &::after {
-    content: '';
-    left: 0;
     position: absolute;
+    top: -1px;
+    left: 0;
     width: 100%;
     height: 1px;
     background: rgba(0, 0, 0, 0.08);
-    top: -1px;
+    content: '';
     z-index: -1;
   }
 }

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -316,9 +316,8 @@ $maxLegendContainerHeight: 300px;
 }
 
 .Bubble-list {
-  position: relative;
-  width: 100px;
-  height: 100px;
+  width: 100%;
+  height: 100%;
 }
 
 .Bubble-item {
@@ -330,11 +329,9 @@ $maxLegendContainerHeight: 300px;
 }
 
 .Bubble-container {
-  @include display-flex();
-  max-height: 100px;
-  padding-top: 10px;
-  padding-bottom: 8px;
+  position: relative;
 }
+
 .Bubble-itemCircle {
   display: block;
   position: relative;
@@ -352,44 +349,33 @@ $maxLegendContainerHeight: 300px;
   visibility: hidden;
 }
 
-.Bubble-numbers {
-  position: relative;
-  width: 100%;
-}
-
 .Bubble-numbersItem {
-  position: absolute;
-  width: 100%;
-  margin-bottom: -6px;
-  padding-right: $baseSize * 2;
-  z-index: 10;
+  position: relative;
+  margin-bottom: 5px;
 
-  &:last-child {
-    background: #FFF;
-  }
-
-  &::after {
+  &:before {
     position: absolute;
-    bottom: 5px;
+    top: 7px;
     left: 0;
-    width: calc(100% + 35px);
     height: 1px;
+    width: calc(100% - 74px);
     background: rgba(0, 0, 0, 0.08);
-    content: '';
-    visibility: visible;
-    z-index: -1;
+    content: ' ';
+    z-index: 0;
+    transform: translate3d(24px, 0, 0);
   }
-}
 
-.Bubble-numbersItem-value {
-  padding-right: 8px;
-  background: #FFF;
+  &:last-of-type {
+    top: 7px;
+  }
 }
 
 .Bubble-inner {
-  @include display-flex();
-  position: relative;
-  width: 100%;
+  position: absolute;
+  top: 7px;
+  right: 0;
+  width: 100px;
+  height: 100px;
 }
 
 .Bubble-average {

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -123,8 +123,8 @@ $buttonColor: #636D72;
     }
 
     &::after {
-      left: 17px;
       bottom: 10px;
+      left: 17px;
       background: #636D72;
     }
 
@@ -149,8 +149,8 @@ $buttonColor: #636D72;
     }
 
     .CDB-Search-text {
-      visibility: visible;
       opacity: 1;
+      visibility: visible;
     }
   }
 }
@@ -167,15 +167,15 @@ $buttonColor: #636D72;
   }
 }
 .CDB-Search-text {
-  transition: all 150ms ease-in;
   width: 100px;
-  visibility: hidden;
   padding: 0 0 0 8px;
+  transition: all 150ms ease-in;
   border: 0;
   border-left: 1px solid #F8F8F8;
   background: none;
   font: 12px/16px 'Open Sans';
   opacity: 0;
+  visibility: hidden;
 
   &:focus {
     outline: none;

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -348,10 +348,10 @@ $maxLegendContainerHeight: 300px;
 
 .Bubble-numbersItem {
   position: absolute;
+  width: 100%;
   margin-bottom: -6px;
   padding-right: $baseSize * 2;
   z-index: 10;
-  width: 100%;
 
   &:last-child {
     background: #FFF;
@@ -360,19 +360,19 @@ $maxLegendContainerHeight: 300px;
   &::after {
     position: absolute;
     bottom: 5px;
+    left: 0;
     width: calc(100% + 35px);
     height: 1px;
     background: rgba(0, 0, 0, 0.08);
     content: '';
     visibility: visible;
     z-index: -1;
-    left: 0;
   }
 }
 
 .Bubble-numbersItem-value {
   padding-right: 8px;
-  background: white;
+  background: #fff;
 }
 
 .Bubble-inner {

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -317,24 +317,38 @@ $maxLegendContainerHeight: 300px;
 
 .Bubble-list {
   width: 100%;
-  height: 100%;
+  height: 100px;
 }
 
 .Bubble-item {
-  @include opacity(0.5);
-  @include transform(translateX(-50%));
   position: absolute;
-  bottom: 0;
-  left: 50%;
+  width: 100%;
+  height: 100px;
 }
 
 .Bubble-container {
   position: relative;
+  margin-top: 10px;
+  top: 7px;
+  right: 0;
+  width: 100%;
+  height: 100px;
+}
+
+.Bubble-circle {
+  @include opacity(0.5);
+  position: absolute;
+  right: 0;
+  width: 100px;
+  height: 100%;
 }
 
 .Bubble-itemCircle {
   display: block;
-  position: relative;
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translate3d(-50%, 0, 0);
   width: 100%;
   height: 100%;
   border: 1px solid rgba(0, 0, 0, 0.1);
@@ -344,45 +358,40 @@ $maxLegendContainerHeight: 300px;
   pointer-events: none;
 }
 
+.Bubble-label {
+  position: absolute;
+  bottom: 0;
+  width: calc(100% - 50px);
+
+  &:after {
+    content: "";
+    left: 0;
+    position: absolute;
+    width: 100%;
+    height: 1px;
+    background: rgba(0, 0, 0, 0.08);
+    top: -1px;
+    z-index: -1;
+  }
+}
+
 .Bubble-list--custom::before,
 .Bubble-item--custom::before {
   visibility: hidden;
 }
 
 .Bubble-numbersItem {
-  position: relative;
-  margin-bottom: 5px;
-
-  &::before {
-    position: absolute;
-    top: 7px;
-    left: 0;
-    width: calc(100% - 74px);
-    height: 1px;
-    transform: translate3d(24px, 0, 0);
-    background: rgba(0, 0, 0, 0.08);
-    content: ' ';
-    z-index: 0;
-  }
-
-  &:last-of-type {
-    top: 7px;
-  }
-}
-
-.Bubble-inner {
-  position: absolute;
-  top: 7px;
-  right: 0;
-  width: 100px;
-  height: 100px;
+  display: inline-block;
+  background: rgba(255, 255, 255, 0.8);
+  transform: translate3d(0, -50%, 0);
+  padding-right: 5px;
 }
 
 .Bubble-average {
   @include transform(translateY(50%));
   display: block;
   position: absolute;
-  right: 105px;
+  right: 102px;
   white-space: nowrap;
   z-index: 1000;
 }

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -316,8 +316,6 @@ $maxLegendContainerHeight: 300px;
 }
 
 .Bubble-list {
-  @include display-flex();
-  @include justify-content(center);
   position: relative;
   width: 100px;
   height: 100px;

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -113,6 +113,9 @@ $buttonColor: #636D72;
   margin-right: 8px;
 
   .CDB-Shape-magnify {
+    width: 32px;
+    height: 32px;
+
     &::before {
       top: 11px;
       left: 10px;
@@ -120,9 +123,13 @@ $buttonColor: #636D72;
     }
 
     &::after {
-      right: 13px;
+      left: 17px;
       bottom: 10px;
       background: #636D72;
+    }
+
+    .is-small::after {
+      left: 17px;
     }
   }
 }
@@ -130,8 +137,6 @@ $buttonColor: #636D72;
 .CDB-Search-inner {
   @include transition(width, 100ms ease-in);
   display: flex;
-  align-items: center;
-  justify-content: center;
   width: 32px;
   height: 100%;
   overflow: hidden;
@@ -148,7 +153,7 @@ $buttonColor: #636D72;
     }
 
     .CDB-Search-text {
-      display: block;
+      visibility: visible;
       opacity: 1;
     }
   }
@@ -160,9 +165,9 @@ $buttonColor: #636D72;
   color: $buttonColor;
 }
 .CDB-Search-text {
-  @include transition(opacity, 150ms ease-in);
-  display: none;
+  transition: all 150ms ease-in;
   width: 100px;
+  visibility: hidden;
   padding: 0 0 0 8px;
   border: 0;
   border-left: 1px solid #F8F8F8;

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -328,11 +328,11 @@ $maxLegendContainerHeight: 300px;
 
 .Bubble-container {
   position: relative;
-  margin-top: 10px;
   top: 7px;
   right: 0;
   width: 100%;
   height: 100px;
+  margin-top: 10px;
 }
 
 .Bubble-circle {
@@ -348,9 +348,9 @@ $maxLegendContainerHeight: 300px;
   position: absolute;
   bottom: 0;
   left: 50%;
-  transform: translate3d(-50%, 0, 0);
   width: 100%;
   height: 100%;
+  transform: translate3d(-50%, 0, 0);
   border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 50%;
   background: #F8AB17;
@@ -363,8 +363,8 @@ $maxLegendContainerHeight: 300px;
   bottom: 0;
   width: calc(100% - 50px);
 
-  &:after {
-    content: "";
+  &::after {
+    content: '';
     left: 0;
     position: absolute;
     width: 100%;
@@ -382,9 +382,9 @@ $maxLegendContainerHeight: 300px;
 
 .Bubble-numbersItem {
   display: inline-block;
-  background: rgba(255, 255, 255, 0.8);
-  transform: translate3d(0, -50%, 0);
   padding-right: 5px;
+  transform: translate3d(0, -50%, 0);
+  background: rgba(255, 255, 255, 0.8);
 }
 
 .Bubble-average {

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -372,7 +372,7 @@ $maxLegendContainerHeight: 300px;
 
 .Bubble-numbersItem-value {
   padding-right: 8px;
-  background: #fff;
+  background: #FFF;
 }
 
 .Bubble-inner {

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -141,10 +141,6 @@ $buttonColor: #636D72;
   height: 100%;
   overflow: hidden;
 
-  &:hover {
-    background: rgba($cBlue, 0.08);
-  }
-
   &.is-active {
     width: 152px;
 
@@ -163,6 +159,12 @@ $buttonColor: #636D72;
   width: 32px;
   height: 32px;
   color: $buttonColor;
+
+  &:hover {
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+    background: rgba($cBlue, 0.08);
+  }
 }
 .CDB-Search-text {
   transition: all 150ms ease-in;

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -11,6 +11,11 @@ $buttonColor: #636D72;
   left: 16px;
   align-items: center;
   z-index: 11;
+  pointer-events: none;
+
+  & > * {
+    pointer-events: all;
+  }
 }
 
 // zoom overlay

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -389,6 +389,7 @@ $maxLegendContainerHeight: 300px;
 .Bubble-inner {
   @include display-flex();
   position: relative;
+  width: 100%;
 }
 
 .Bubble-average {

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -517,3 +517,11 @@ $maxLegendContainerHeight: 300px;
     display: none;
   }
 }
+
+@media (max-width: 425px) {
+  .CDB-Logo {
+    right: 0;
+    left: initial;
+    transform: initial;
+  }
+}

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -131,6 +131,7 @@ $buttonColor: #636D72;
   @include transition(width, 100ms ease-in);
   display: flex;
   align-items: center;
+  justify-content: center;
   width: 32px;
   height: 100%;
   overflow: hidden;

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -309,16 +309,7 @@ $maxLegendContainerHeight: 300px;
   width: 100px;
   height: 100px;
 }
-.Bubble-list::before {
-  position: absolute;
-  right: 50%;
-  bottom: 0;
-  width: 140px;
-  height: 1px;
-  background: rgba(0, 0, 0, 0.08);
-  content: '';
-  visibility: visible;
-}
+
 .Bubble-item {
   @include opacity(0.5);
   @include transform(translateX(-50%));
@@ -330,7 +321,7 @@ $maxLegendContainerHeight: 300px;
 .Bubble-container {
   @include display-flex();
   max-height: 100px;
-  padding-top: 3px;
+  padding-top: 10px;
   padding-bottom: 8px;
 }
 .Bubble-itemCircle {
@@ -344,36 +335,51 @@ $maxLegendContainerHeight: 300px;
   box-shadow: -1px 0 2px 0 rgba(0, 0, 0, 0.1);
   pointer-events: none;
 }
-.Bubble-item::before {
-  position: absolute;
-  top: 5px;
-  right: 50%;
-  width: 140px;
-  height: 1px;
-  background: rgba(0, 0, 0, 0.08);
-  content: '';
-}
+
 .Bubble-list--custom::before,
 .Bubble-item--custom::before {
   visibility: hidden;
 }
+
 .Bubble-numbers {
   position: relative;
+  width: 100%;
 }
+
 .Bubble-numbersItem {
   position: absolute;
-  margin-bottom: -11px; /* to review */
+  margin-bottom: -6px;
   padding-right: $baseSize * 2;
-  background: rgba(#FFF, 0.8);
   z-index: 10;
+  width: 100%;
+
   &:last-child {
     background: #FFF;
   }
+
+  &::after {
+    position: absolute;
+    bottom: 5px;
+    width: calc(100% + 35px);
+    height: 1px;
+    background: rgba(0, 0, 0, 0.08);
+    content: '';
+    visibility: visible;
+    z-index: -1;
+    left: 0;
+  }
 }
+
+.Bubble-numbersItem-value {
+  padding-right: 8px;
+  background: white;
+}
+
 .Bubble-inner {
   @include display-flex();
   position: relative;
 }
+
 .Bubble-average {
   @include transform(translateY(50%));
   display: block;
@@ -382,6 +388,7 @@ $maxLegendContainerHeight: 300px;
   white-space: nowrap;
   z-index: 1000;
 }
+
 .Bubble-average::after {
   display: block;
   position: absolute;


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/13393

This PR renders the legends view outside of Carto.js views if the class `js-embed-legends` is found, not the best approach but works for now until we create a public API for legends in v4

Extras
------

- Fix "Allow hover on map elements beneath CDB-OverlayContainer". https://github.com/CartoDB/cartodb/issues/13341