### PR TITLE
Remove category value stringify

### DIFF
--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -225,8 +225,7 @@ module.exports = DataviewModelBase.extend({
     var acceptedCategoryNames = [];
 
     _.each(allNewCategories, function (datum) {
-      // Category might be a non-string type (e.g. number), make sure it's always a string for concistency
-      var category = String(datum.category);
+      var category = datum.category;
 
       allNewCategoryNames.push(category);
       var isRejected = this.filter.isRejected(category);

--- a/test/spec/dataviews/category-dataview-model.spec.js
+++ b/test/spec/dataviews/category-dataview-model.spec.js
@@ -272,19 +272,6 @@ describe('dataviews/category-dataview-model', function () {
       expect(resetSpy).toHaveBeenCalled();
     });
 
-    it('should cast any category value to string', function () {
-      _parseData(this.model, _.map([null, undefined, 0, 'hello', false], function (v) {
-        return {
-          category: v,
-          value: 1
-        };
-      }));
-      var areNamesString = _.every(this.model.get('data'), function (obj) {
-        return obj.name;
-      });
-      expect(areNamesString).toBeTruthy();
-    });
-
     describe('when filter is disabled', function () {
       it('should NOT add categories that are accepted when they are not present in the new categories', function () {
         this.model.filter.accept('Madrid');


### PR DESCRIPTION
We need to remove the category stringification to distinguish between numeric categories and string categories that contains numbers.