### PR TITLE
Fix popup examples for polygons

### DIFF
--- a/examples/public/misc/popups-gmaps.html
+++ b/examples/public/misc/popups-gmaps.html
@@ -142,25 +142,25 @@
       const infowindow = new google.maps.InfoWindow();
 
       function openPopup(featureEvent) {
+        let content = '';
+        content += `<div class="popup-container">`;
+        if (featureEvent.data.name) {
+          content += `<h2>${featureEvent.data.name}</h2>`;
+        }
+        if (featureEvent.data.pop_max || featureEvent.data.pop_min) {
+          content += `<ul>`;
+          if (featureEvent.data.pop_max) {
+            content += `<li><h3>Max:</h3> <h4>${featureEvent.data.pop_max}</h4></li>`;
+          }
+          if (featureEvent.data.pop_min) {
+            content += `<li><h3>Min:</h3> <h4>${featureEvent.data.pop_min}<h4></li>`;
+          }
+          content += `</ul>`;
+        }
+        content += `</div>`;
+        infowindow.setContent(content);
         infowindow.setPosition(featureEvent.latLng);
         if (!infowindow.map) {
-          let content = '';
-          content += `<div class="popup-container">`;
-          if (featureEvent.data.name) {
-            content += `<h2>${featureEvent.data.name}</h2>`;
-          }
-          if (featureEvent.data.pop_max || featureEvent.data.pop_min) {
-            content += `<ul>`;
-            if (featureEvent.data.pop_max) {
-              content += `<li><h3>Max:</h3> <h4>${featureEvent.data.pop_max}</h4></li>`;
-            }
-            if (featureEvent.data.pop_min) {
-              content += `<li><h3>Min:</h3> <h4>${featureEvent.data.pop_min}<h4></li>`;
-            }
-            content += `</ul>`;
-          }
-          content += `</div>`;
-          infowindow.setContent(content);
           infowindow.open(map);
         }
       }

--- a/examples/public/misc/popups-leaflet.html
+++ b/examples/public/misc/popups-leaflet.html
@@ -145,25 +145,25 @@
       const popup = L.popup({ closeButton: false });
 
       function openPopup(featureEvent) {
+        let content = '';
+        content += `<div class="popup-container">`;
+        if (featureEvent.data.name) {
+          content += `<h2>${featureEvent.data.name}</h2>`;
+        }
+        if (featureEvent.data.pop_max || featureEvent.data.pop_min) {
+          content += `<ul>`;
+          if (featureEvent.data.pop_max) {
+            content += `<li><h3>Max:</h3> <h4>${featureEvent.data.pop_max}</h4></li>`;
+          }
+          if (featureEvent.data.pop_min) {
+            content += `<li><h3>Min:</h3> <h4>${featureEvent.data.pop_min}<h4></li>`;
+          }
+          content += `</ul>`;
+        }
+        content += `</div>`;
+        popup.setContent(content);
         popup.setLatLng(featureEvent.latLng);
         if (!popup.isOpen()) {
-          let content = '';
-          content += `<div class="popup-container">`;
-          if (featureEvent.data.name) {
-            content += `<h2>${featureEvent.data.name}</h2>`;
-          }
-          if (featureEvent.data.pop_max || featureEvent.data.pop_min) {
-            content += `<ul>`;
-            if (featureEvent.data.pop_max) {
-              content += `<li><h3>Max:</h3> <h4>${featureEvent.data.pop_max}</h4></li>`;
-            }
-            if (featureEvent.data.pop_min) {
-              content += `<li><h3>Min:</h3> <h4>${featureEvent.data.pop_min}<h4></li>`;
-            }
-            content += `</ul>`;
-          }
-          content += `</div>`;
-          popup.setContent(content);
           popup.openOn(map);
         }
       }


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb.js/issues/2043
---

In this PR both popup examples (leaflet/gmaps) are updated in order to check if the popup/infowindow is opened only to call the open function:

### Leaflet
```js
if (!popup.isOpen()) {
  popup.openOn(map);
}
```

### Google Maps
```js
if (!infowindow.map) {
  infowindow.open(map);
}
```