### PR TITLE
Fix attributions while showing a map

### DIFF
--- a/src/geo/ui/attribution/attribution-view.js
+++ b/src/geo/ui/attribution/attribution-view.js
@@ -31,7 +31,12 @@ module.exports = View.extend({
   },
 
   render: function () {
-    var attributions = _.compact(this.map.get('attribution')).join(', ');
+    var attributionsSet = [...new Set(this.map.get('attribution'))];
+    var attributions = _.compact(attributionsSet)
+      .join(', ')
+      .replace(/\s{2,}/g, ' ')
+      .replace(/\s,/g, ',')
+      .replace(/\,{2,}/g, ',');
     var isGMaps = this.map.get('provider') !== 'leaflet';
     this.$el.html(
       template({
@@ -46,7 +51,7 @@ module.exports = View.extend({
 
   _initBinds: function () {
     this.model.bind('change:visible', function (mdl, isVisible) {
-      this[ isVisible ? '_showAttributions' : '_hideAttributions' ]();
+      this[isVisible ? '_showAttributions' : '_hideAttributions']();
     }, this);
     this.map.bind('change:attribution', this.render, this);
     this.add_related_model(this.map);


### PR DESCRIPTION
## Resources
[Shortcut story](https://app.shortcut.com/cartoteam/story/178449/notify-about-the-limit-of-4096-named-maps-in-builder)

## Context
Datasets' attributions are not working fine when loading a map. Sometimes the attributions are duplicated, or an empty space is being shown.

## Changes
I've checked that the attributions array doesn't contain duplicated elements. I've also checked with a regular expression that the string that is going to be rendered is clean.
