### PR TITLE
Check README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,11 @@ First public release of CARTO.js library
 - New metadata: Buckets, Categories
 - New dataviews: Formula, Category, Histogram, TimeSeries
 - New filters: BoundingBox, BoundingBoxLeaflet, BoundingBoxGoogleMaps
+- Server aggregation options for layers
 - Multiple clients support
 - Return native Leaflet and Google Maps layers
-- Manage layers' interactivity
+- Manage layers interactivity
 - Granular error management
 - Publish to npm and CDN
+- Public documentation within the repo
+- Examples

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -2,6 +2,124 @@
 
 ## Current
 
+## 4.0.0-beta.39 - 2018-03-28
+
+- Added example for the url server parameter
+- Unify engine mock
+
+## 4.0.0-beta.38 - 2018-03-23
+
+- Move template2x decision to leaflet rendering
+
+## 4.0.0-beta.37 - 2018-03-23
+
+- Propagate API keys to dataviews in public API
+
+## 4.0.0-beta.36 - 2018-03-20
+
+
+## 4.0.0-beta.35 - 2018-03-19
+
+- Add hasBeenFetched flag to histogram
+
+## 4.0.0-beta.34 - 2018-03-14
+
+- Re-render legends when layers order is changed
+
+## 4.0.0-beta.33 - 2018-03-05
+
+- Suppress horizontal scroll in legends. Fixes IE11
+
+## 4.0.0-beta.32 - 2018-02-26
+
+- Fix legends
+
+## 4.0.0-beta.31 - 2018-02-23
+
+### Fixes
+- Hot size legends are broken.
+
+## 4.0.0-beta.30 - 2018-02-23
+
+
+## 4.0.0-beta.29 - 2018-02-23
+
+- prepare shield-placement-keyword CartoCSS property
+
+## 4.0.0-beta.28 - 2018-02-21
+
+- 2046 move docs
+
+## 4.0.0-beta.27 - 2018-02-21
+
+- Adjust styles mobile view embed maps [WIP]
+
+## 4.0.0-beta.26 - 2018-02-20
+
+- add marker size to layer cartocss props to reinstantiate torque map
+
+## 4.0.0-beta.25 - 2018-02-15
+
+
+## 4.0.0-beta.24 - 2018-02-15
+
+- Freeze GMaps script version
+- Warn instead of error if no API key
+- Fix popup examples for polygons
+### New features
+- Revert "Hide aggregation from public api" (#2029)
+### Fixes
+- Added server aggregation validation #2032
+- Check parameters when creating bounding box filters. #2003
+
+## 4.0.0-beta.23 - 2018-02-06
+
+- Update all examples to Leaflet1.3.1
+### Fixes
+- remove unnecessary`sync_on_data_change` #2036
+
+## 4.0.0-beta.22 - 2018-02-01
+
+- Use retina url in high resolution screens
+
+## 4.0.0-beta.21 - 2018-02-01
+
+- Set Leaflet zoomAnimationThreshold to 1000 (internal only)
+- Define layers order
+
+## 4.0.0-beta.20 - 2018-02-01
+
+- Remove tangram support
+
+## 4.0.0-beta.19 - 2018-02-01
+
+- Examples feedback
+- 2011 autogenerate changelog
+
+## 4.0.0-beta.18 - 2018-01-31
+
+- Override scrollwheel if it's boolean
+
+## 4.0.0-beta.17 - 2018-01-30
+
+
+## 4.0.0-beta.12 - 2018-01-30
+
+- 5067 add mapbox geocoder
+
+## 4.0.0-beta.16 - 2018-01-30
+
+- Append legends view if js-embed-legends is found
+
+## 4.0.0-beta.15 - 2018-01-29
+
+- Remove category value stringify
+
+## 4.0.0-beta.14 - 2018-01-19
+
+- Merge pull request #2017 from CartoDB/11341-add-dblclick-event
+- 11341 add dblclick event
+
 ## 4.0.0-beta.13 - 2018-01-18
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ The best way to get started is to navigate through the CARTO.js documentation si
 
 ## Versioning
 
-We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/CartoDB/cartodb.js/tags).
+We use [SemVer](http://semver.org/) for versioning.
+
+Please refer to [CHANGELOG.md](CHANGELOG.md) for a list of notables changes for each version of the library.
+
+You can also see the [tags on this repository](https://github.com/CartoDB/cartodb.js/tags).
 
 ## Submitting Contributions
 
@@ -25,7 +29,7 @@ This project is licensed under the BSD 3-clause "New" or "Revised" License - see
 
 ## Documentation
 
-### API Reference
+### API Reference
 
 Run `npm run docs` to build the API reference documentation from jsdoc annotations.
 


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb.js/issues/2077
----

This PR just adds:
- the current content of DEVLOG.md, that contains all merge and tag information for both the internal and public API.
- Four notes to CHANGELOG.md. The ones that are important since the first version of CHANGELOG.md. Take into account that this file is the starting point so no detailed info is needed now, only a big picture of what CARTO.js v4 enables.
- a changelog reference to README.

Please review if you miss something.