### PR TITLE
add marker size to layer cartocss props to reinstantiate torque map

### DIFF
--- a/src/geo/map/torque-layer.js
+++ b/src/geo/map/torque-layer.js
@@ -13,7 +13,11 @@ var TORQUE_LAYER_CARTOCSS_PROPS = [
   '-torque-data-aggregation',
   '-torque-resolution'
 ];
-var LAYER_NAME_IN_CARTO_CSS = 'Map';
+var LAYER_CARTOCSS_PROPS = [
+  'marker-width'
+];
+var LAYER_NAME_IN_CARTO_CSS = '#layer';
+var TORQUE_LAYER_NAME_IN_CARTO_CSS = 'Map';
 var DEFAULT_ANIMATION_DURATION = 30;
 var TORQUE_DURATION_ATTRIBUTE = '-torque-animation-duration';
 
@@ -95,9 +99,17 @@ var TorqueLayer = LayerModelBase.extend({
 
   _getTorqueLayerCartoCSSProperties: function (renderer, cartoCSS) {
     var shader = renderer.render(cartoCSS);
+    var torqueLayer = shader.findLayer({ name: TORQUE_LAYER_NAME_IN_CARTO_CSS });
     var layer = shader.findLayer({ name: LAYER_NAME_IN_CARTO_CSS });
+
     var properties = {};
     _.each(TORQUE_LAYER_CARTOCSS_PROPS, function (property) {
+      var value = torqueLayer && torqueLayer.eval(property);
+      if (value) {
+        properties[property] = value;
+      }
+    });
+    _.each(LAYER_CARTOCSS_PROPS, function (property) {
       var value = layer && layer.eval(property);
       if (value) {
         properties[property] = value;


### PR DESCRIPTION
re: https://github.com/CartoDB/support/issues/1294

- cartodb.js: https://github.com/CartoDB/cartodb.js/pull/2057
- cartodb: https://github.com/CartoDB/cartodb/pull/13590

update cartodb.js dependencies, to add `marker-size` to layer cartocss props to reinstantiate torque map
