### PR TITLE
Propagate API keys to dataviews in public API

### DIFF
--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -37,7 +37,7 @@ module.exports = DataviewModelBase.extend({
     // Internal model for calculating total amount of values in the category
     this._rangeModel = new CategoryModelRange({
       apiKey: this._engine.getApiKey(),
-      authToken: this.get('authToken')
+      authToken: this._engine.getAuthToken()
     });
 
     this._data = new CategoriesCollection(null, {
@@ -46,7 +46,7 @@ module.exports = DataviewModelBase.extend({
 
     this._searchModel = new SearchModel({
       apiKey: this._engine.getApiKey(),
-      authToken: this.get('authToken')
+      authToken: this._engine.getAuthToken()
     }, {
       aggregationModel: this
     });

--- a/src/dataviews/category-dataview-model.js
+++ b/src/dataviews/category-dataview-model.js
@@ -36,7 +36,7 @@ module.exports = DataviewModelBase.extend({
 
     // Internal model for calculating total amount of values in the category
     this._rangeModel = new CategoryModelRange({
-      apiKey: this.get('apiKey'),
+      apiKey: this._engine.getApiKey(),
       authToken: this.get('authToken')
     });
 
@@ -45,7 +45,7 @@ module.exports = DataviewModelBase.extend({
     });
 
     this._searchModel = new SearchModel({
-      apiKey: this.get('apiKey'),
+      apiKey: this._engine.getApiKey(),
       authToken: this.get('authToken')
     }, {
       aggregationModel: this

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -34,8 +34,8 @@ module.exports = Model.extend({
 
     if (this._engine.getApiKey()) {
       params.push('api_key=' + this._engine.getApiKey());
-    } else if (this.get('authToken')) {
-      var authToken = this.get('authToken');
+    } else if (this._engine.getAuthToken()) {
+      var authToken = this._engine.getAuthToken();
       if (authToken instanceof Array) {
         _.each(authToken, function (token) {
           params.push('auth_token[]=' + token);

--- a/src/dataviews/dataview-model-base.js
+++ b/src/dataviews/dataview-model-base.js
@@ -32,8 +32,8 @@ module.exports = Model.extend({
       this._getDataviewSpecificURLParams()
     );
 
-    if (this.get('apiKey')) {
-      params.push('api_key=' + this.get('apiKey'));
+    if (this._engine.getApiKey()) {
+      params.push('api_key=' + this._engine.getApiKey());
     } else if (this.get('authToken')) {
       var authToken = this.get('authToken');
       if (authToken instanceof Array) {

--- a/src/dataviews/dataviews-factory.js
+++ b/src/dataviews/dataviews-factory.js
@@ -77,14 +77,7 @@ module.exports = Model.extend({
   },
 
   _generateAttrsForDataview: function (attrs, whitelistedAttrs) {
-    attrs = _.pick(attrs, whitelistedAttrs);
-    if (this.get('apiKey')) {
-      attrs.apiKey = this.get('apiKey');
-    }
-    if (this.get('authToken')) {
-      attrs.authToken = this.get('authToken');
-    }
-    return attrs;
+    return _.pick(attrs, whitelistedAttrs);
   },
 
   _newModel: function (m) {

--- a/src/dataviews/histogram-dataview-model.js
+++ b/src/dataviews/histogram-dataview-model.js
@@ -60,7 +60,7 @@ module.exports = DataviewModelBase.extend({
       offset: this.get('offset'),
       column_type: this.get('column_type'),
       apiKey: opts && opts.engine && opts.engine.getApiKey(),
-      authToken: this.get('authToken'),
+      authToken: opts && opts.engine && opts.engine.getAuthToken(),
       localTimezone: this.get('localTimezone'),
       localOffset: this._localOffset
     });

--- a/src/dataviews/histogram-dataview-model.js
+++ b/src/dataviews/histogram-dataview-model.js
@@ -59,7 +59,7 @@ module.exports = DataviewModelBase.extend({
       aggregation: this.get('aggregation'),
       offset: this.get('offset'),
       column_type: this.get('column_type'),
-      apiKey: this.get('apiKey'),
+      apiKey: opts && opts.engine && opts.engine.getApiKey(),
       authToken: this.get('authToken'),
       localTimezone: this.get('localTimezone'),
       localOffset: this._localOffset

--- a/src/engine.js
+++ b/src/engine.js
@@ -84,6 +84,13 @@ Engine.prototype.getApiKey = function () {
 };
 
 /**
+ * Returns the Auth token attached to the engine
+ */
+Engine.prototype.getAuthToken = function () {
+  return this._windshaftSettings && this._windshaftSettings.authToken;
+};
+
+/**
  * Bind a callback function to an event. The callback will be invoked whenever the event is fired.
  *
  * @param {string} event - The name of the event that triggers the callback execution.

--- a/src/engine.js
+++ b/src/engine.js
@@ -77,6 +77,13 @@ Engine.prototype.getLayerGroup = function () {
 };
 
 /**
+ * Returns the API key attached to the engine
+ */
+Engine.prototype.getApiKey = function () {
+  return this._windshaftSettings && this._windshaftSettings.apiKey;
+};
+
+/**
  * Bind a callback function to an event. The callback will be invoked whenever the event is fired.
  *
  * @param {string} event - The name of the event that triggers the callback execution.

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -174,8 +174,8 @@ var VisModel = Backbone.Model.extend({
     // Create the public Dataview Factory
     // TODO: create dataviews more explicitly
     this.dataviews = new DataviewsFactory({
-      apiKey: this.get('apiKey'),
-      authToken: this.get('authToken')
+      apiKey: windshaftSettings.apiKey,
+      authToken: windshaftSettings.authToken
     }, {
       map: this.map,
       engine: this._engine,

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -173,10 +173,7 @@ var VisModel = Backbone.Model.extend({
 
     // Create the public Dataview Factory
     // TODO: create dataviews more explicitly
-    this.dataviews = new DataviewsFactory({
-      apiKey: windshaftSettings.apiKey,
-      authToken: windshaftSettings.authToken
-    }, {
+    this.dataviews = new DataviewsFactory({}, {
       map: this.map,
       engine: this._engine,
       dataviewsCollection: this._dataviewsCollection

--- a/src/vis/vis.js
+++ b/src/vis/vis.js
@@ -24,10 +24,6 @@ var VisModel = Backbone.Model.extend({
 
   initialize: function () {
     this._loadingObjects = [];
-
-    // this._layersCollection = new LayersCollection();
-    // this._dataviewsCollection = new DataviewsCollection();
-
     this.overlaysCollection = new Backbone.Collection();
     this.settings = new SettingsModel();
     this._instantiateMapWasCalled = false;

--- a/test/helpers/mockFactory.js
+++ b/test/helpers/mockFactory.js
@@ -1,7 +1,7 @@
 var _ = require('underscore');
 var VisModel = require('../../src/vis/vis');
 var AnalysisModel = require('../../src/analysis/analysis-model');
-var Engine = require('../../src/engine');
+var createEngineFixture = require('../spec/fixtures/engine.fixture.js');
 
 // We use a "fake" reference instead of the one in src/analysis/camshaft-reference
 // to ensure that tests won't break if the real thing changes
@@ -54,8 +54,8 @@ function createVisModel () {
   return new VisModel();
 }
 
-function createEngine () {
-  return new Engine({ serverUrl: 'http://example.com', username: 'fake-username', apiKey: 'fake-api-key', statTag: 'fake-stat-tag' });
+function createEngine (opts) {
+  return createEngineFixture(opts);
 }
 
 module.exports = {

--- a/test/spec/api/v4/dataview/category.spec.js
+++ b/test/spec/api/v4/dataview/category.spec.js
@@ -1,6 +1,7 @@
 var Backbone = require('backbone');
 var _ = require('underscore');
 var carto = require('../../../../../src/api/v4/index');
+var createEngine = require('../../../fixtures/engine.fixture.js');
 
 function createInternalModelMock () {
   var internalModelMock = {
@@ -35,16 +36,6 @@ function createInternalModelMock () {
 
 function createSourceMock () {
   return new carto.source.Dataset('foo');
-}
-
-function createEngineMock () {
-  var engine = {
-    name: 'Engine mock',
-    reload: function () {}
-  };
-  spyOn(engine, 'reload');
-
-  return engine;
 }
 
 describe('api/v4/dataview/category', function () {
@@ -169,7 +160,7 @@ describe('api/v4/dataview/category', function () {
       dataview.on('limitChanged', limitChangedSpy);
 
       expect(limitChangedSpy).not.toHaveBeenCalled();
-      dataview.$setEngine(createEngineMock());
+      dataview.$setEngine(createEngine());
       dataview.setLimit(7);
 
       expect(limitChangedSpy).toHaveBeenCalledWith(7);
@@ -221,7 +212,7 @@ describe('api/v4/dataview/category', function () {
       dataview.on('operationChanged', operationChangedSpy);
 
       expect(operationChangedSpy).not.toHaveBeenCalled();
-      dataview.$setEngine(createEngineMock());
+      dataview.$setEngine(createEngine());
       dataview.setOperation(carto.operation.AVG);
 
       expect(operationChangedSpy).toHaveBeenCalledWith(carto.operation.AVG);
@@ -284,7 +275,7 @@ describe('api/v4/dataview/category', function () {
       dataview.on('operationColumnChanged', operationColumnChangedSpy);
 
       expect(operationColumnChangedSpy).not.toHaveBeenCalled();
-      dataview.$setEngine(createEngineMock());
+      dataview.$setEngine(createEngine());
       dataview.setOperationColumn('column2');
 
       expect(operationColumnChangedSpy).toHaveBeenCalledWith('column2');
@@ -344,7 +335,7 @@ describe('api/v4/dataview/category', function () {
         operation: carto.operation.MIN,
         operationColumn: 'column-test'
       });
-      engine = createEngineMock();
+      engine = createEngine();
     });
 
     it('creates the internal model', function () {
@@ -362,7 +353,7 @@ describe('api/v4/dataview/category', function () {
       expect(internalModel.isEnabled()).toBe(false);
       expect(internalModel._bboxFilter).toBeDefined();
       expect(internalModel.syncsOnBoundingBoxChanges()).toBe(true);
-      expect(internalModel._engine.name).toEqual('Engine mock');
+      expect(internalModel._engine).toBe(engine);
     });
 
     it('creates the internal model with no bounding box if not provided', function () {

--- a/test/spec/api/v4/dataview/histogram.spec.js
+++ b/test/spec/api/v4/dataview/histogram.spec.js
@@ -1,6 +1,7 @@
 var Backbone = require('backbone');
 var _ = require('underscore');
 var carto = require('../../../../../src/api/v4/index');
+var createEngine = require('../../../fixtures/engine.fixture.js');
 
 function createHistogramInternalModelMock (options) {
   options = options || {};
@@ -52,16 +53,6 @@ function createHistogramInternalModelMock (options) {
 
 function createSourceMock () {
   return new carto.source.Dataset('ne_10m_populated_places_simple');
-}
-
-function createEngineMock () {
-  var engine = {
-    name: 'Engine mock',
-    reload: function () {}
-  };
-  spyOn(engine, 'reload');
-
-  return engine;
 }
 
 describe('api/v4/dataview/histogram', function () {
@@ -225,7 +216,7 @@ describe('api/v4/dataview/histogram', function () {
       dataview.on('binsChanged', binsChangedSpy);
 
       expect(binsChangedSpy).not.toHaveBeenCalled();
-      dataview.$setEngine(createEngineMock());
+      dataview.$setEngine(createEngine());
       dataview.setBins(11);
 
       expect(binsChangedSpy).toHaveBeenCalledWith(11);
@@ -238,7 +229,7 @@ describe('api/v4/dataview/histogram', function () {
 
     beforeEach(function () {
       dataview = new carto.dataview.Histogram(source, 'population');
-      engine = createEngineMock();
+      engine = createEngine();
     });
 
     it('creates the internal model', function () {
@@ -255,7 +246,7 @@ describe('api/v4/dataview/histogram', function () {
       expect(internalModel.isEnabled()).toBe(false);
       expect(internalModel._bboxFilter).toBeDefined();
       expect(internalModel.syncsOnBoundingBoxChanges()).toBe(true);
-      expect(internalModel._engine.name).toEqual('Engine mock');
+      expect(internalModel._engine).toBe(engine);
     });
 
     it('creates the internal model with no bounding box if not provided', function () {

--- a/test/spec/api/v4/dataview/time-series.spec.js
+++ b/test/spec/api/v4/dataview/time-series.spec.js
@@ -1,6 +1,7 @@
 var Backbone = require('backbone');
 var _ = require('underscore');
 var carto = require('../../../../../src/api/v4/index');
+var createEngine = require('../../../fixtures/engine.fixture.js');
 
 function createHistogramInternalModelMock (options) {
   options = options || {};
@@ -55,16 +56,6 @@ function createHistogramInternalModelMock (options) {
 
 function createSourceMock () {
   return new carto.source.Dataset('ne_10m_populated_places_simple');
-}
-
-function createEngineMock () {
-  var engine = {
-    name: 'Engine mock',
-    reload: function () {}
-  };
-  spyOn(engine, 'reload');
-
-  return engine;
 }
 
 describe('api/v4/dataview/time-series', function () {
@@ -255,7 +246,7 @@ describe('api/v4/dataview/time-series', function () {
       dataview.on('aggregationChanged', aggregationChangedSpy);
 
       expect(aggregationChangedSpy).not.toHaveBeenCalled();
-      dataview.$setEngine(createEngineMock());
+      dataview.$setEngine(createEngine());
       dataview.setAggregation(carto.dataview.timeAggregation.HOUR);
 
       expect(aggregationChangedSpy).toHaveBeenCalledWith(carto.dataview.timeAggregation.HOUR);
@@ -330,7 +321,7 @@ describe('api/v4/dataview/time-series', function () {
 
     beforeEach(function () {
       dataview = new carto.dataview.TimeSeries(source, 'population');
-      engine = createEngineMock();
+      engine = createEngine();
     });
 
     it('creates the internal model', function () {
@@ -351,7 +342,7 @@ describe('api/v4/dataview/time-series', function () {
       expect(internalModel.isEnabled()).toBe(false);
       expect(internalModel._bboxFilter).toBeDefined();
       expect(internalModel.syncsOnBoundingBoxChanges()).toBe(true);
-      expect(internalModel._engine.name).toEqual('Engine mock');
+      expect(internalModel._engine).toBe(engine);
     });
 
     it('creates the internal model with no bounding box if not provided', function () {

--- a/test/spec/dataviews/category-dataview-model.spec.js
+++ b/test/spec/dataviews/category-dataview-model.spec.js
@@ -5,16 +5,17 @@ var WindshaftFiltersCategory = require('../../../src/windshaft/filters/category'
 var WindshaftFiltersBoundingBox = require('../../../src/windshaft/filters/bounding-box');
 var AnalysisService = require('../../../src/analysis/analysis-service');
 var MapModelBoundingBoxAdapter = require('../../../src/geo/adapters/map-model-bounding-box-adapter');
-var MockFactory = require('../../helpers/mockFactory');
+var createEngine = require('../fixtures/engine.fixture.js');
 
 describe('dataviews/category-dataview-model', function () {
   var engineMock;
+  var apiKey = 'API_KEY';
+  var apiKeyQueryParam = 'api_key=' + apiKey;
 
   beforeEach(function () {
     this.map = new Backbone.Model();
     this.map.getViewBounds = jasmine.createSpy();
-    engineMock = MockFactory.createEngine();
-    spyOn(engineMock, 'reload');
+    engineMock = createEngine({ apiKey: apiKey });
     this.map.getViewBounds.and.returnValue([[1, 2], [3, 4]]);
     var analysisDefinition = {
       id: 'a0',
@@ -60,8 +61,7 @@ describe('dataviews/category-dataview-model', function () {
 
   it('should set the api_key attribute on the internal models', function () {
     this.model = new CategoryDataviewModel({
-      source: this.source,
-      apiKey: 'API_KEY'
+      source: this.source
     }, {
       map: this.map,
       engine: engineMock,
@@ -69,26 +69,26 @@ describe('dataviews/category-dataview-model', function () {
       filter: new WindshaftFiltersCategory()
     });
 
-    expect(this.model._searchModel.get('apiKey')).toEqual('API_KEY');
-    expect(this.model._rangeModel.get('apiKey')).toEqual('API_KEY');
+    expect(this.model._searchModel.get('apiKey')).toEqual(apiKey);
+    expect(this.model._rangeModel.get('apiKey')).toEqual(apiKey);
   });
 
   describe('.url', function () {
     it('should include the bbox,own_filter and categories parameters', function () {
       expect(this.model.set('url', 'http://example.com'));
-      expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&own_filter=0&categories=6');
+      expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&own_filter=0&categories=6&' + apiKeyQueryParam);
 
       this.model.set('filterEnabled', true);
 
-      expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&own_filter=1&categories=6');
+      expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&own_filter=1&categories=6&' + apiKeyQueryParam);
 
       this.model.set('filterEnabled', false);
 
-      expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&own_filter=0&categories=6');
+      expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&own_filter=0&categories=6&' + apiKeyQueryParam);
 
       this.model.set('categories', 1);
 
-      expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&own_filter=0&categories=1');
+      expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&own_filter=0&categories=1&' + apiKeyQueryParam);
     });
   });
 
@@ -108,12 +108,12 @@ describe('dataviews/category-dataview-model', function () {
 
       it('should set search url when it changes', function () {
         expect(this.model._searchModel.get('url')).toBe('http://heytest.io');
-        expect(this.model._searchModel.url()).toBe('http://heytest.io/search?q=');
+        expect(this.model._searchModel.url()).toBe('http://heytest.io/search?q=&' + apiKeyQueryParam);
       });
 
       it('should set rangeModel url when it changes', function () {
         expect(this.model._rangeModel.get('url')).toBe('http://heytest.io');
-        expect(this.model._rangeModel.url()).toBe('http://heytest.io');
+        expect(this.model._rangeModel.url()).toBe('http://heytest.io?' + apiKeyQueryParam);
       });
     });
 

--- a/test/spec/dataviews/dataviews-factory.spec.js
+++ b/test/spec/dataviews/dataviews-factory.spec.js
@@ -2,6 +2,7 @@ var _ = require('underscore');
 var Backbone = require('backbone');
 var DataviewsFactory = require('../../../src/dataviews/dataviews-factory');
 var MockFactory = require('../../helpers/mockFactory');
+var createEngine = require('../fixtures/engine.fixture.js');
 
 var source = MockFactory.createAnalysisModel({ id: 'a0' });
 
@@ -26,7 +27,7 @@ describe('dataviews/dataviews-factory', function () {
     this.dataviewsCollection = new Backbone.Collection();
     this.factory = new DataviewsFactory(null, {
       map: createMapMock(),
-      engine: {},
+      engine: createEngine(),
       dataviewsCollection: this.dataviewsCollection
     });
   });
@@ -54,41 +55,31 @@ describe('dataviews/dataviews-factory', function () {
       }.bind(this)).toThrowError(requiredAttributes[0] + ' is required');
     });
 
-    it(factoryMethod + ' should set the apiKey attribute on the dataview if present', function () {
-      this.factory = new DataviewsFactory({
-        apiKey: 'THE_API_KEY'
-      }, {
+    it(factoryMethod + ' should set the engine to get the apiKey attribute on the dataview', function () {
+      this.factory = new DataviewsFactory({}, {
         map: createMapMock(),
-        engine: {},
+        engine: createEngine(),
         dataviewsCollection: this.dataviewsCollection
       });
 
       var attributes = generateFakeAttributes(requiredAttributes);
       var model = this.factory[factoryMethod](attributes);
 
-      expect(model.get('apiKey')).toEqual('THE_API_KEY');
+      expect(model._engine.getApiKey()).toEqual('API_KEY');
     });
 
-    it(factoryMethod + ' should set the authToken', function () {
-      this.factory.set({
-        authToken: 'AUTH_TOKEN'
+    it(factoryMethod + ' should set the engine to get the authToken attribute on the dataview', function () {
+      var engine = createEngine({ apiKey: null });
+      this.factory = new DataviewsFactory({}, {
+        map: createMapMock(),
+        engine: engine,
+        dataviewsCollection: this.dataviewsCollection
       });
 
       var attributes = generateFakeAttributes(requiredAttributes);
       var model = this.factory[factoryMethod](attributes);
 
-      expect(model.get('authToken')).toEqual('AUTH_TOKEN');
-    });
-
-    it(factoryMethod + ' should set the apiKey', function () {
-      this.factory.set({
-        apiKey: 'API_KEY'
-      });
-
-      var attributes = generateFakeAttributes(requiredAttributes);
-      var model = this.factory[factoryMethod](attributes);
-
-      expect(model.get('apiKey')).toEqual('API_KEY');
+      expect(model._engine.getAuthToken()).toEqual(engine.getAuthToken());
     });
   }, this);
 });

--- a/test/spec/dataviews/histogram-dataview-model.spec.js
+++ b/test/spec/dataviews/histogram-dataview-model.spec.js
@@ -5,6 +5,7 @@ var HistogramDataviewModel = require('../../../src/dataviews/histogram-dataview-
 var MapModelBoundingBoxAdapter = require('../../../src/geo/adapters/map-model-bounding-box-adapter');
 var helper = require('../../../src/dataviews/helpers/histogram-helper');
 var MockFactory = require('../../helpers/mockFactory');
+var createEngine = require('../fixtures/engine.fixture.js');
 
 function randomString (length, chars) {
   var result = '';
@@ -14,11 +15,13 @@ function randomString (length, chars) {
 
 describe('dataviews/histogram-dataview-model', function () {
   var engineMock;
+  var apiKeyQueryParam;
+
   beforeEach(function () {
     this.map = jasmine.createSpyObj('map', ['getViewBounds', 'on']);
     this.map.getViewBounds.and.returnValue([[1, 2], [3, 4]]);
-    engineMock = MockFactory.createEngine();
-    spyOn(engineMock, 'reload');
+    engineMock = createEngine({});
+    apiKeyQueryParam = 'api_key=' + engineMock.getApiKey();
 
     this.filter = new WindshaftFiltersRange();
     this.bboxFilter = new WindshaftFiltersBoundingBox(new MapModelBoundingBoxAdapter(this.map));
@@ -69,7 +72,6 @@ describe('dataviews/histogram-dataview-model', function () {
 
   it('should set the api_key attribute on the internal models', function () {
     this.model = new HistogramDataviewModel({
-      apiKey: 'API_KEY',
       source: this.source
     }, {
       engine: engineMock,
@@ -77,7 +79,7 @@ describe('dataviews/histogram-dataview-model', function () {
       bboxFilter: this.bboxFilter
     });
 
-    expect(this.model._totals.get('apiKey')).toEqual('API_KEY');
+    expect(this.model._totals.get('apiKey')).toEqual(engineMock.getApiKey());
   });
 
   describe('should get the correct histogram shape', function () {
@@ -473,7 +475,7 @@ describe('dataviews/histogram-dataview-model', function () {
     });
 
     it('should include bbox', function () {
-      expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3');
+      expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&' + apiKeyQueryParam);
     });
 
     describe('column type is number', function () {
@@ -486,7 +488,7 @@ describe('dataviews/histogram-dataview-model', function () {
             column_type: 'number'
           });
 
-          expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&bins=33&start=11&end=22');
+          expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&bins=33&start=11&end=22&' + apiKeyQueryParam);
         });
 
         it('should include bins', function () {
@@ -495,7 +497,7 @@ describe('dataviews/histogram-dataview-model', function () {
             column_type: 'number'
           });
 
-          expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&bins=33');
+          expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&bins=33&' + apiKeyQueryParam);
         });
       });
 
@@ -508,11 +510,11 @@ describe('dataviews/histogram-dataview-model', function () {
           column_type: 'number'
         });
 
-        expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&bins=25&start=0&end=10');
+        expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&bins=25&start=0&end=10&' + apiKeyQueryParam);
 
         this.model.enableFilter();
 
-        expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&own_filter=1&bins=25');
+        expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&own_filter=1&bins=25&' + apiKeyQueryParam);
       });
     });
 
@@ -524,7 +526,7 @@ describe('dataviews/histogram-dataview-model', function () {
           column_type: 'date'
         });
 
-        expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&aggregation=month');
+        expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&aggregation=month&' + apiKeyQueryParam);
       });
 
       it('should include aggregation auto if column type is date and no aggregation set', function () {
@@ -532,7 +534,7 @@ describe('dataviews/histogram-dataview-model', function () {
           aggregation: undefined,
           column_type: 'date'
         });
-        expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&aggregation=auto');
+        expect(this.model.url()).toEqual('http://example.com?bbox=2,1,4,3&aggregation=auto&' + apiKeyQueryParam);
       });
 
       it('should use offset if present', function () {
@@ -545,7 +547,7 @@ describe('dataviews/histogram-dataview-model', function () {
 
         var url = this.model.url();
 
-        expect(url).toEqual('http://example.com?bbox=2,1,4,3&aggregation=month&offset=7200');
+        expect(url).toEqual('http://example.com?bbox=2,1,4,3&aggregation=month&offset=7200&' + apiKeyQueryParam);
       });
 
       it('should use local offset if localTimezone is true', function () {
@@ -559,7 +561,7 @@ describe('dataviews/histogram-dataview-model', function () {
 
         var url = this.model.url();
 
-        expect(url).toEqual('http://example.com?bbox=2,1,4,3&aggregation=month&offset=43200');
+        expect(url).toEqual('http://example.com?bbox=2,1,4,3&aggregation=month&offset=43200&' + apiKeyQueryParam);
       });
     });
   });

--- a/test/spec/engine.spec.js
+++ b/test/spec/engine.spec.js
@@ -11,7 +11,10 @@ describe('Engine', function () {
   var engineMock;
 
   beforeEach(function () {
-    engineMock = MockFactory.createEngine();
+    engineMock = MockFactory.createEngine({
+      spyReload: false,
+      username: 'fake-username'
+    });
   });
 
   describe('Constructor', function () {
@@ -111,7 +114,7 @@ describe('Engine', function () {
     it('should perform a request with the state encoded in a payload (no layers, no dataviews) ', function (done) {
       spyOn($, 'ajax').and.callFake(function (params) {
         var actual = params.url;
-        var expected = 'http://example.com/api/v1/map?config=%7B%22buffersize%22%3A%7B%22mvt%22%3A0%7D%2C%22layers%22%3A%5B%5D%2C%22dataviews%22%3A%7B%7D%2C%22analyses%22%3A%5B%5D%7D&stat_tag=fake-stat-tag&api_key=fake-api-key';
+        var expected = 'http://example.com/api/v1/map?config=%7B%22buffersize%22%3A%7B%22mvt%22%3A0%7D%2C%22layers%22%3A%5B%5D%2C%22dataviews%22%3A%7B%7D%2C%22analyses%22%3A%5B%5D%7D&stat_tag=fake-stat-tag&api_key=' + engineMock.getApiKey();
         expect(actual).toEqual(expected);
         done();
       });
@@ -121,7 +124,7 @@ describe('Engine', function () {
     it('should perform a request with the state encoded in a payload (single layer) ', function (done) {
       spyOn($, 'ajax').and.callFake(function (params) {
         var actual = params.url;
-        var expected = 'http://example.com/api/v1/map?config=%7B%22buffersize%22%3A%7B%22mvt%22%3A0%7D%2C%22layers%22%3A%5B%7B%22type%22%3A%22mapnik%22%2C%22options%22%3A%7B%22cartocss_version%22%3A%222.1.0%22%2C%22source%22%3A%7B%22id%22%3A%22a1%22%7D%2C%22interactivity%22%3A%5B%22cartodb_id%22%5D%7D%7D%5D%2C%22dataviews%22%3A%7B%7D%2C%22analyses%22%3A%5B%7B%22id%22%3A%22a1%22%2C%22type%22%3A%22source%22%2C%22params%22%3A%7B%22query%22%3A%22SELECT%20*%20FROM%20table%22%7D%7D%5D%7D&stat_tag=fake-stat-tag&api_key=fake-api-key';
+        var expected = 'http://example.com/api/v1/map?config=%7B%22buffersize%22%3A%7B%22mvt%22%3A0%7D%2C%22layers%22%3A%5B%7B%22type%22%3A%22mapnik%22%2C%22options%22%3A%7B%22cartocss_version%22%3A%222.1.0%22%2C%22source%22%3A%7B%22id%22%3A%22a1%22%7D%2C%22interactivity%22%3A%5B%22cartodb_id%22%5D%7D%7D%5D%2C%22dataviews%22%3A%7B%7D%2C%22analyses%22%3A%5B%7B%22id%22%3A%22a1%22%2C%22type%22%3A%22source%22%2C%22params%22%3A%7B%22query%22%3A%22SELECT%20*%20FROM%20table%22%7D%7D%5D%7D&stat_tag=fake-stat-tag&api_key=' + engineMock.getApiKey();
         expect(actual).toEqual(expected);
         done();
       });
@@ -293,6 +296,33 @@ describe('Engine', function () {
         origin: 'windshaft',
         _error: 'an error'
       }));
+    });
+  });
+
+  describe('.getApiKey', function () {
+    it('should return the internal API key', function () {
+      var apiKey = 'qwud2iu2';
+      var anotherEngine = MockFactory.createEngine({
+        apiKey: apiKey
+      });
+
+      var returnedKey = anotherEngine.getApiKey();
+
+      expect(returnedKey).toBe(apiKey);
+    });
+  });
+
+  describe('.getAuthToken', function () {
+    it('should return the internal auth token', function () {
+      var authToken = ['covfefe', 'location'];
+      var anotherEngine = MockFactory.createEngine({
+        apiKey: null,
+        authToken: authToken
+      });
+
+      var returnedAuthToken = anotherEngine.getAuthToken();
+
+      expect(returnedAuthToken).toBe(authToken);
     });
   });
 });

--- a/test/spec/fixtures/engine.fixture.js
+++ b/test/spec/fixtures/engine.fixture.js
@@ -1,0 +1,31 @@
+var Engine = require('../../../src/engine');
+
+function createEngine (opts) {
+  opts = opts || {};
+  var apiKey = opts.hasOwnProperty('apiKey')
+    ? opts.apiKey
+    : 'API_KEY';
+  var authToken = opts.authToken || ['fabada', 'coffee'];
+  var username = opts.username || 'wadus';
+  var serverUrl = opts.serverUrl || 'http://example.com';
+  var spyReload = opts.hasOwnProperty('spyReload')
+    ? opts.spyReload
+    : true;
+  var statTag = opts.statTag || 'fake-stat-tag';
+
+  var engine = new Engine({
+    apiKey: apiKey,
+    authToken: authToken,
+    username: username,
+    serverUrl: serverUrl,
+    statTag: statTag
+  });
+
+  if (spyReload) {
+    spyOn(engine, 'reload');
+  }
+
+  return engine;
+}
+
+module.exports = createEngine;

--- a/test/spec/geo/cartodb-layer-group.spec.js
+++ b/test/spec/geo/cartodb-layer-group.spec.js
@@ -6,15 +6,14 @@ var TileLayer = require('../../../src/geo/map/tile-layer');
 var TorqueLayer = require('../../../src/geo/map/torque-layer');
 var GMapsBaseLayer = require('../../../src/geo/map/gmaps-base-layer');
 var CartoDBLayerGroup = require('../../../src/geo/cartodb-layer-group');
-var MockFactory = require('../../helpers/mockFactory');
+var createEngine = require('../fixtures/engine.fixture.js');
 
 describe('geo/cartodb-layer-group', function () {
   var engineMock;
 
   beforeEach(function () {
     this.layersCollection = new Layers();
-    engineMock = MockFactory.createEngine();
-    spyOn(engineMock, 'reload');
+    engineMock = createEngine();
 
     this.cartoDBLayerGroup = new CartoDBLayerGroup({}, {
       layersCollection: this.layersCollection

--- a/test/spec/geo/gmaps/gmaps-torque-layer-view.spec.js
+++ b/test/spec/geo/gmaps/gmaps-torque-layer-view.spec.js
@@ -7,11 +7,12 @@ var TorqueLayer = require('../../../../src/geo/map/torque-layer');
 var MockFactory = require('../../../helpers/mockFactory');
 var SharedTestsForTorqueLayer = require('../shared-tests-for-torque-layer');
 var torque = require('torque.js');
+var createEngine = require('../../fixtures/engine.fixture.js');
 
 describe('geo/gmaps/gmaps-torque-layer-view', function () {
   beforeEach(function () {
     var container = $('<div>').css('height', '200px');
-    var engineMock = MockFactory.createEngine();
+    var engineMock = createEngine();
     this.map = new Map(null, {
       layersFactory: {}
     });

--- a/test/spec/geo/leaflet/leaflet-map-view.spec.js
+++ b/test/spec/geo/leaflet/leaflet-map-view.spec.js
@@ -11,7 +11,7 @@ var CartoDBLayerGroup = require('../../../../src/geo/cartodb-layer-group');
 var LeafletMapView = require('../../../../src/geo/leaflet/leaflet-map-view');
 var LeafletTiledLayerView = require('../../../../src/geo/leaflet/leaflet-tiled-layer-view');
 var LeafletPlainLayerView = require('../../../../src/geo/leaflet/leaflet-plain-layer-view');
-var MockFactory = require('../../../helpers/mockFactory');
+var createEngine = require('../../fixtures/engine.fixture.js');
 
 describe('geo/leaflet/leaflet-map-view', function () {
   var mapView;
@@ -58,7 +58,7 @@ describe('geo/leaflet/leaflet-map-view', function () {
     map.bind('change:center', spy.centerChanged);
     map.bind('change', spy.changed);
 
-    engineMock = MockFactory.createEngine();
+    engineMock = createEngine();
   });
 
   it('should change bounds when center is set', function () {

--- a/test/spec/geo/leaflet/leaflet-torque-layer-view.spec.js
+++ b/test/spec/geo/leaflet/leaflet-torque-layer-view.spec.js
@@ -6,6 +6,7 @@ var LeafletMapView = require('../../../../src/geo/leaflet/leaflet-map-view');
 var LeafletLayerViewFactory = require('../../../../src/geo/leaflet/leaflet-layer-view-factory');
 var TorqueLayer = require('../../../../src/geo/map/torque-layer');
 var MockFactory = require('../../../helpers/mockFactory');
+var createEngine = require('../../fixtures/engine.fixture.js');
 var SharedTestsForTorqueLayer = require('../shared-tests-for-torque-layer');
 
 describe('geo/leaflet/leaflet-torque-layer-view', function () {
@@ -16,7 +17,7 @@ describe('geo/leaflet/leaflet-torque-layer-view', function () {
       'height': '200px',
       'width': '200px'
     });
-    engineMock = MockFactory.createEngine();
+    engineMock = createEngine();
     this.map = new Map(null, {
       layersFactory: {}
     });

--- a/test/spec/geo/map-view.spec.js
+++ b/test/spec/geo/map-view.spec.js
@@ -1,6 +1,6 @@
 var $ = require('jquery');
 var Backbone = require('backbone');
-var MockFactory = require('../../helpers/mockFactory');
+var createEngine = require('../fixtures/engine.fixture.js');
 var Map = require('../../../src/geo/map');
 var MapView = require('../../../src/geo/map-view');
 var TileLayer = require('../../../src/geo/map/tile-layer');
@@ -30,8 +30,7 @@ describe('core/geo/map-view', function () {
   var engineMock;
   beforeEach(function () {
     this.container = $('<div>').css('height', '200px');
-    engineMock = MockFactory.createEngine();
-    spyOn(engineMock, 'reload');
+    engineMock = createEngine();
 
     this.map = new Map(null, {
       layersFactory: {}

--- a/test/spec/geo/map/cartodb-layer.spec.js
+++ b/test/spec/geo/map/cartodb-layer.spec.js
@@ -8,7 +8,6 @@ describe('geo/map/cartodb-layer', function () {
 
   beforeEach(function () {
     engineMock = MockFactory.createEngine();
-    spyOn(engineMock, 'reload');
   });
 
   sharedTestsForInteractiveLayers(CartoDBLayer);

--- a/test/spec/geo/map/plain-layer.spec.js
+++ b/test/spec/geo/map/plain-layer.spec.js
@@ -6,7 +6,6 @@ describe('PlainLayer', function () {
   var engineMock;
   beforeEach(function () {
     engineMock = MockFactory.createEngine();
-    spyOn(engineMock, 'reload');
   });
 
   it('should be type plain', function () {

--- a/test/spec/geo/map/tile-layer.spec.js
+++ b/test/spec/geo/map/tile-layer.spec.js
@@ -7,7 +7,6 @@ describe('TileLayer', function () {
 
   beforeEach(function () {
     engineMock = MockFactory.createEngine();
-    spyOn(engineMock, 'reload');
     layer = new TileLayer(null, { engine: engineMock });
   });
 

--- a/test/spec/geo/map/torque-layer.spec.js
+++ b/test/spec/geo/map/torque-layer.spec.js
@@ -7,7 +7,6 @@ describe('geo/map/torque-layer', function () {
   var engineMock;
   beforeEach(function () {
     engineMock = MockFactory.createEngine();
-    spyOn(engineMock, 'reload');
   });
 
   sharedTestsForInteractiveLayers(TorqueLayer);

--- a/test/spec/geo/ui/overlays-view.spec.js
+++ b/test/spec/geo/ui/overlays-view.spec.js
@@ -1,12 +1,14 @@
 var Backbone = require('backbone');
 var OverlaysView = require('../../../../src/geo/ui/overlays-view.js');
 var Engine = require('../../../../src/engine');
-var MockFactory = require('../../../helpers/mockFactory');
+var createEngine = require('../../fixtures/engine.fixture.js');
 
 describe('src/geo/ui/overlays-view.js', function () {
-  var engineMock = MockFactory.createEngine();
   var mapModelMock = new Backbone.Model();
+  var engineMock;
+
   beforeEach(function () {
+    engineMock = createEngine();
     this.overlaysCollection = new Backbone.Collection([
       {
         type: 'zoom',

--- a/test/spec/vis/infowindow-manager.spec.js
+++ b/test/spec/vis/infowindow-manager.spec.js
@@ -57,7 +57,6 @@ describe('src/vis/infowindow-manager.js', function () {
     });
 
     engineMock = MockFactory.createEngine();
-    spyOn(engineMock, 'reload');
 
     this.infowindowManager = new InfowindowManager({ // eslint-disable-line
       engine: engineMock,

--- a/test/spec/vis/tooltip-manager.spec.js
+++ b/test/spec/vis/tooltip-manager.spec.js
@@ -36,7 +36,6 @@ describe('src/vis/tooltip-manager.js', function () {
     });
 
     engineMock = MockFactory.createEngine();
-    spyOn(engineMock, 'reload');
 
     this.tooltipModel = new TooltipModel();
     this.infowindowModel = new InfowindowModel();

--- a/test/spec/windshaft/map-serializer/anonymous-map-serializer/dataviews-serializer.spec.js
+++ b/test/spec/windshaft/map-serializer/anonymous-map-serializer/dataviews-serializer.spec.js
@@ -4,6 +4,7 @@ var HistogramDataviewModel = require('../../../../../src/dataviews/histogram-dat
 var FormulaDataviewModel = require('../../../../../src/dataviews/formula-dataview-model');
 var MockFactory = require('../../../../helpers/mockFactory');
 var DataviewsSerializer = require('../../../../../src/windshaft/map-serializer/anonymous-map-serializer/dataviews-serializer');
+var createEngine = require('../../../fixtures/engine.fixture.js');
 
 describe('dataviews-serializer', function () {
   describe('.serialize', function () {
@@ -13,7 +14,7 @@ describe('dataviews-serializer', function () {
     var analysis;
 
     beforeEach(function () {
-      engineMock = new Backbone.Model();
+      engineMock = createEngine();
       map = new Backbone.Model();
       layer = new Backbone.Model();
       analysis = MockFactory.createAnalysisModel({ id: 'a0' });


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb.js/issues/2071
----

This PR propagates the credentials set in `carto.client` to dataviews. It fixes a bug, where the dataviews didn't had the API key and then they build URLs with no keys.

### Acceptance

*Public API*
- Create all type of widgets against a private dataset.
- Use an API key [1] with SQL select and MAPS permission for that dataset.
- Check that the widgets return data. No 403 must be received.
- Create all type of widgets against a public dataset.
- Use the `default_public` key.
- Check that widgets work.

*Builder*
- [x] Generally speaking, check that widgets behave.
- [x] In Builder, create several type of widgets. They must be created with no problem and filters should work.
- [x] In Category widgets, perform a search.
- [x] Publish the map
- [x] Interact with the widgets. They should work as always.
- [x] To test Auth tokens
    - [x] In a organization, share a private map with all type of widgets with a colleague.
    - [x] Seeing the map with the colleague profile, check in the URLs that the widgets are requested using auth tokens.
    - [x] Widgets should work as always.





