### PR TITLE
Freeze Google Maps version to v3.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/SpecRunner.html
 .idea/
 themes/css/cartodb.css
 cartodb.js-bower/
+docs

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+3.15.14
+-------
+* Update all Google Maps script references to v3.3.0
+
+3.15.13 (30/01/2018)
+-------
+* Replace Mapzen geocoding search to Mapbox
+
 3.15.12 (12/06/2017)
 -------
 * New Mapzen API key.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,7 +13,7 @@
 - Create a new branch to prepare the release:
 
 ```
-git flow release start 3.15.12
+git flow release start 3.15.14
 ```
 
 - Build CartoDB.js files, choosing the new version:
@@ -25,7 +25,7 @@ grunt release
 - Update the NEWS file and commit the changes. Take into account that new CartoDB.js version will be replaced in ```API.md```, ```RELEASING.md```, ```README.md```, ```package.json```, ```cartodb.js``` and ```examples``` files.
 
 ```
-git commit -am "Files changed for version 3.15.12"
+git commit -am "Files changed for version 3.15.14"
 ```
 
 - Release it.
@@ -36,8 +36,8 @@ grunt publish
 
 - Check if those files have been updated in the CDN:
 ```
-http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.15.12/cartodb.js
-http://libs.cartocdn.com/cartodb.js/v3/3.15.12/cartodb.js
+http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.15.14/cartodb.js
+http://libs.cartocdn.com/cartodb.js/v3/3.15.14/cartodb.js
 http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.15/cartodb.js
 http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js
 ```
@@ -46,7 +46,7 @@ http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js
 - And to finish: close the release and push it.
 
 ```
-git flow release finish 3.15.12
+git flow release finish 3.15.14
 git push --all
 git push --tags
 ```
@@ -75,7 +75,7 @@ grunt
 grunt publish
 ```
 
-For example, if we are in 3.15.12 and we want to go back to 3.13.4
+For example, if we are in 3.15.14 and we want to go back to 3.13.4
 
 ```
 git checkout 3.13.4

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "cartodb.js",
     "themes/css/cartodb.css"
   ],
