### PR TITLE
Added example for the url server parameter

### DIFF
--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -25,7 +25,7 @@ function getValidationError (code) {
  * @param {object} settings
  * @param {string} settings.apiKey - API key used to authenticate against CARTO
  * @param {string} settings.username - Name of the user
- * @param {string} [settings.serverUrl] - URL of the windshaft server
+ * @param {string} [settings.serverUrl] - URL of the windshaft server example: https://your.carto.instance/user/username
  *
  * @example
  * var client = new carto.Client({

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -25,12 +25,18 @@ function getValidationError (code) {
  * @param {object} settings
  * @param {string} settings.apiKey - API key used to authenticate against CARTO
  * @param {string} settings.username - Name of the user
- * @param {string} [settings.serverUrl] - URL of the windshaft server example: https://your.carto.instance/user/username
+ * @param {string} [settings.serverUrl] - URL of the windshaft server. Only needed in custom installations. Pattern: `https:\\{username}.yourinstance.com` or `https://your.carto.instance/user/{username}`, depending on your environment.
  *
  * @example
  * var client = new carto.Client({
  *   apiKey: 'YOUR_API_KEY_HERE',
  *   username: 'YOUR_USERNAME_HERE'
+ * });
+ * 
+ * var client = new carto.Client({
+ *   apiKey: 'YOUR_API_KEY_HERE',
+ *   username: 'YOUR_USERNAME_HERE',
+ *   serverUrl: 'https://YOUR.CARTO.INSTANCE/user/YOUR_USERNAME_HERE'
  * });
  *
  * @constructor


### PR DESCRIPTION
I have [this example](https://codepen.io/jsanz/pen/MVmNpm) running against a current carto instance, but was hesitant to use a real one since that carto instance can disappear anytime. I think it's worth adding that example to make clear that the URL needs the `/user/username`, even the console error is meaningful enough to be easy to fix, so not really strong on this suggestion :smile: 

