### PR TITLE
Override scrollwheel if it's boolean

### DIFF
--- a/src/api/create-vis.js
+++ b/src/api/create-vis.js
@@ -109,7 +109,7 @@ var loadVizJSON = function (el, visModel, vizjsonData, options) {
 
 var applyOptionsToVizJSON = function (vizjson, options) {
   vizjson.options = vizjson.options || {};
-  vizjson.options.scrollwheel = options.scrollwheel || vizjson.options.scrollwheel;
+  vizjson.options.scrollwheel = _.isBoolean(options.scrollwheel) ? options.scrollwheel : vizjson.options.scrollwheel;
 
   if (!options.tiles_loader || !options.loaderControl) {
     vizjson.removeLoaderOverlay();


### PR DESCRIPTION
When migrating the dashboard to builder (which uses cartodb.js v4 now) we found a problem with the `user feed` view, where you could scroll the map with the trackpad/mouse wheel. I've found out it was because of this:

```
vizjson.options.scrollwheel = options.scrollwheel || vizjson.options.scrollwheel;
```

In the `vizjson` the option is true, and why are trying to override it with `false`, which is impossible using an `||`.