-  "version": "3.15.12",
+  "version": "3.15.14",
   "homepage": "https://github.com/CartoDB/cartodb.js",
   "authors": [
     "CartoDB <support@cartodb.com>"

--- a/examples/gmaps/gmaps_driving_directions_plus_sql_api.html
+++ b/examples/gmaps/gmaps_driving_directions_plus_sql_api.html
@@ -19,7 +19,7 @@
     <div id="map"></div>
 
     <!-- include google maps library -->
-    <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.12"></script>
+    <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.30"></script>
 
     <!-- include cartodb.js library -->
     <script src="http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.12/cartodb.js"></script>

--- a/examples/gmaps/gmaps_heatmap_plus_sql_api.html
+++ b/examples/gmaps/gmaps_heatmap_plus_sql_api.html
@@ -19,7 +19,7 @@
     <div id="map"></div>
 
     <!-- include google maps library + visualization-->
-    <script src="https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=visualization"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?v=3.30&libraries=visualization"></script>
 
     <!-- include cartodb.js library -->
     <script src="http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.12/cartodb.js"></script>

--- a/examples/gmaps/gmaps_satellite.html
+++ b/examples/gmaps/gmaps_satellite.html
@@ -19,7 +19,7 @@
     <div id="map"></div>
 
     <!-- include google maps library -->
-    <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.12"></script>
+    <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.30"></script>
 
     <!-- include cartodb.js library -->
     <script src="../../dist/cartodb.uncompressed.js"></script>

--- a/examples/gmaps/gmaps_with_torque.html
+++ b/examples/gmaps/gmaps_with_torque.html
@@ -19,7 +19,7 @@
     <div id="map"></div>
 
     <!-- include google maps library -->
-    <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.12"></script>
+    <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.30"></script>
 
     <!-- include cartodb.js library -->
     <script src="http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.12/cartodb.js"></script>

--- a/examples/gmaps_driving_directions_plus_sql_api.html
+++ b/examples/gmaps_driving_directions_plus_sql_api.html
@@ -19,7 +19,7 @@
     <div id="map"></div>
 
     <!-- include google maps library -->
-    <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.12"></script>
+    <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.30"></script>
 
     <!-- include cartodb.js library -->
     <script src="http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.15/cartodb.js"></script>

--- a/examples/gmaps_force_basemap.html
+++ b/examples/gmaps_force_basemap.html
@@ -19,7 +19,7 @@
     <div id="map"></div>
 
     <!-- include google maps library -->
-    <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.12"></script>
+    <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.30"></script>
 
     <!-- include cartodb.js library -->
     <script src="http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.15/cartodb.js"></script>

--- a/examples/gmaps_heatmap_plus_sql_api.html
+++ b/examples/gmaps_heatmap_plus_sql_api.html
@@ -19,7 +19,7 @@
     <div id="map"></div>
 
     <!-- include google maps library + visualization-->
-    <script src="https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=visualization"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?v=3.30&libraries=visualization"></script>
 
     <!-- include cartodb.js library -->
     <script src="http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.15/cartodb.js"></script>

--- a/examples/gmaps_satellite.html
+++ b/examples/gmaps_satellite.html
@@ -19,7 +19,7 @@
     <div id="map"></div>
 
     <!-- include google maps library -->
-    <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.12"></script>
+    <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.30"></script>
 
     <!-- include cartodb.js library -->
     <script src="../../dist/cartodb.uncompressed.js"></script>

--- a/examples/gmaps_with_torque.html
+++ b/examples/gmaps_with_torque.html
@@ -19,7 +19,7 @@
     <div id="map"></div>
 
     <!-- include google maps library -->
-    <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.12"></script>
+    <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.30"></script>
 
     <!-- include cartodb.js library -->
     <script src="http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.15/cartodb.js"></script>

--- a/examples/tutorial-google-driving-2.html
+++ b/examples/tutorial-google-driving-2.html
@@ -19,7 +19,7 @@
     <div id="map"></div>
 
     <!-- include google maps library -->
-    <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.12"></script>
+    <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.30"></script>
 
     <!-- include cartodb.js library -->
     <script src="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js"></script>

--- a/examples/tutorial-google-heatmap-2.html
+++ b/examples/tutorial-google-heatmap-2.html
@@ -20,7 +20,7 @@
     <div id="map"></div>
 
     <!-- include google maps library + visualization-->
-    <script src="https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=visualization"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?v=3.30&libraries=visualization"></script>
 
     <!-- include cartodb.js library -->
     <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>

--- a/examples/tutorial-google-heatmap.html
+++ b/examples/tutorial-google-heatmap.html
@@ -20,7 +20,7 @@
     <div id="map"></div>
 
     <!-- include google maps library -->
-    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=INSERTYOURAPIKEYHERE"></script>
+    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=INSERTYOURAPIKEYHERE&v=3.30"></script>
 
     <!-- include google visualization library -->
     <script type="text/javascript"

--- a/examples/tutorials/tutorial-google-driving-2.html
+++ b/examples/tutorials/tutorial-google-driving-2.html
@@ -19,7 +19,7 @@
     <div id="map"></div>
 
     <!-- include google maps library -->
-    <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.12"></script>
+    <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.30"></script>
 
     <!-- include cartodb.js library -->
     <script src="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js"></script>

--- a/examples/tutorials/tutorial-google-heatmap-2.html
+++ b/examples/tutorials/tutorial-google-heatmap-2.html
@@ -20,7 +20,7 @@
     <div id="map"></div>
 
     <!-- include google maps library + visualization-->
-    <script src="https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=visualization"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?v=3.30&libraries=visualization"></script>
 
     <!-- include cartodb.js library -->
     <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>

--- a/examples/tutorials/tutorial-google-heatmap.html
+++ b/examples/tutorials/tutorial-google-heatmap.html
@@ -20,7 +20,7 @@
     <div id="map"></div>
 
     <!-- include google maps library -->
-    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=INSERTYOURAPIKEYHERE"></script>
+    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=INSERTYOURAPIKEYHERE&v=3.30"></script>
 
     <!-- include google visualization library -->
     <script type="text/javascript"

--- a/grunt/tasks/jasmine.js
+++ b/grunt/tasks/jasmine.js
@@ -90,7 +90,7 @@ module.exports = {
           outfile: 'test/SpecRunner.html',
           specs: 'test/spec/**/*.js',
           helpers: 'test/spec/SpecHelper.js',
-          vendor: [ "http://maps.googleapis.com/maps/api/js?sensor=false&v=3.12" ],
+          vendor: [ "http://maps.googleapis.com/maps/api/js?sensor=false&v=3.30" ],
           summary: true,
           display: 'short'
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb.js",
-  "version": "3.15.13",
+  "version": "3.15.14",
   "description": "CartoDB javascript library",
   "repository": {
     "type": "git",

--- a/src/cartodb.js
+++ b/src/cartodb.js
@@ -5,7 +5,7 @@
 
     var cdb = root.cdb = {};
 
-    cdb.VERSION = "3.15.13";
+    cdb.VERSION = "3.15.14";
     cdb.DEBUG = false;
 
     cdb.CARTOCSS_VERSIONS = {

--- a/test/SpecRunner-src.html
+++ b/test/SpecRunner-src.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Jasmine Spec Runner</title>
+  <link rel="shortcut icon" type="image/png" href=".grunt/grunt-contrib-jasmine/jasmine_favicon.png">
+
+  <link rel="stylesheet" type="text/css" href="../.grunt/grunt-contrib-jasmine/jasmine.css">
+
+
+</head>
+<body>
+
+  
+  <script src="../.grunt/grunt-contrib-jasmine/jasmine.js"></script>
+  
+  <script src="../.grunt/grunt-contrib-jasmine/jasmine-html.js"></script>
+  
+  <script src="../.grunt/grunt-contrib-jasmine/json2.js"></script>
+  
+  <script src="../.grunt/grunt-contrib-jasmine/boot.js"></script>
+  
+  <script src="../node_modules/source-map-support/browser-source-map-support.js"></script>
+  
+  <script src="install-source-map-support.js"></script>
+  
+  <script src="http://maps.googleapis.com/maps/api/js?key=AIzaSyA4KzmztukvT7C49NSlzWkz75Xg3J_UyFI&v=3.30"></script>
+  
+  <script src="../node_modules/jasmine-ajax/lib/mock-ajax.js"></script>
+  
+  <script src="../node_modules/leaflet/dist/leaflet-src.js"></script>
+  
+  <script src="../.tmp/src-specs.js"></script>
+  
+  <script src="../.grunt/grunt-contrib-jasmine/reporter.js"></script>
+  
+
+</body>
+</html>

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -20,7 +20,7 @@
   
   <script src="../.grunt/grunt-contrib-jasmine/boot.js"></script>
   
-  <script src="http://maps.googleapis.com/maps/api/js?sensor=false&v=3.12"></script>
+  <script src="http://maps.googleapis.com/maps/api/js?sensor=false&v=3.30"></script>
   
   <script src="spec/SpecHelper.js"></script>
   

--- a/test/demos/geo/google_maps.html
+++ b/test/demos/geo/google_maps.html
@@ -8,7 +8,7 @@
     #map_canvas { height: 100% }
   </style>
   <script type="text/javascript"
-      src="https://maps.google.com/maps/api/js?sensor=false">
+      src="https://maps.google.com/maps/api/js?sensor=false&v=3.30">
   </script>
   <script src="../../src/cartodb.js"></script>
   </head>


### PR DESCRIPTION
A recent deploy of a new GMaps experimental version provokes errors, both in our specs and in our API examples.This PR freezes the GMaps version to the currently frozen one, v=3.30.



