### PR TITLE
Warn instead of error if no API key

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -291,7 +291,7 @@ Engine.prototype._buildParams = function (includeFilters) {
     params.auth_token = this._windshaftSettings.authToken;
     return params;
   }
-  console.error('Engine initialized with no apiKeys neither authToken');
+  console.warn('Engine initialized with no apiKeys neither authToken');
 };
 
 /**


### PR DESCRIPTION
Just to not fill trackjs with this error.

When Auth API is available, we can force this error and not letting it pass through. In this moment, we're flooding trackjs and console with this error in legit cases where we do not provide a key.