### PR TITLE
Define layers order

### DIFF
--- a/examples/examples.json
+++ b/examples/examples.json
@@ -40,6 +40,14 @@
             "leaflet": "public/layers/change-style-leaflet.html",
             "gmaps": "public/layers/change-style-gmaps.html"
           }
+        },
+        {
+          "title": "Move the layers",
+          "desc": "Update the order of your layers",
+          "file": {
+            "leaflet": "public/layers/change-order-leaflet.html",
+            "gmaps": "public/layers/change-order-gmaps.html"
+          }
         }
       ]
     },

--- a/examples/public/layers/change-order-gmaps.html
+++ b/examples/public/layers/change-order-gmaps.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Change order | CARTO</title>
+    <meta name="viewport" content="initial-scale=1.0">
+    <meta charset="utf-8">
+    <!-- Include Google Maps -->
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <!-- Include CARTO.js -->
+    <script src="../../../dist/public/carto.js"></script>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body, *{ margin: 0; padding: 0; }
+      #map {
+        position: absolute;
+        height: 100%;
+        width: 100%;
+        z-index: 0;
+      }
+      #controls {
+        position: absolute;
+        padding: 20px;
+        background: white;
+        top: 12px;
+        right: 12px;
+        box-shadow: 0 0 16px rgba(0, 0, 0, 0.12);
+        border-radius: 4px;
+        width: 200px;
+        color: #2E3C43;
+        z-index: 2;
+      }
+      #controls li {
+        list-style-type: none;
+        margin: 0 0 8px 0;
+        display: flex;
+        vertical-align: middle;
+      }
+      #controls li input {
+        margin: 0 8px 0 0;
+      }
+      #controls li label {
+        font: 12px/16px 'Open Sans';
+        cursor: pointer;
+      }
+      #controls li:last-child {
+        margin-bottom: 0;
+      }
+      #controls li:hover {
+        cursor: pointer;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="map"></div>
+    <div id="controls">
+      <ul>
+        <li onclick="bringToBack()">
+          <input type="radio" name="style" id="bringToBack">
+          <label for="bringToBack">Bring to back</label>
+        </li>
+        <li onclick="bringToFront()">
+          <input type="radio" name="style" checked id="bringToFront">
+          <label for="bringToFront">Bring to front</label>
+        </li>
+      </ul>
+    </div>
+    <script>
+      const map = new google.maps.Map(document.getElementById('map'), {
+        center: {lat: 30, lng: 0},
+        zoom: 3
+      });
+      // Hide the map labels and geometry strokes
+      map.set('styles', [{
+        elementType: 'labels',
+        stylers: [{ visibility: 'off' }]
+      }, {
+        elementType: 'geometry.stroke',
+        stylers: [{ visibility: 'off' }]
+      }]);
+
+      const client = new carto.Client({
+        apiKey: 'YOUR_API_KEY',
+        username: 'cartojs-test'
+      });
+
+      const spainCitiesSource = new carto.source.Dataset(`
+        ne_10m_populated_places_simple
+      `);
+      const spainCitiesStyle = new carto.style.CartoCSS(`
+        #layer {
+          marker-width: 7;
+          marker-fill: #EE4D5A;
+          marker-line-color: #FFFFFF;
+        }
+      `);
+      const spainCitiesLayer = new carto.layer.Layer(spainCitiesSource, spainCitiesStyle);
+
+      const europeCountriesSource = new carto.source.Dataset(`
+        ne_adm0_europe
+      `);
+      const europeCountriesStyle = new carto.style.CartoCSS(`
+        #layer {
+          polygon-fill: #826DBA;
+          polygon-opacity: 0.8;
+          ::outline {
+            line-width: 1;
+            line-color: #FFFFFF;
+            line-opacity: 0.8;
+          }
+        }
+      `);
+      const europeCountriesLayer = new carto.layer.Layer(europeCountriesSource, europeCountriesStyle);
+
+      client.addLayers([europeCountriesLayer, spainCitiesLayer]);
+      map.overlayMapTypes.push(client.getGoogleMapsMapType(map));
+
+      function bringToBack() {
+        spainCitiesLayer.bringToBack();
+        // or
+        // spainCitiesLayer.setOrder(0);
+        // or
+        // client.moveLayer(spainCitiesLayer, 0);
+      }
+
+      function bringToFront() {
+        spainCitiesLayer.bringToFront();
+        // or
+        // spainCitiesLayer.setOrder(1);
+        // // or
+        // client.moveLayer(spainCitiesLayer, 1);
+      }
+    </script>
+  </body>
+</html>

