### PR TITLE
Set Leaflet zoomAnimationThreshold to 1000 (internal only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "jasmine-ajax": "git://github.com/nobuti/jasmine-ajax.git#master",
     "jsdoc": "~3.5.5",
     "jstify": "0.12.0",
-    "leaflet": "1.2.0",
+    "leaflet": "1.3.1",
     "load-grunt-tasks": "~0.6.0",
     "npm-watch": "^0.3.0",
     "semver": "~5.4.0",

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -269,7 +269,7 @@ Client.prototype.getDataviews = function () {
 };
 
 /**
- * Return a {@link http://leafletjs.com/reference-1.2.0.html#tilelayer|leaflet layer} that groups all the layers that have been
+ * Return a {@link http://leafletjs.com/reference-1.3.1.html#tilelayer|leaflet layer} that groups all the layers that have been
  * added to this client.
  *
  * @example
@@ -280,7 +280,7 @@ Client.prototype.getDataviews = function () {
  * // Add the leafletLayer to a leafletMap
  * client.getLeafletLayer().addTo(map);
  *
- * @returns A {@link http://leafletjs.com/reference-1.2.0.html#tilelayer|L.TileLayer} layer that groups all the layers.
+ * @returns A {@link http://leafletjs.com/reference-1.3.1.html#tilelayer|L.TileLayer} layer that groups all the layers.
  *
  * @api
  */
@@ -389,7 +389,7 @@ Client.prototype._bindEngine = function (engine) {
 
 /**
  * Check if some layer in the client has the same id.
- * @param {carto.layer.Base} layer 
+ * @param {carto.layer.Base} layer
  */
 Client.prototype._checkDuplicatedLayerId = function (layer) {
   if (this._layers.findById(layer.getId())) {

--- a/src/api/v4/filter/bounding-box-leaflet.js
+++ b/src/api/v4/filter/bounding-box-leaflet.js
@@ -4,8 +4,8 @@ var BoundingBoxFilterModel = require('../../../windshaft/filters/bounding-box');
 
 /**
  * Bounding box filter for Leaflet maps.
- * 
- * When this filter is included into a dataview only the data inside the {@link http://leafletjs.com/reference-1.2.0.html#map|leafletMap}
+ *
+ * When this filter is included into a dataview only the data inside the {@link http://leafletjs.com/reference-1.3.1.html#map|leafletMap}
  * bounds will be taken into account.
  *
  * @param {L.Map} map - The leaflet map view
@@ -16,7 +16,7 @@ var BoundingBoxFilterModel = require('../../../windshaft/filters/bounding-box');
  * @extends carto.filter.Base
  * @memberof carto.filter
  * @api
- * 
+ *
  * @example
  * // Create a bonding box attached to a leaflet map.
  * const bboxFilter = new carto.filter.BoundingBoxLeaflet(leafletMap);

--- a/src/geo/leaflet/leaflet-map-view.js
+++ b/src/geo/leaflet/leaflet-map-view.js
@@ -19,7 +19,8 @@ var LeafletMapView = MapView.extend({
       doubleClickZoom: !!this.map.get('drag'),
       scrollWheelZoom: !!this.map.get('scrollwheel'),
       keyboard: !!this.map.get('keyboard'),
-      attributionControl: false
+      attributionControl: false,
+      zoomAnimationThreshold: 1000
     };
 
     this._leafletMap = new L.Map(this.el, mapConfig);


### PR DESCRIPTION
Set Leaflet `zoomAnimationThreshold` to 1000 (in the internal API) to avoid unnecessary gray background flashes.
