### PR TITLE
Re-render legends when layers order is changed

### DIFF
--- a/src/geo/map/layers.js
+++ b/src/geo/map/layers.js
@@ -91,6 +91,8 @@ var Layers = Backbone.Collection.extend({
       silent: true
     });
 
+    this.trigger('layerMoved', movingLayer);
+
     return movingLayer;
   }
 });

--- a/src/geo/ui/legends/legends-view.js
+++ b/src/geo/ui/legends/legends-view.js
@@ -21,10 +21,8 @@ var LegendsView = View.extend({
   },
 
   _initBinds: function () {
-    this._layersCollection.on('add remove', this._onLayerAddedOrRemoved, this);
-    this.add_related_model(this._layersCollection);
-    this.settingsModel.on('change', this._onSettingsModelChanged, this);
-    this.add_related_model(this.settingsModel);
+    this.listenTo(this._layersCollection, 'add remove layerMoved', this._onLegendsChanged);
+    this.listenTo(this.settingsModel, 'change', this._onSettingsModelChanged);
   },
 
   render: function () {
@@ -109,7 +107,7 @@ var LegendsView = View.extend({
     this.$(this._container()).append(layerLegendsView.render().$el);
   },
 
-  _onLayerAddedOrRemoved: function (layerModel) {
+  _onLegendsChanged: function (layerModel) {
     // If view has already been rendered and a layer is added / removed
     if (this._isRendered && this._hasLegends(layerModel)) {
       this._clear();

--- a/src/geo/ui/legends/legends-view.js
+++ b/src/geo/ui/legends/legends-view.js
@@ -11,17 +11,19 @@ var LegendsView = View.extend({
 
   initialize: function (options) {
     if (!options.layersCollection) throw new Error('layersCollection is required');
-    this._layersCollection = options.layersCollection;
+    if (!options.settingsModel) throw new Error('settingsModel is required');
 
-    this._isRendered = false;
+    this._layersCollection = options.layersCollection;
     this.settingsModel = options.settingsModel;
+    this._isRendered = false;
+
     this._initBinds();
 
     this._layerLegendsViews = [];
   },
 
   _initBinds: function () {
-    this.listenTo(this._layersCollection, 'add remove layerMoved', this._onLegendsChanged);
+    this.listenTo(this._layersCollection, 'add remove layerMoved', this._onLayersChanged);
     this.listenTo(this.settingsModel, 'change', this._onSettingsModelChanged);
   },
 
@@ -107,7 +109,7 @@ var LegendsView = View.extend({
     this.$(this._container()).append(layerLegendsView.render().$el);
   },
 
-  _onLegendsChanged: function (layerModel) {
+  _onLayersChanged: function (layerModel) {
     // If view has already been rendered and a layer is added / removed
     if (this._isRendered && this._hasLegends(layerModel)) {
       this._clear();

--- a/test/spec/geo/map/layers.spec.js
+++ b/test/spec/geo/map/layers.spec.js
@@ -141,6 +141,14 @@ describe('geo/map/layers', function () {
       expect(movedLayer.get('title')).toBe('CARTO 2');
     });
 
+    it('should move a layer from one position to other', function () {
+      spyOn(layers, 'trigger');
+
+      var movedLayer = layers.moveCartoDBLayer(1, 0);
+
+      expect(layers.trigger).toHaveBeenCalledWith('layerMoved', movedLayer);
+    });
+
     it('should not move anything if the position is the same', function () {
       var movedLayer = layers.moveCartoDBLayer(1, 1);
       expect(movedLayer).toBeFalsy();

--- a/test/spec/geo/ui/legends/legends-view.spec.js
+++ b/test/spec/geo/ui/legends/legends-view.spec.js
@@ -65,6 +65,14 @@ describe('geo/ui/legends/legends-view', function () {
     expect(getLayerLegendTitles(this.legendsView)).toEqual(['Torque Layer #3', 'CartoDB Layer #2', 'CartoDB Layer #1']);
   });
 
+  it('should re-render when a layer with legends is moved', function () {
+    expect(getLayerLegendTitles(this.legendsView)).toEqual(['Torque Layer #3', 'CartoDB Layer #2', 'CartoDB Layer #1']);
+
+    this.layersCollection.moveCartoDBLayer(2, 1);
+
+    expect(getLayerLegendTitles(this.legendsView)).toEqual(['Torque Layer #3', 'CartoDB Layer #1', 'CartoDB Layer #2']);
+  });
+
   it('should show legends if showLegends is true', function () {
     this.settingsModel.set('showLegends', true);
     expect(this.legendsView.$('.Legends').length).toBe(3);


### PR DESCRIPTION
Related to https://github.com/CartoDB/support/issues/1379

This PR adds a custom `layerMoved` event to refresh legends when `moveCartoDBLayer` is used.