### PR TITLE
Add hasBeenFetched flag to histogram

### DIFF
--- a/src/dataviews/histogram-dataview/histogram-data-model.js
+++ b/src/dataviews/histogram-dataview/histogram-data-model.js
@@ -49,6 +49,7 @@ module.exports = Model.extend({
   },
 
   initialize: function () {
+    this.hasBeenFetched = false;
     this.sync = BackboneAbortSync.bind(this);
     this._initBinds();
   },
@@ -76,6 +77,10 @@ module.exports = Model.extend({
 
     this.on('change:column', function () {
       this.set('aggregation', 'auto', { silent: true });
+    });
+
+    this.on('sync', function () {
+      this.hasBeenFetched = true;
     });
   },
 

--- a/src/dataviews/histogram-dataview/histogram-data-model.js
+++ b/src/dataviews/histogram-dataview/histogram-data-model.js
@@ -13,7 +13,8 @@ module.exports = Model.extend({
     url: '',
     data: [],
     localTimezone: false,
-    localOffset: 0
+    localOffset: 0,
+    hasBeenFetched: false
   },
 
   url: function () {
@@ -49,7 +50,6 @@ module.exports = Model.extend({
   },
 
   initialize: function () {
-    this.hasBeenFetched = false;
     this.sync = BackboneAbortSync.bind(this);
     this._initBinds();
   },
@@ -80,7 +80,7 @@ module.exports = Model.extend({
     });
 
     this.on('sync', function () {
-      this.hasBeenFetched = true;
+      this.set('hasBeenFetched', true);
     });
   },
 

--- a/test/spec/dataviews/histogram-dataview/histogram-data-model.spec.js
+++ b/test/spec/dataviews/histogram-dataview/histogram-data-model.spec.js
@@ -1,7 +1,7 @@
 var _ = require('underscore');
 var HistogramDataModel = require('../../../../src/dataviews/histogram-dataview/histogram-data-model');
 
-fdescribe('dataviews/histogram-data-model', function () {
+describe('dataviews/histogram-data-model', function () {
   var apiKey = 'ac3560ef-78f8-45d8-b043-5544f8a76753';
   var url = 'https://carto.geo';
   var defaultBins = 45;

--- a/test/spec/dataviews/histogram-dataview/histogram-data-model.spec.js
+++ b/test/spec/dataviews/histogram-dataview/histogram-data-model.spec.js
@@ -1,7 +1,7 @@
 var _ = require('underscore');
 var HistogramDataModel = require('../../../../src/dataviews/histogram-dataview/histogram-data-model');
 
-describe('dataviews/histogram-data-model', function () {
+fdescribe('dataviews/histogram-data-model', function () {
   var apiKey = 'ac3560ef-78f8-45d8-b043-5544f8a76753';
   var url = 'https://carto.geo';
   var defaultBins = 45;
@@ -25,6 +25,7 @@ describe('dataviews/histogram-data-model', function () {
     expect(this.model.get('data').length).toBe(0);
     expect(this.model.get('localTimezone')).toBe(false);
     expect(this.model.get('localOffset')).toBe(0);
+    expect(this.model.get('hasBeenFetched')).toBe(false);
   });
 
   describe('._initBinds', function () {
@@ -76,6 +77,14 @@ describe('dataviews/histogram-data-model', function () {
       this.model.set('localTimezone', !originalValue);
 
       expect(this.model.fetch).toHaveBeenCalled();
+    });
+
+    it('should set `hasBeenFetched` to true when a sync event is triggered', function () {
+      this.model.set('hasBeenFetched', false, { silent: true });
+
+      this.model.trigger('sync');
+
+      expect(this.model.get('hasBeenFetched')).toBe(true);
     });
   });
 


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/13706
Cartodb PR: https://github.com/CartoDB/cartodb/pull/13705

This PR adds a flag when the `histogram-data-model` has been fetched to be able to handle event bindings related to it in Builder.