### PR TITLE
Freeze GMaps script version

### DIFF
--- a/examples/public/filters/bounding-box-gmaps.html
+++ b/examples/public/filters/bounding-box-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/examples/public/layers/change-feature-columns-gmaps.html
+++ b/examples/public/layers/change-feature-columns-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/examples/public/layers/change-order-gmaps.html
+++ b/examples/public/layers/change-order-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/examples/public/layers/change-source-gmaps.html
+++ b/examples/public/layers/change-source-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/examples/public/layers/change-style-gmaps.html
+++ b/examples/public/layers/change-style-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/examples/public/layers/feature-click-gmaps.html
+++ b/examples/public/layers/feature-click-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/examples/public/layers/feature-over-out-gmaps.html
+++ b/examples/public/layers/feature-over-out-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/examples/public/layers/layer-with-aggregation-gmaps.html
+++ b/examples/public/layers/layer-with-aggregation-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/examples/public/layers/layer-with-zoom-options-gmaps.html
+++ b/examples/public/layers/layer-with-zoom-options-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/examples/public/layers/multilayer-gmaps.html
+++ b/examples/public/layers/multilayer-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/examples/public/layers/single-layer-gmaps.html
+++ b/examples/public/layers/single-layer-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/examples/public/misc/boilerplate-gmaps.html
+++ b/examples/public/misc/boilerplate-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
   </head>

--- a/examples/public/misc/edit-sql-cartocss-gmaps.html
+++ b/examples/public/misc/edit-sql-cartocss-gmaps.html
@@ -7,7 +7,7 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/examples/public/misc/error-handling-gmaps.html
+++ b/examples/public/misc/error-handling-gmaps.html
@@ -7,7 +7,7 @@
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/examples/public/misc/guide-gmaps.html
+++ b/examples/public/misc/guide-gmaps.html
@@ -7,7 +7,7 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/examples/public/misc/legends-gmaps.html
+++ b/examples/public/misc/legends-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/examples/public/misc/populated-places-gmaps.html
+++ b/examples/public/misc/populated-places-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/examples/public/misc/popups-gmaps.html
+++ b/examples/public/misc/popups-gmaps.html
@@ -7,7 +7,7 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/grunt/tasks/jasmine.js
+++ b/grunt/tasks/jasmine.js
@@ -8,7 +8,7 @@ var defaultOptions = {
     // Load & install the source-map-support lib (get proper stack traces from inlined source-maps)
     'node_modules/source-map-support/browser-source-map-support.js',
     'test/install-source-map-support.js',
-    'https://maps.googleapis.com/maps/api/js?key=AIzaSyA4KzmztukvT7C49NSlzWkz75Xg3J_UyFI&v=3.30',
+    'http://maps.googleapis.com/maps/api/js?key=AIzaSyA4KzmztukvT7C49NSlzWkz75Xg3J_UyFI&v=3.30',
     'node_modules/jasmine-ajax/lib/mock-ajax.js',
     'node_modules/leaflet/dist/leaflet-src.js'
   ]

--- a/grunt/tasks/jasmine.js
+++ b/grunt/tasks/jasmine.js
@@ -8,7 +8,7 @@ var defaultOptions = {
     // Load & install the source-map-support lib (get proper stack traces from inlined source-maps)
     'node_modules/source-map-support/browser-source-map-support.js',
     'test/install-source-map-support.js',
-    'http://maps.googleapis.com/maps/api/js?key=AIzaSyA4KzmztukvT7C49NSlzWkz75Xg3J_UyFI',
+    'https://maps.googleapis.com/maps/api/js?key=AIzaSyA4KzmztukvT7C49NSlzWkz75Xg3J_UyFI&v=3.30',
     'node_modules/jasmine-ajax/lib/mock-ajax.js',
     'node_modules/leaflet/dist/leaflet-src.js'
   ]

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -179,8 +179,9 @@ util.isGoogleMapsLoaded = function () {
   if (!window.google.maps) {
     throw new Error('Google Maps is required');
   }
-  if (window.google.maps.version < '3.0.0') {
-    throw new Error('Google Maps +3.0 is required');
+  var version = window.google.maps.version;
+  if (version < '3.0.0' || version >= '3.31.0') {
+    throw new Error('Google Maps version should be > 3.0 and < 3.31');
   }
 };
 

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -181,7 +181,7 @@ util.isGoogleMapsLoaded = function () {
   }
   var version = window.google.maps.version;
   if (version < '3.0.0' || version >= '3.31.0') {
-    throw new Error('Google Maps version should be > 3.0 and < 3.31');
+    throw new Error('Google Maps version should be >= 3.0 and < 3.31');
   }
 };
 

--- a/test/spec/api/v4/client.spec.js
+++ b/test/spec/api/v4/client.spec.js
@@ -325,7 +325,7 @@ describe('api/v4/client', function () {
       window.google.maps = { version: '2.4' };
       expect(function () {
         client.getGoogleMapsMapType();
-      }).toThrowError('Google Maps +3.0 is required');
+      }).toThrowError('Google Maps version should be >= 3.0 and < 3.31');
 
       // Restore window.google
       window.google = google;

--- a/test/spec/core/util.spec.js
+++ b/test/spec/core/util.spec.js
@@ -80,12 +80,12 @@ describe('core/util', function () {
       window.google.maps = {
         version: '2.9.9'
       };
-      expect(checkGoogle).toThrowError('Google Maps version should be > 3.0 and < 3.31');
+      expect(checkGoogle).toThrowError('Google Maps version should be >= 3.0 and < 3.31');
 
       window.google.maps = {
         version: '3.31.0'
       };
-      expect(checkGoogle).toThrowError('Google Maps version should be > 3.0 and < 3.31');
+      expect(checkGoogle).toThrowError('Google Maps version should be >= 3.0 and < 3.31');
 
       window.google.maps = {
         version: '3.30.0'

--- a/test/spec/core/util.spec.js
+++ b/test/spec/core/util.spec.js
@@ -55,7 +55,7 @@ describe('core/util', function () {
     });
   });
 
-  fdescribe('google maps checks', function () {
+  describe('google maps checks', function () {
     var existingGMaps = null;
 
     beforeEach(function () {

--- a/test/spec/core/util.spec.js
+++ b/test/spec/core/util.spec.js
@@ -54,4 +54,43 @@ describe('core/util', function () {
       navigator.msMaxTouchPoints = currentTouchPointsValue;
     });
   });
+
+  fdescribe('google maps checks', function () {
+    var existingGMaps = null;
+
+    beforeEach(function () {
+      existingGMaps = window.google;
+      window.google = undefined;
+    });
+
+    afterEach(function () {
+      window.google = existingGMaps;
+    });
+
+    it('gmaps is required as global and it must be between 3.0 and 3.31', function () {
+      var checkGoogle = function () {
+        util.isGoogleMapsLoaded();
+      };
+
+      expect(checkGoogle).toThrowError('Google Maps is required');
+
+      window.google = { something: 'something' };
+      expect(checkGoogle).toThrowError('Google Maps is required');
+
+      window.google.maps = {
+        version: '2.9.9'
+      };
+      expect(checkGoogle).toThrowError('Google Maps version should be > 3.0 and < 3.31');
+
+      window.google.maps = {
+        version: '3.31.0'
+      };
+      expect(checkGoogle).toThrowError('Google Maps version should be > 3.0 and < 3.31');
+
+      window.google.maps = {
+        version: '3.30.0'
+      };
+      expect(checkGoogle).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
A recent deploy of a new GMaps experimental version provokes errors, both in our specs and in our API examples.

This PR freezes the GMaps version to the currently stable one, `v=3.30`.