--- a/examples/public/layers/change-order-leaflet.html
+++ b/examples/public/layers/change-order-leaflet.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Change order | CARTO</title>
+    <meta name="viewport" content="initial-scale=1.0">
+    <meta charset="utf-8">
+    <!-- Include Leaflet -->
+    <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet.js"></script>
+    <link href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" rel="stylesheet">
+    <!-- Include CARTO.js -->
+    <script src="../../../dist/public/carto.js"></script>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body, *{ margin: 0; padding: 0; }
+      #map {
+        position: absolute;
+        height: 100%;
+        width: 100%;
+        z-index: 0;
+      }
+      #controls {
+        position: absolute;
+        padding: 20px;
+        background: white;
+        top: 12px;
+        right: 12px;
+        box-shadow: 0 0 16px rgba(0, 0, 0, 0.12);
+        border-radius: 4px;
+        width: 200px;
+        color: #2E3C43;
+        z-index: 2;
+      }
+      #controls li {
+        list-style-type: none;
+        margin: 0 0 8px 0;
+        display: flex;
+        vertical-align: middle;
+      }
+      #controls li input {
+        margin: 0 8px 0 0;
+      }
+      #controls li label {
+        font: 12px/16px 'Open Sans';
+        cursor: pointer;
+      }
+      #controls li:last-child {
+        margin-bottom: 0;
+      }
+      #controls li:hover {
+        cursor: pointer;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="map"></div>
+    <div id="controls">
+      <ul>
+        <li onclick="bringToBack()">
+          <input type="radio" name="style" id="bringToBack">
+          <label for="bringToBack">Bring to back</label>
+        </li>
+        <li onclick="bringToFront()">
+          <input type="radio" name="style" checked id="bringToFront">
+          <label for="bringToFront">Bring to front</label>
+        </li>
+      </ul>
+    </div>
+    <script>
+      const map = L.map('map').setView([30, 0], 3);
+
+      L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager_nolabels/{z}/{x}/{y}.png', {
+        maxZoom: 18
+      }).addTo(map);
+
+      const client = new carto.Client({
+        apiKey: 'YOUR_API_KEY',
+        username: 'cartojs-test'
+      });
+
+      const spainCitiesSource = new carto.source.Dataset(`
+        ne_10m_populated_places_simple
+      `);
+      const spainCitiesStyle = new carto.style.CartoCSS(`
+        #layer {
+          marker-width: 7;
+          marker-fill: #EE4D5A;
+          marker-line-color: #FFFFFF;
+        }
+      `);
+      const spainCitiesLayer = new carto.layer.Layer(spainCitiesSource, spainCitiesStyle);
+
+      const europeCountriesSource = new carto.source.Dataset(`
+        ne_adm0_europe
+      `);
+      const europeCountriesStyle = new carto.style.CartoCSS(`
+        #layer {
+          polygon-fill: #826DBA;
+          polygon-opacity: 0.8;
+          ::outline {
+            line-width: 1;
+            line-color: #FFFFFF;
+            line-opacity: 0.8;
+          }
+        }
+      `);
+      const europeCountriesLayer = new carto.layer.Layer(europeCountriesSource, europeCountriesStyle);
+
+      client.addLayers([europeCountriesLayer, spainCitiesLayer]);
+      client.getLeafletLayer().addTo(map);
+
+      function bringToBack() {
+        spainCitiesLayer.bringToBack();
+        // or
+        // spainCitiesLayer.setOrder(0);
+        // or
+        // client.moveLayer(spainCitiesLayer, 0);
+      }
+
+      function bringToFront() {
+        spainCitiesLayer.bringToFront();
+        // or
+        // spainCitiesLayer.setOrder(1);
+        // // or
+        // client.moveLayer(spainCitiesLayer, 1);
+      }
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
   },
   "scripts": {
     "test": "grunt test",
+    "test:browser": "grunt dev",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "build": "rm -rf dist/public; webpack --config webpack/webpack.config.js && webpack --config webpack/webpack.min.config.js",

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -165,7 +165,7 @@ Client.prototype.removeLayers = function (layers) {
  * // Move layer order
  * client.moveLayer(layer1, 0)
  * .then(() => {
- *  console.log('Layers removed');
+ *  console.log('Layer moved');
  * })
  * .catch(cartoError => {
  *  console.error(cartoError.message);

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -346,8 +346,6 @@ Client.prototype.getLeafletLayer = function () {
  * @api
  */
 Client.prototype.getGoogleMapsMapType = function (map) {
-  // NOTE: the map is required here because of wax.g.connector
-
   // Check if Google Maps is loaded
   _isGoogleMapsLoaded();
   if (!this._gmapsMapType) {

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -159,6 +159,34 @@ Client.prototype.removeLayers = function (layers) {
 };
 
 /**
+ * Move layer order.
+ *
+ * @example
+ * // Move layer order
+ * client.moveLayer(layer1, 0)
+ * .then(() => {
+ *  console.log('Layers removed');
+ * })
+ * .catch(cartoError => {
+ *  console.error(cartoError.message);
+ * });
+ *
+ *
+ * @param {carto.layer.Base} - The layer to be moved
+ * @param {number} toIndex - Final index for the layer
+ *
+ * @fires error
+ * @fires success
+ *
+ * @returns {Promise} A promise that will be fulfilled when the layer is moved
+ * @api
+ */
+Client.prototype.moveLayer = function (layer, toIndex) {
+  this._moveLayer(layer, toIndex);
+  return this._reload();
+};
+
+/**
  * Get all the {@link carto.layer.Base|layers} from the client.
  *
  * @example
@@ -352,11 +380,23 @@ Client.prototype._addLayer = function (layer, engine) {
 
 /**
  * Helper used to remove a layer from the client.
+ * @private
  */
 Client.prototype._removeLayer = function (layer) {
   _checkLayer(layer);
   this._layers.remove(layer);
   this._engine.removeLayer(layer.$getInternalModel());
+};
+
+/**
+ * Helper used to remove a layer from the client.
+ * @private
+ */
+Client.prototype._moveLayer = function (layer, toIndex) {
+  _checkLayer(layer);
+  _checkLayerIndex(toIndex, this._layers.length());
+  this._layers.move(layer, toIndex);
+  this._engine.moveLayer(layer.$getInternalModel(), toIndex);
 };
 
 /**
@@ -389,7 +429,7 @@ Client.prototype._bindEngine = function (engine) {
 
 /**
  * Check if some layer in the client has the same id.
- * @param {carto.layer.Base} layer 
+ * @param {carto.layer.Base} layer
  */
 Client.prototype._checkDuplicatedLayerId = function (layer) {
   if (this._layers.findById(layer.getId())) {
@@ -403,6 +443,15 @@ Client.prototype._checkDuplicatedLayerId = function (layer) {
 function _checkLayer (layer) {
   if (!(layer instanceof LayerBase)) {
     throw getValidationError('badLayerType');
+  }
+}
+
+function _checkLayerIndex (index, length) {
+  if (!_.isNumber(index)) {
+    throw getValidationError('indexNumber');
+  }
+  if (index < 0 || index >= length) {
+    throw getValidationError('indexOutOfRange');
   }
 }
 

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -182,8 +182,13 @@ Client.prototype.removeLayers = function (layers) {
  * @api
  */
 Client.prototype.moveLayer = function (layer, toIndex) {
+  var fromIndex = this._layers.indexOf(layer);
   this._moveLayer(layer, toIndex);
-  return this._reload();
+  if (fromIndex === toIndex) {
+    return Promise.resolve();
+  } else {
+    return this._reload();
+  }
 };
 
 /**

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -374,6 +374,7 @@ Client.prototype._addLayer = function (layer, engine) {
   _checkLayer(layer);
   this._checkDuplicatedLayerId(layer);
   this._layers.add(layer);
+  layer.$setClient(this);
   layer.$setEngine(this._engine);
   this._engine.addLayer(layer.$getInternalModel());
 };
@@ -394,7 +395,7 @@ Client.prototype._removeLayer = function (layer) {
  */
 Client.prototype._moveLayer = function (layer, toIndex) {
   _checkLayer(layer);
-  _checkLayerIndex(toIndex, this._layers.length());
+  _checkLayerIndex(toIndex, this._layers.size());
   this._layers.move(layer, toIndex);
   this._engine.moveLayer(layer.$getInternalModel(), toIndex);
 };
@@ -446,11 +447,11 @@ function _checkLayer (layer) {
   }
 }
 
-function _checkLayerIndex (index, length) {
+function _checkLayerIndex (index, size) {
   if (!_.isNumber(index)) {
     throw getValidationError('indexNumber');
   }
-  if (index < 0 || index >= length) {
+  if (index < 0 || index >= size) {
     throw getValidationError('indexOutOfRange');
   }
 }

--- a/src/api/v4/error-handling/error-list/validation-errors.js
+++ b/src/api/v4/error-handling/error-list/validation-errors.js
@@ -58,6 +58,14 @@ module.exports = {
       messageRegex: /badLayerType/,
       friendlyMessage: 'The given object is not a layer.'
     },
+    'index-number': {
+      messageRegex: /indexNumber/,
+      friendlyMessage: 'index property must be a number.'
+    },
+    'index-out-of-range': {
+      messageRegex: /indexOutOfRange/,
+      friendlyMessage: 'index is out of range.'
+    },
     'api-key-required': {
       messageRegex: /apiKeyRequired/,
       friendlyMessage: 'apiKey property is required.'

--- a/src/api/v4/layer/layer.js
+++ b/src/api/v4/layer/layer.js
@@ -424,7 +424,9 @@ Layer.prototype._createInternalModel = function (engine) {
 // Internal functions.
 
 Layer.prototype.$setClient = function (client) {
-  if (this._client) {
+  // Exit if the client is already set or
+  // it has a different engine than the layer
+  if (this._client || (this._engine && client._engine !== this._engine)) {
     return;
   }
   this._client = client;

--- a/src/api/v4/layer/layer.js
+++ b/src/api/v4/layer/layer.js
@@ -70,6 +70,7 @@ function Layer (source, style, options) {
   _checkSource(source);
   _checkStyle(style);
 
+  this._client = undefined;
   this._engine = undefined;
   this._internalModel = undefined;
 
@@ -88,7 +89,7 @@ Layer.prototype = Object.create(Base.prototype);
 /**
  * Set a new style for this layer.
  *
- * @param {carto.style.CartoCSS} New style
+ * @param {carto.style.CartoCSS} style - New style
  * @fires styleChanged
  * @fires error
  * @return {Promise} A promise that will be fulfilled when the style is applied to the layer or rejected with a
@@ -140,7 +141,7 @@ Layer.prototype.getStyle = function () {
  * A source and a layer must belong to the same client so you can't
  * add a source belonging to a different client.
  *
- * @param {carto.source.Base} source New source
+ * @param {carto.source.Base} source - New source
  * @fires sourceChanged
  * @fires error
  * @return {Promise} A promise that will be fulfilled when the style is applied to the layer or rejected with a
@@ -190,8 +191,9 @@ Layer.prototype.getSource = function () {
 /**
  * Set new columns for featureClick events.
  *
- * @param {Array<string>} columns An array containing column names
- * @return {carto.layer.Layer} this
+ * @param {Array<string>} columns - An array containing column names
+ * @fires error
+ * @return {Promise}
  * @api
  */
 Layer.prototype.setFeatureClickColumns = function (columns) {
@@ -220,15 +222,16 @@ Layer.prototype.setFeatureClickColumns = function (columns) {
  * @return  {Array<string>} Column names available in featureClicked events
  * @api
  */
-Layer.prototype.getFeatureClickColumns = function (columns) {
+Layer.prototype.getFeatureClickColumns = function () {
   return this._featureClickColumns;
 };
 
 /**
  * Set new columns for featureOver events.
  *
- * @param {Array<string>} columns An array containing column names
- * @return {carto.layer.Layer} this
+ * @param {Array<string>} columns - An array containing column names
+ * @fires error
+ * @return {Promise}
  * @api
  */
 Layer.prototype.setFeatureOverColumns = function (columns) {
@@ -257,13 +260,14 @@ Layer.prototype.setFeatureOverColumns = function (columns) {
  * @return  {Array<string>} Column names available in featureOver events
  * @api
  */
-Layer.prototype.getFeatureOverColumns = function (columns) {
+Layer.prototype.getFeatureOverColumns = function () {
   return this._featureOverColumns;
 };
 
 /**
  * Hides the layer.
  *
+ * @fires visibilityChanged
  * @return {carto.layer.Layer} this
  * @api
  */
@@ -282,6 +286,7 @@ Layer.prototype.hide = function () {
 /**
  * Shows the layer.
  *
+ * @fires visibilityChanged
  * @return {carto.layer.Layer} this
  * @api
  */
@@ -300,6 +305,7 @@ Layer.prototype.show = function () {
 /**
  * Change the layer's visibility.
  *
+ * @fires visibilityChanged
  * @return {carto.layer.Layer} this
  */
 Layer.prototype.toggle = function () {
@@ -317,7 +323,7 @@ Layer.prototype.isVisible = function () {
 };
 
 /**
- * Return `true` if the layer is not visible and false when visible.
+ * Return true if the layer is not visible and false when visible.
  *
  * @return {boolean} - A boolean value indicating the layer's visibility
  * @api
@@ -326,8 +332,49 @@ Layer.prototype.isHidden = function () {
   return !this.isVisible();
 };
 
+/**
+ * Return true if the layer has interactivity.
+ *
+ * @return {boolean} - A boolean value indicating the layer's interactivity
+ * @api
+ */
 Layer.prototype.isInteractive = function () {
   return this.getFeatureClickColumns().length > 0 || this.getFeatureOverColumns().length > 0;
+};
+
+/**
+ * Set the layer's order.
+ *
+ * @param {number} index - new order index for the layer.
+ *
+ * @return {Promise}
+ * @api
+ */
+Layer.prototype.setOrder = function (index) {
+  if (!this._client) {
+    return Promise.resolve();
+  }
+  return this._client.moveLayer(this, index);
+};
+
+/**
+ * Move the layer to the back.
+ *
+ * @return {Promise}
+ * @api
+ */
+Layer.prototype.bringToBack = function () {
+  return this.setOrder(0);
+};
+
+/**
+ * Move the layer to the front.
+ *
+ * @return {Promise}
+ * @api
+ */
+Layer.prototype.bringToFront = function () {
+  return this.setOrder(this._client._layers.size() - 1);
 };
 
 // Private functions.
@@ -375,6 +422,13 @@ Layer.prototype._createInternalModel = function (engine) {
 };
 
 // Internal functions.
+
+Layer.prototype.$setClient = function (client) {
+  if (this._client) {
+    return;
+  }
+  this._client = client;
+};
 
 Layer.prototype.$setEngine = function (engine) {
   if (this._engine) {

--- a/src/api/v4/layers.js
+++ b/src/api/v4/layers.js
@@ -17,6 +17,10 @@ Layers.prototype.size = function () {
   return this._layers.length;
 };
 
+Layers.prototype.indexOf = function (layer) {
+  return this._layers.indexOf(layer);
+};
+
 Layers.prototype.contains = function (layer) {
   return this._layers.indexOf(layer) >= 0;
 };

--- a/src/api/v4/layers.js
+++ b/src/api/v4/layers.js
@@ -13,6 +13,10 @@ Layers.prototype.remove = function (layer) {
   return this._layers.splice(this._layers.indexOf(layer));
 };
 
+Layers.prototype.length = function () {
+  return this._layers.length;
+};
+
 Layers.prototype.contains = function (layer) {
   return this._layers.indexOf(layer) >= 0;
 };
@@ -25,6 +29,13 @@ Layers.prototype.findById = function (layerId) {
 
 Layers.prototype.toArray = function () {
   return this._layers;
+};
+
+Layers.prototype.move = function (layer, toIndex) {
+  var fromIndex = this._layers.indexOf(layer);
+  if (fromIndex >= 0 && fromIndex !== toIndex) {
+    this._layers.splice(toIndex, 0, this._layers.splice(fromIndex, 1)[0]);
+  }
 };
 
 module.exports = Layers;

--- a/src/api/v4/layers.js
+++ b/src/api/v4/layers.js
@@ -13,7 +13,7 @@ Layers.prototype.remove = function (layer) {
   return this._layers.splice(this._layers.indexOf(layer));
 };
 
-Layers.prototype.length = function () {
+Layers.prototype.size = function () {
   return this._layers.length;
 };
 

--- a/src/api/v4/native/google-maps-map-type.js
+++ b/src/api/v4/native/google-maps-map-type.js
@@ -33,7 +33,8 @@ GoogleMapsMapType.prototype.getTile = function (coord, zoom, ownerDocument) {
 };
 
 GoogleMapsMapType.prototype._onFeatureClick = function (internalEvent) {
-  triggerLayerFeatureEvent(Layer.events.FEATURE_CLICKED, internalEvent, this._layers);
+  var layer = this._layers.findById(internalEvent.layer.id);
+  triggerLayerFeatureEvent(Layer.events.FEATURE_CLICKED, layer);
 };
 
 GoogleMapsMapType.prototype._onFeatureOver = function (internalEvent) {
@@ -42,17 +43,18 @@ GoogleMapsMapType.prototype._onFeatureOver = function (internalEvent) {
     this._hoveredLayers[internalEvent.layerIndex] = true;
     this._map.setOptions({ draggableCursor: 'pointer' });
   }
-  triggerLayerFeatureEvent(Layer.events.FEATURE_OVER, internalEvent, this._layers);
+  triggerLayerFeatureEvent(Layer.events.FEATURE_OVER, layer);
 };
 
 GoogleMapsMapType.prototype._onFeatureOut = function (internalEvent) {
+  var layer = this._layers.findById(internalEvent.layer.id);
   this._hoveredLayers[internalEvent.layerIndex] = false;
   if (_.any(this._hoveredLayers)) {
     this._map.setOptions({ draggableCursor: 'pointer' });
   } else {
     this._map.setOptions({ draggableCursor: 'auto' });
   }
-  triggerLayerFeatureEvent(Layer.events.FEATURE_OUT, internalEvent, this._layers);
+  triggerLayerFeatureEvent(Layer.events.FEATURE_OUT, layer);
 };
 
 GoogleMapsMapType.prototype._onFeatureError = function (error) {

--- a/src/api/v4/native/google-maps-map-type.js
+++ b/src/api/v4/native/google-maps-map-type.js
@@ -34,7 +34,7 @@ GoogleMapsMapType.prototype.getTile = function (coord, zoom, ownerDocument) {
 
 GoogleMapsMapType.prototype._onFeatureClick = function (internalEvent) {
   var layer = this._layers.findById(internalEvent.layer.id);
-  triggerLayerFeatureEvent(Layer.events.FEATURE_CLICKED, layer);
+  triggerLayerFeatureEvent(Layer.events.FEATURE_CLICKED, internalEvent, layer);
 };
 
 GoogleMapsMapType.prototype._onFeatureOver = function (internalEvent) {
@@ -43,7 +43,7 @@ GoogleMapsMapType.prototype._onFeatureOver = function (internalEvent) {
     this._hoveredLayers[internalEvent.layerIndex] = true;
     this._map.setOptions({ draggableCursor: 'pointer' });
   }
-  triggerLayerFeatureEvent(Layer.events.FEATURE_OVER, layer);
+  triggerLayerFeatureEvent(Layer.events.FEATURE_OVER, internalEvent, layer);
 };
 
 GoogleMapsMapType.prototype._onFeatureOut = function (internalEvent) {
@@ -54,7 +54,7 @@ GoogleMapsMapType.prototype._onFeatureOut = function (internalEvent) {
   } else {
     this._map.setOptions({ draggableCursor: 'auto' });
   }
-  triggerLayerFeatureEvent(Layer.events.FEATURE_OUT, layer);
+  triggerLayerFeatureEvent(Layer.events.FEATURE_OUT, internalEvent, layer);
 };
 
 GoogleMapsMapType.prototype._onFeatureError = function (error) {

--- a/src/api/v4/native/leaflet-layer.js
+++ b/src/api/v4/native/leaflet-layer.js
@@ -68,7 +68,8 @@ var LeafletLayer = L.TileLayer.extend({
   },
 
   _onFeatureClick: function (internalEvent) {
-    triggerLayerFeatureEvent(Layer.events.FEATURE_CLICKED, internalEvent, this._layers);
+    var layer = this._layers.findById(internalEvent.layer.id);
+    triggerLayerFeatureEvent(Layer.events.FEATURE_CLICKED, layer);
   },
 
   _onFeatureOver: function (internalEvent) {
@@ -77,17 +78,18 @@ var LeafletLayer = L.TileLayer.extend({
       this._hoveredLayers[internalEvent.layerIndex] = true;
       this._map.getContainer().style.cursor = 'pointer';
     }
-    triggerLayerFeatureEvent(Layer.events.FEATURE_OVER, internalEvent, this._layers);
+    triggerLayerFeatureEvent(Layer.events.FEATURE_OVER, layer);
   },
 
   _onFeatureOut: function (internalEvent) {
+    var layer = this._layers.findById(internalEvent.layer.id);
     this._hoveredLayers[internalEvent.layerIndex] = false;
     if (_.any(this._hoveredLayers)) {
       this._map.getContainer().style.cursor = 'pointer';
     } else {
       this._map.getContainer().style.cursor = 'auto';
     }
-    triggerLayerFeatureEvent(Layer.events.FEATURE_OUT, internalEvent, this._layers);
+    triggerLayerFeatureEvent(Layer.events.FEATURE_OUT, layer);
   },
 
   _onFeatureError: function (error) {

--- a/src/api/v4/native/leaflet-layer.js
+++ b/src/api/v4/native/leaflet-layer.js
@@ -69,7 +69,7 @@ var LeafletLayer = L.TileLayer.extend({
 
   _onFeatureClick: function (internalEvent) {
     var layer = this._layers.findById(internalEvent.layer.id);
-    triggerLayerFeatureEvent(Layer.events.FEATURE_CLICKED, layer);
+    triggerLayerFeatureEvent(Layer.events.FEATURE_CLICKED, internalEvent, layer);
   },
 
   _onFeatureOver: function (internalEvent) {
@@ -78,7 +78,7 @@ var LeafletLayer = L.TileLayer.extend({
       this._hoveredLayers[internalEvent.layerIndex] = true;
       this._map.getContainer().style.cursor = 'pointer';
     }
-    triggerLayerFeatureEvent(Layer.events.FEATURE_OVER, layer);
+    triggerLayerFeatureEvent(Layer.events.FEATURE_OVER, internalEvent, layer);
   },
 
   _onFeatureOut: function (internalEvent) {
@@ -89,7 +89,7 @@ var LeafletLayer = L.TileLayer.extend({
     } else {
       this._map.getContainer().style.cursor = 'auto';
     }
-    triggerLayerFeatureEvent(Layer.events.FEATURE_OUT, layer);
+    triggerLayerFeatureEvent(Layer.events.FEATURE_OUT, internalEvent, layer);
   },
 
   _onFeatureError: function (error) {

--- a/src/api/v4/native/trigger-layer-feature-event.js
+++ b/src/api/v4/native/trigger-layer-feature-event.js
@@ -1,5 +1,4 @@
-module.exports = function (eventName, internalEvent, layers) {
-  var layer = layers.findById(internalEvent.layer.id);
+module.exports = function (eventName, internalEvent, layer) {
   if (layer) {
     var event = {
       data: undefined,

--- a/src/engine.js
+++ b/src/engine.js
@@ -186,6 +186,25 @@ Engine.prototype.removeLayer = function (layer) {
 
 /**
  *
+ * Move a layer in the engine layersCollection
+ *
+ * @param {layer} layer - A new layer to be moved in the engine.
+ * @param {number} toIndex - Final index for the layer.
+ *
+ * @public
+ */
+Engine.prototype.moveLayer = function (layer, toIndex) {
+  var fromIndex = this._layersCollection.indexOf(layer);
+  if (fromIndex >= 0 && fromIndex !== toIndex) {
+    this._layersCollection.models.splice(toIndex, 0, this._layersCollection.models.splice(fromIndex, 1)[0]);
+    // Equivalent to:
+    // this._layersCollection.remove(layer, { silent: true });
+    // this._layersCollection.add(layer, { at: toIndex });
+  }
+};
+
+/**
+ *
  * Add a dataview to the engine dataviewsCollection
  *
  * @param {Dataview} dataview - A new dataview to be added to the engine.

--- a/test/spec/api/v4/client.spec.js
+++ b/test/spec/api/v4/client.spec.js
@@ -186,6 +186,45 @@ describe('api/v4/client', function () {
       client.addLayer(layer);
 
       expect(client.getLayers().length).toEqual(1);
+
+      client.removeLayer(layer);
+
+      expect(client.getLayers().length).toEqual(0);
+    });
+  });
+
+  describe('.moveLayer', function () {
+    it('should throw a descriptive error when the parameter is invalid', function () {
+      var source = new carto.source.Dataset('ne_10m_populated_places_simple');
+      var style = new carto.style.CartoCSS('#layer {  marker-fill: red; }');
+      var layer = new carto.layer.Layer(source, style, {});
+
+      expect(function () {
+        client.moveLayer({}, 0);
+      }).toThrowError('The given object is not a layer.');
+
+      expect(function () {
+        client.moveLayer(layer, false);
+      }).toThrowError('index property must be a number.');
+
+      expect(function () {
+        client.moveLayer(layer, 1234);
+      }).toThrowError('index is out of range.');
+    });
+
+    it('should move the layer when is in the client', function () {
+      var source = new carto.source.Dataset('ne_10m_populated_places_simple');
+      var style = new carto.style.CartoCSS('#layer {  marker-fill: red; }');
+      var layer0 = new carto.layer.Layer(source, style, {});
+      var layer1 = new carto.layer.Layer(source, style, {});
+
+      client.addLayers([layer0, layer1]);
+      expect(client.getLayers()[0]).toEqual(layer0);
+      expect(client.getLayers()[1]).toEqual(layer1);
+
+      client.moveLayer(layer0, 1);
+      expect(client.getLayers()[1]).toEqual(layer0);
+      expect(client.getLayers()[0]).toEqual(layer1);
     });
   });
 

--- a/test/spec/api/v4/layer/layer.spec.js
+++ b/test/spec/api/v4/layer/layer.spec.js
@@ -553,6 +553,40 @@ describe('api/v4/layer', function () {
     });
   });
 
+  describe('.setOrder', function () {
+    it('should call moveLayer with the passed index', function () {
+      var clientMock = { moveLayer: jasmine.createSpy('moveLayer') };
+      var layer = new carto.layer.Layer(source, style);
+      layer.$setClient(clientMock);
+
+      layer.setOrder(1);
+      expect(clientMock.moveLayer).toHaveBeenCalledWith(layer, 1);
+    });
+  });
+
+  describe('.bringToBack', function () {
+    it('should call moveLayer with the passed index', function () {
+      var clientMock = { moveLayer: jasmine.createSpy('moveLayer') };
+      var layer = new carto.layer.Layer(source, style);
+      layer.$setClient(clientMock);
+
+      layer.bringToBack();
+      expect(clientMock.moveLayer).toHaveBeenCalledWith(layer, 0);
+    });
+  });
+
+  describe('.bringToFront', function () {
+    it('should call moveLayer with the passed index', function () {
+      var numberOfLayers = 3;
+      var clientMock = { moveLayer: jasmine.createSpy('moveLayer'), _layers: { size: function () { return numberOfLayers; } } };
+      var layer = new carto.layer.Layer(source, style);
+      layer.$setClient(clientMock);
+
+      layer.bringToFront();
+      expect(clientMock.moveLayer).toHaveBeenCalledWith(layer, numberOfLayers - 1);
+    });
+  });
+
   xit('should update "internalmodel.cartocss" when the style is updated', function (done) {
     var client = new carto.Client({
       apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',

--- a/test/spec/engine.spec.js
+++ b/test/spec/engine.spec.js
@@ -50,7 +50,7 @@ describe('Engine', function () {
   });
 
   describe('.addLayer', function () {
-    it('should add a new layer', function () {
+    it('should add a layer', function () {
       var style = '#layer { marker-color: red; }';
       var source = MockFactory.createAnalysisModel({ id: 'a1', type: 'source', query: 'SELECT * FROM table' });
       var layer = new CartoDBLayer({ source: source, style: style }, { engine: engineMock });
@@ -58,6 +58,33 @@ describe('Engine', function () {
       engineMock.addLayer(layer);
       expect(engineMock._layersCollection.length).toEqual(1);
       expect(engineMock._layersCollection.at(0)).toEqual(layer);
+    });
+  });
+
+  describe('.removeLayer', function () {
+    it('should remove a layer', function () {
+      var style = '#layer { marker-color: red; }';
+      var source = MockFactory.createAnalysisModel({ id: 'a1', type: 'source', query: 'SELECT * FROM table' });
+      var layer = new CartoDBLayer({ source: source, style: style }, { engine: engineMock });
+      engineMock.addLayer(layer);
+      engineMock.removeLayer(layer);
+      expect(engineMock._layersCollection.length).toEqual(0);
+    });
+  });
+
+  describe('.moveLayer', function () {
+    it('should move a layer', function () {
+      var style = '#layer { marker-color: red; }';
+      var source = MockFactory.createAnalysisModel({ id: 'a1', type: 'source', query: 'SELECT * FROM table' });
+      var layer0 = new CartoDBLayer({ source: source, style: style }, { engine: engineMock });
+      var layer1 = new CartoDBLayer({ source: source, style: style }, { engine: engineMock });
+      engineMock.addLayer(layer0);
+      engineMock.addLayer(layer1);
+      expect(engineMock._layersCollection.at(0)).toEqual(layer0);
+      expect(engineMock._layersCollection.at(1)).toEqual(layer1);
+      engineMock.moveLayer(layer0, 1);
+      expect(engineMock._layersCollection.at(1)).toEqual(layer0);
+      expect(engineMock._layersCollection.at(0)).toEqual(layer1);
     });
   });
 


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb.js/issues/1982

- [x] Add `moveLayer(layer, index)` function to Engine
- [x] Add `moveLayer(layer, index)` function to Client
- [x] Add `setOrder(index)` function to Layer
- [x] Add `bringToBack()` function to Layer
- [x] Add `bringToFront()` function to Layer
- [x] Add tests
- [x] Add examples
- [x] Little refactor for internal `triggerLayerFeatureEvent` function